### PR TITLE
Remove the / before target can help ignore build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-/target
+target
 **/*.rs.bk


### PR DESCRIPTION
Besides /target, there are many target folders inside examples. Please change /target to target so that those build files can be ignored by github