### PR TITLE
Prepare initial ipfs-unixfs release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "ipfs-unixfs"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "cid",
  "either",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,6 @@ dependencies = [
  "multihash 0.10.1",
  "quick-protobuf",
  "sha2",
- "tar",
 ]
 
 [[package]]

--- a/unixfs/CHANGELOG.md
+++ b/unixfs/CHANGELOG.md
@@ -1,0 +1,8 @@
+# 0.0.1
+
+Initial release.
+
+* `ipfs_unixfs::walk::Walker` for walking directories, files and symlinks
+* `ipfs_unixfs::resolve` for resoving a single named link over directories
+  (plain or HAMT sharded)
+* `ipfs_unixfs::file::visit::FileVisit` lower level file visitor

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "ipfs-unixfs"
-version = "0.1.0"
+version = "0.0.1"
 authors = ["Joonas Koivunen <joonas@equilibrium.co>"]
 edition = "2018"
+license = "MIT OR Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.1"
 authors = ["Joonas Koivunen <joonas@equilibrium.co>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
+description = "UnixFs tree support"
+repository = "https://github.com/rs-ipfs/rust-ipfs"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -13,12 +13,10 @@ default = [ "filetime" ]
 quick-protobuf = "0.7.0"
 cid = "0.4.0"
 filetime = { version = "0.2.10", optional = true }
-either = ">=1.5.3"
+either = "1.5.3"
 
 [dev-dependencies]
 multibase = "0.8.0"
 multihash = "0.10.1"
 sha2 = "0.8.1"
 hex-literal = "0.2.1"
-# we don't need the xattr and we didn't actually need any filetime either
-tar = { version = "0.4.28", default-features = false }

--- a/unixfs/README.md
+++ b/unixfs/README.md
@@ -1,12 +1,12 @@
 # ipfs-unixfs
 
-Goals:
+## Goals
 
 * blockstore API independent way to traverse the merkledag
     * the core read API does not deal with loading blocks
     * instead access to interesting `Cid`s is given
 
-Status:
+## Status
 
 * first iteration of file reader has been implemented
 * first iteration of resolving IpfsPath segments through directories has been
@@ -17,9 +17,13 @@ Status:
 * first iteration of `/get`-like tree walking implemented
 * creation and alteration of dags has not been implemented
 
-Usage:
+## Usage
 
 * The main entry point to walking anything unixfs should be `ipfs_unixfs::walk::Walker`
 * The main entry point to resolving links under dag-pb or unixfs should be `ipfs_unixfs::resolve`
 * There is a `ipfs_unixfs::file::visit::FileVisit` utility but it should be
   considered superceded by `ipfs_unixfs::walk::Walker`
+
+## License
+
+MIT or APL2.


### PR DESCRIPTION
The ipfs-unixfs crate could go out while we still have git deps on the main crate.

This PR adds Cargo.toml metadata, initial CHANGELOG for the subcrate, README changes, license mentioning. Also drops the `tar` dependency which I had forgotten and uses simpler version requirement for `either` as I can't come up with a reason to be `>=1.5.3`.

Once merged, I'll tag the merge commit as `ipfs-unixfs/v0.0.1`.