### PR TITLE
fix test using non-unique tempfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,6 +1432,7 @@ dependencies = [
  "serde_json",
  "structopt",
  "tar",
+ "tempfile",
  "thiserror",
  "tokio 0.2.16",
  "url",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -37,3 +37,4 @@ bytes = "0.5.4"
 [dev-dependencies]
 hex = "0.4.2"
 hex-literal = "0.2.1"
+tempfile = "3.1.0"

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -269,8 +269,8 @@ mod tests {
                     let size = header.size()?;
 
                     // writing to file is the only supported way to get the contents
-                    let mut temp_file = std::env::temp_dir();
-                    temp_file.push("temporary_file_for_testing.txt");
+                    let tempdir = tempfile::tempdir()?;
+                    let temp_file = tempdir.path().join("temporary_file_for_testing.txt");
                     entry.unpack(&temp_file)?;
 
                     let bytes = std::fs::read(&temp_file);


### PR DESCRIPTION
If the test fails to delete once, it'll persist the failure. Using tempfile::tempdir should give us a cleaned up after temporary directory.