### PR TITLE
fix: flaky adding two same ip ephemerals

### DIFF
--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -251,7 +251,7 @@ mod tests {
         Swarm::listen_on(&mut swarm1, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
         let peer1 = async move {
-            while let Some(_) = swarm1.next().now_or_never() {}
+            while swarm1.next().now_or_never().is_some() {}
 
             for l in Swarm::listeners(&swarm1) {
                 tx.send(l.clone()).await.unwrap();

--- a/tests/multiple_listening_addresses.rs
+++ b/tests/multiple_listening_addresses.rs
@@ -40,7 +40,12 @@ fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
         // intuitively it could seem that first will always succeed because it must get the first
         // attempt to push messages into the queue but not sure if that should be leaned on.
 
-        assert!(first.is_ok() || second.is_ok(), "first: {:?}, second: {:?}", first, second);
+        assert!(
+            first.is_ok() || second.is_ok(),
+            "first: {:?}, second: {:?}",
+            first,
+            second
+        );
     });
 }
 

--- a/tests/multiple_listening_addresses.rs
+++ b/tests/multiple_listening_addresses.rs
@@ -45,12 +45,7 @@ fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
             .filter(|&&success| success)
             .count();
 
-        assert!(
-            successes > 0,
-            "first: {:?}, second: {:?}",
-            first,
-            second
-        );
+        assert!(successes > 0, "first: {:?}, second: {:?}", first, second);
     });
 }
 

--- a/tests/multiple_listening_addresses.rs
+++ b/tests/multiple_listening_addresses.rs
@@ -30,9 +30,9 @@ fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
 
         let (first, second) = futures::future::join(first, second).await;
 
-        // before an Swarm alike api on the background task to make sure we attempt to modify the
-        // background task twice before the swarm gets to poll, this will forever produce one or two
-        // successes.
+        // before we have an Swarm-alike api on the background task to make sure the two futures
+        // (first and second) would attempt to modify the background task before a poll to the
+        // inner swarm, this will produce one or two successes.
         //
         // with two attempts without polling the swarm in the between:
         // assert_eq!(first.is_ok(), second.is_err());
@@ -40,12 +40,7 @@ fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
         // intuitively it could seem that first will always succeed because it must get the first
         // attempt to push messages into the queue but not sure if that should be leaned on.
 
-        let successes = [first.is_ok(), second.is_ok()]
-            .iter()
-            .filter(|&&success| success)
-            .count();
-
-        assert!(successes > 0, "first: {:?}, second: {:?}", first, second);
+        assert!(first.is_ok() || second.is_ok(), "first: {:?}, second: {:?}", first, second);
     });
 }
 


### PR DESCRIPTION
This one test is failing consistently in #176. I separated it to be able to cleanup the commits in #176 better.

The macosx segfault does not seem to be related to possibly anything.