### PR TITLE
fix: cache openssl build on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,20 @@ jobs:
       if: matrix.platform.host == 'macos-latest'
       run: brew install llvm openssl
 
+    - name: Cache windows (llvm)
+      if: matrix.platform.host == 'windows-latest'
+      uses: actions/cache@v2
+      with:
+        path: 'C:\Program Files\LLVM'
+        key: ${{ runner.os }}-llvm
+
+    - name: Cache windows (openssl)
+      if: matrix.platform.host == 'windows-latest'
+      uses: actions/cache@v2
+      with:
+        path: 'C:\vcpkg\installed\x64-windows'
+        key: ${{ runner.os }}-${{ hashFiles('C:\vcpkg\installed\x64-windows\bin\libcrypto.dll', 'C:\vcpkg\installed\x64-windows\bin\libssl.dll') }}
+
     - name: Install dependencies windows
       if: matrix.platform.host == 'windows-latest'
       run: |
@@ -81,7 +95,6 @@ jobs:
         vcpkg install openssl:x64-windows
         Copy-Item C:\vcpkg\installed\x64-windows\bin\libcrypto-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libcrypto.dll
         Copy-Item C:\vcpkg\installed\x64-windows\bin\libssl-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libssl.dll
-        Get-ChildItem C:\vcpkg\installed\x64-windows\bin
         Get-ChildItem C:\vcpkg\installed\x64-windows\lib
 
     - name: Install rust toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,13 +73,6 @@ jobs:
       if: matrix.platform.host == 'macos-latest'
       run: brew install llvm openssl
 
-    - name: Cache windows (llvm)
-      if: matrix.platform.host == 'windows-latest'
-      uses: actions/cache@v2
-      with:
-        path: 'C:\Program Files\LLVM'
-        key: ${{ runner.os }}-llvm
-
     - name: Cache windows (openssl)
       if: matrix.platform.host == 'windows-latest'
       uses: actions/cache@v2
@@ -96,6 +89,7 @@ jobs:
         Copy-Item C:\vcpkg\installed\x64-windows\bin\libcrypto-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libcrypto.dll
         Copy-Item C:\vcpkg\installed\x64-windows\bin\libssl-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libssl.dll
         Get-ChildItem C:\vcpkg\installed\x64-windows\lib
+        Get-ChildItem "C:\Program Files\LLVM"
 
     - name: Install rust toolchain
       uses: hecrj/setup-rust-action@v1


### PR DESCRIPTION
also attempt to cache llvm as well, but apparently that does not work and chocolatey ends up downloading the same 160MB either way.

after first successful build this should be able to cache the 15min openssl build away.

Merging when I get a passing build, unless there are objections.