### PR TITLE
Alternatives section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,13 @@ A large portion of this work is covered by an [IPFS Devgrant from Protocol Labs]
 
 Rust IPFS is actively maintained by @koivunej, and @aphelionz. Special thanks is given to [Protocol Labs](https://github.com/protocol), [Equilibrium Labs](https://github.com/eqlabs), and [MRH.io](https://mrh.io).
 
+## Alternatives
+
+It’s been noted that the Rust-IPFS name and popularity may serve us from a "first-mover" perspective.  However, alternatives do exist with different philosophies, and we believe that supporting this community and diversity is both important and will ultimately help produce the best solution possible.
+
+- [`ipfs-embed`](https://github.com/ipfs-rust/ipfs-embed/) - An implementation based on [`sled`](https://github.com/ipfs-rust/ipfs-embed/)
+- PolkaX's [`rust-ipfs`](https://github.com/PolkaX/rust-ipfs)
+
 ## Contributors
 
 ### Code Contributors

--- a/README.md
+++ b/README.md
@@ -142,12 +142,17 @@ A large portion of this work is covered by an [IPFS Devgrant from Protocol Labs]
 
 Rust IPFS is actively maintained by @koivunej, and @aphelionz. Special thanks is given to [Protocol Labs](https://github.com/protocol), [Equilibrium Labs](https://github.com/eqlabs), and [MRH.io](https://mrh.io).
 
-## Alternatives
+## Alternatives and other cool, related projects
 
 It’s been noted that the Rust-IPFS name and popularity may serve us from a "first-mover" perspective.  However, alternatives do exist with different philosophies, and we believe that supporting this community and diversity is both important and will ultimately help produce the best solution possible.
 
+- [`rust-ipfs-api`](https://github.com/ferristseng/rust-ipfs-api) - A Rust client for an existing IPFS HTTP API. Supports both tokio and actix.
 - [`ipfs-embed`](https://github.com/ipfs-rust/ipfs-embed/) - An implementation based on [`sled`](https://github.com/ipfs-rust/ipfs-embed/)
-- PolkaX's [`rust-ipfs`](https://github.com/PolkaX/rust-ipfs)
+- [`rust-ipld`](https://github.com/ipfs-rust/rust-ipld) - Basic rust ipld library supporting `dag-cbor`, `dag-json` and `dag-pb` formats.
+- PolkaX's own [`rust-ipfs`](https://github.com/PolkaX/rust-ipfs)
+- Parity's [`rust-libp2p`](https://github.com/libp2p/rust-libp2p), which does a lot the of heavy lifting here
+
+If you know of another implementation or another cool project adjacent to these efforts, let us know!
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Rust IPFS is actively maintained by @koivunej, and @aphelionz. Special thanks is
 
 ## Alternatives and other cool, related projects
 
-It’s been noted that the Rust-IPFS name and popularity may serve us from a "first-mover" perspective.  However, alternatives do exist with different philosophies, and we believe that supporting this community and diversity is both important and will ultimately help produce the best solution possible.
+It’s been noted that the Rust-IPFS name and popularity may serve its organization from a "first-mover" perspective. However, alternatives with different philosophies do exist, and we believe that supporting a diverse IPFS community is important and will ultimately help produce the best solution possible.
 
 - [`rust-ipfs-api`](https://github.com/ferristseng/rust-ipfs-api) - A Rust client for an existing IPFS HTTP API. Supports both tokio and actix.
 - [`ipfs-embed`](https://github.com/ipfs-rust/ipfs-embed/) - An implementation based on [`sled`](https://github.com/ipfs-rust/ipfs-embed/)


### PR DESCRIPTION
This PR adds an "Alternatives" section to the README, to raise awareness of other implementations.