### PR TITLE
ci: skip llvm install if openssl is cached on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
       run: brew install llvm openssl
 
     - name: Cache windows (openssl)
+      id: windows-openssl-cache
       if: matrix.platform.host == 'windows-latest'
       uses: actions/cache@v2
       with:
@@ -81,7 +82,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('C:\vcpkg\installed\x64-windows\bin\libcrypto.dll', 'C:\vcpkg\installed\x64-windows\bin\libssl.dll') }}
 
     - name: Install dependencies windows
-      if: matrix.platform.host == 'windows-latest'
+      if: matrix.platform.host == 'windows-latest' && steps.windows-openssl-cache.outputs.cache-hit != 'true'
       run: |
         choco install llvm
         vcpkg integrate install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,16 +81,19 @@ jobs:
         path: 'C:\vcpkg\installed\x64-windows'
         key: ${{ runner.os }}-${{ hashFiles('C:\vcpkg\installed\x64-windows\bin\libcrypto.dll', 'C:\vcpkg\installed\x64-windows\bin\libssl.dll') }}
 
-    - name: Install dependencies windows
+    - name: Install dependencies windows (slow)
       if: matrix.platform.host == 'windows-latest' && steps.windows-openssl-cache.outputs.cache-hit != 'true'
       run: |
         choco install llvm
+
+    - name: Install dependencies windows
+      if: matrix.platform.host == 'windows-latest'
+      run: |
         vcpkg integrate install
         vcpkg install openssl:x64-windows
         Copy-Item C:\vcpkg\installed\x64-windows\bin\libcrypto-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libcrypto.dll
         Copy-Item C:\vcpkg\installed\x64-windows\bin\libssl-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libssl.dll
         Get-ChildItem C:\vcpkg\installed\x64-windows\lib
-        Get-ChildItem "C:\Program Files\LLVM"
 
     - name: Install rust toolchain
       uses: hecrj/setup-rust-action@v1


### PR DESCRIPTION
If this works it should shave some 4min of the runtime. Still unsure how to upgrade the openssl later. Probably by doing a run with the cache steps disabled and later enabled?