### PR TITLE
add: p2p suffixes to multiaddrs from identify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1379,6 +1379,7 @@ dependencies = [
  "multibase",
  "multihash",
  "openssl",
+ "parity-multiaddr",
  "percent-encoding",
  "prost",
  "prost-build",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -24,6 +24,7 @@ multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 # openssl is required for rsa keygen but not used by the rust-ipfs or its dependencies
 openssl = { default-features = false, version = "0.10" }
+parity-multiaddr = { default-features = false, version = "0.9" }
 percent-encoding = { default-features = false, version = "2.1" }
 prost = { default-features = false, version = "0.6.1" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }

--- a/http/src/v0/id.rs
+++ b/http/src/v0/id.rs
@@ -47,7 +47,11 @@ async fn identity_query<T: IpfsTypes>(
             // append /p2p/peer_id if missing (as of libp2p 0.16 it should be missing) to remain
             // compatible with go-ipfs output. go-ipfs though uses /ipfs/peer_id but that is
             // supposed to be changing in the near future.
-            let addresses = addresses.into_iter().map(|addr| append_p2p(addr, &peer_id)).map(|addr| addr.to_string()).collect();
+            let addresses = addresses
+                .into_iter()
+                .map(|addr| append_p2p(addr, &peer_id))
+                .map(|addr| addr.to_string())
+                .collect();
 
             let response = Response {
                 id,
@@ -64,7 +68,10 @@ async fn identity_query<T: IpfsTypes>(
 }
 
 fn append_p2p(mut addr: Multiaddr, peer_id: &PeerId) -> Multiaddr {
-    match addr.iter().find(|protocol| matches!(protocol, Protocol::P2p(_))) {
+    match addr
+        .iter()
+        .find(|protocol| matches!(protocol, Protocol::P2p(_)))
+    {
         Some(Protocol::P2p(_)) => addr,
         _ => {
             addr.push(Protocol::P2p(peer_id.clone().into()));

--- a/http/src/v0/id.rs
+++ b/http/src/v0/id.rs
@@ -43,10 +43,7 @@ async fn identity_query<T: IpfsTypes>(
             let id = peer_id.to_string();
             let public_key = Base64Pad.encode(public_key.into_protobuf_encoding());
 
-            let addresses = addresses
-                .into_iter()
-                .map(|addr| addr.to_string())
-                .collect();
+            let addresses = addresses.into_iter().map(|addr| addr.to_string()).collect();
 
             let response = Response {
                 id,

--- a/http/src/v0/id.rs
+++ b/http/src/v0/id.rs
@@ -1,5 +1,6 @@
 use super::{with_ipfs, InvalidPeerId, NotImplemented, StringError};
 use ipfs::{Ipfs, IpfsTypes, PeerId};
+use parity_multiaddr::{Multiaddr, Protocol};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use warp::{query, Filter};
@@ -39,22 +40,36 @@ async fn identity_query<T: IpfsTypes>(
 
     match ipfs.identity().await {
         Ok((public_key, addresses)) => {
-            let id = public_key.clone().into_peer_id().to_string();
+            let peer_id = public_key.clone().into_peer_id();
+            let id = peer_id.to_string();
             let public_key = Base64Pad.encode(public_key.into_protobuf_encoding());
+
+            // append /p2p/peer_id if missing (as of libp2p 0.16 it should be missing) to remain
+            // compatible with go-ipfs output. go-ipfs though uses /ipfs/peer_id but that is
+            // supposed to be changing in the near future.
+            let addresses = addresses.into_iter().map(|addr| append_p2p(addr, &peer_id)).map(|addr| addr.to_string()).collect();
 
             let response = Response {
                 id,
                 public_key,
-                addresses: addresses.into_iter().map(|addr| addr.to_string()).collect(),
+                addresses,
                 agent_version: "rust-ipfs/0.1.0",
                 protocol_version: "ipfs/0.1.0",
             };
 
-            // TODO: investigate how this could be avoided, perhaps by making the ipfs::Error a
-            // Reject
             Ok(warp::reply::json(&response))
         }
         Err(e) => Err(warp::reject::custom(StringError::from(e))),
+    }
+}
+
+fn append_p2p(mut addr: Multiaddr, peer_id: &PeerId) -> Multiaddr {
+    match addr.iter().find(|protocol| matches!(protocol, Protocol::P2p(_))) {
+        Some(Protocol::P2p(_)) => addr,
+        _ => {
+            addr.push(Protocol::P2p(peer_id.clone().into()));
+            addr
+        }
     }
 }
 

--- a/http/src/v0/swarm.rs
+++ b/http/src/v0/swarm.rs
@@ -1,5 +1,5 @@
 use super::support::{with_ipfs, StringError};
-use ipfs::{p2p::ConnectionTarget, Ipfs, IpfsTypes, Multiaddr};
+use ipfs::{Ipfs, IpfsTypes, Multiaddr};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -16,7 +16,7 @@ async fn connect_query<T: IpfsTypes>(
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let target = query
         .arg
-        .parse::<ConnectionTarget>()
+        .parse::<Multiaddr>()
         .map_err(|e| warp::reject::custom(StringError::from(e)))?;
     ipfs.connect(target)
         .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,6 +448,10 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     }
 
     pub async fn connect(&self, target: Multiaddr) -> Result<(), Error> {
+        if !target.iter().any(|p| matches!(p, Protocol::P2p(_))) {
+            return Err(anyhow!("The target address is missing the P2p protocol"));
+        }
+
         self.span
             .in_scope(|| async {
                 let (tx, rx) = oneshot_channel();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -513,6 +513,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     }
 
     /// Returns the local node public key and the listened and externally visible addresses.
+    /// The addresses are suffixed with the P2p protocol containing the node's PeerId.
     ///
     /// Public key can be converted to [`PeerId`].
     pub async fn identity(&self) -> Result<(PublicKey, Vec<Multiaddr>), Error> {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -1,5 +1,5 @@
 use super::pubsub::Pubsub;
-use super::swarm::{Connection, ConnectionTarget, Disconnector, SwarmApi};
+use super::swarm::{Connection, Disconnector, SwarmApi};
 use crate::p2p::SwarmOptions;
 use crate::repo::BlockPut;
 use crate::subscription::{SubscriptionFuture, SubscriptionRegistry};
@@ -414,8 +414,8 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         self.swarm.connections()
     }
 
-    pub fn connect(&mut self, target: ConnectionTarget) -> Option<SubscriptionFuture<(), String>> {
-        self.swarm.connect(target)
+    pub fn connect(&mut self, addr: Multiaddr) -> Option<SubscriptionFuture<(), String>> {
+        self.swarm.connect(addr)
     }
 
     pub fn disconnect(&mut self, addr: Multiaddr) -> Option<Disconnector> {
@@ -462,6 +462,10 @@ impl<Types: IpfsTypes> Behaviour<Types> {
 
     pub fn bitswap(&mut self) -> &mut Bitswap {
         &mut self.bitswap
+    }
+
+    pub fn ipfs(&self) -> &Ipfs<Types> {
+        &self.ipfs
     }
 
     pub fn bootstrap(&mut self) -> Result<SubscriptionFuture<(), String>, anyhow::Error> {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -464,10 +464,6 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         &mut self.bitswap
     }
 
-    pub fn ipfs(&self) -> &Ipfs<Types> {
-        &self.ipfs
-    }
-
     pub fn bootstrap(&mut self) -> Result<SubscriptionFuture<(), String>, anyhow::Error> {
         match self.kademlia.bootstrap() {
             Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod pubsub;
 mod swarm;
 mod transport;
 
-pub use swarm::{Connection, ConnectionTarget};
+pub use swarm::Connection;
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -3,14 +3,14 @@
 //! that contains them. `SubscriptionFuture` is the `Future` bound to pending `Subscription`s and
 //! sharing the same unique numeric identifier, the `SubscriptionId`.
 
-use crate::{p2p::ConnectionTarget, RepoEvent};
+use crate::RepoEvent;
 use cid::Cid;
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::pin::Pin;
 use futures::channel::mpsc::Sender;
 use futures::future::Future;
-use libp2p::{kad::QueryId, Multiaddr, PeerId};
+use libp2p::{kad::QueryId, Multiaddr};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
@@ -29,7 +29,7 @@ static GLOBAL_REQ_COUNT: AtomicU64 = AtomicU64::new(0);
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum RequestKind {
     /// A request to connect to the given `Multiaddr` or `PeerId`.
-    Connect(ConnectionTarget),
+    Connect(Multiaddr),
     /// A request to obtain a `Block` with a specific `Cid`.
     GetBlock(Cid),
     /// A DHT request to Kademlia.
@@ -40,19 +40,7 @@ pub enum RequestKind {
 
 impl From<Multiaddr> for RequestKind {
     fn from(addr: Multiaddr) -> Self {
-        Self::Connect(ConnectionTarget::Addr(addr))
-    }
-}
-
-impl From<PeerId> for RequestKind {
-    fn from(peer_id: PeerId) -> Self {
-        Self::Connect(ConnectionTarget::PeerId(peer_id))
-    }
-}
-
-impl From<ConnectionTarget> for RequestKind {
-    fn from(target: ConnectionTarget) -> Self {
-        Self::Connect(target)
+        Self::Connect(addr)
     }
 }
 

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -1,4 +1,5 @@
-use ipfs::{ConnectionTarget, Node};
+use ipfs::Node;
+use libp2p::Multiaddr;
 use std::time::Duration;
 use tokio::time::timeout;
 
@@ -29,30 +30,12 @@ async fn connect_two_nodes_by_peer_id() {
 
     let (b_key, mut b_addrs) = node_b.identity().await.unwrap();
     let b_id = b_key.into_peer_id();
+    let b_id_multiaddr: Multiaddr = format!("/p2p/{}", b_id).parse().unwrap();
 
     while let Some(addr) = b_addrs.pop() {
         node_a.add_peer(b_id.clone(), addr).await.unwrap();
     }
-    timeout(Duration::from_secs(10), node_a.connect(b_id))
-        .await
-        .expect("timeout")
-        .expect("should've connected");
-}
-
-// Make sure two instances of ipfs can be connected with a multiaddr+peer combo.
-#[tokio::test(max_threads = 1)]
-async fn connect_two_nodes_by_addr_and_peer() {
-    let node_a = Node::new("a").await;
-    let node_b = Node::new("b").await;
-
-    let (b_key, mut b_addrs) = node_b.identity().await.unwrap();
-
-    let b_id = b_key.into_peer_id();
-    let b_addr = b_addrs.pop().unwrap();
-    let b_addr_long = format!("{}/p2p/{}", b_addr, b_id);
-    let b_conn_target = b_addr_long.parse::<ConnectionTarget>().unwrap();
-
-    timeout(Duration::from_secs(1), node_a.connect(b_conn_target))
+    timeout(Duration::from_secs(10), node_a.connect(b_id_multiaddr))
         .await
         .expect("timeout")
         .expect("should've connected");
@@ -76,26 +59,6 @@ async fn connect_duplicate_multiaddr() {
     }
 }
 
-// Ensure that duplicate connection attempts don't cause hangs.
-#[tokio::test(max_threads = 1)]
-async fn connect_duplicate_peer_id() {
-    let node_a = Node::new("a").await;
-    let node_b = Node::new("b").await;
-
-    let (b_key, mut b_addrs) = node_b.identity().await.unwrap();
-    let b_id = b_key.into_peer_id();
-    let b_addr = b_addrs.pop().unwrap();
-
-    // test duplicate connections by peer id
-    node_a.add_peer(b_id.clone(), b_addr).await.unwrap();
-    for _ in 0..3 {
-        // final success or failure doesn't matter, there should be no timeout
-        let _ = timeout(Duration::from_secs(1), node_a.connect(b_id.clone()))
-            .await
-            .unwrap();
-    }
-}
-
 // More complicated one to the above; first node will have two listening addresses and the second
 // one should dial both of the addresses, resulting in two connections.
 #[tokio::test(max_threads = 1)]
@@ -112,7 +75,7 @@ async fn connect_two_nodes_with_two_connections_doesnt_panic() {
     assert_eq!(
         addresses.len(),
         2,
-        "there should had been two local addresses, found {:?}",
+        "there should have been two local addresses, found {:?}",
         addresses
     );
 
@@ -129,7 +92,7 @@ async fn connect_two_nodes_with_two_connections_doesnt_panic() {
     assert_eq!(
         peers.len(),
         1,
-        "there should had been one peer, found {:?}",
+        "there should have been one peer, found {:?}",
         peers
     );
 


### PR DESCRIPTION
not verified but indirectly used by the conformance tests when dialing a peer with an expected peerid.

Not 100% sure if this should be done, at least long as #105 is done at least to accept the multiaddrs with `/p2p/`.