### PR TITLE
ci: macos core dump collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,11 @@ jobs:
       if: contains(matrix.platform.target, 'android')
       run: cargo install cargo-ndk
 
-    - name: Build
+    - name: Build (others)
       if: matrix.platform.cross == false
       run: cargo build --locked --workspace --tests --examples
 
-    - name: Build android
+    - name: Build (android)
       if: contains(matrix.platform.target, 'android')
       run: cargo ndk --android-platform 29 --target ${{ matrix.platform.target }} build --locked --workspace --exclude ipfs-http
       # exclude http on android because openssl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
 
     - name: Build (others)
       if: matrix.platform.cross == false
-      run: cargo build --locked --workspace --tests --examples
+      run: cargo build --locked --workspace --all-targets
 
     - name: Build (android)
       if: contains(matrix.platform.target, 'android')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           sudo touch /cores/test || { ls -ld /cores; exit 1; }
           sudo rm /cores/test
           retval=0
-          cargo test --workspace || retval=$?
+          sudo cargo test --workspace || retval=$?
           sudo chmod -R a+rwx /cores
           exit $retval
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,9 +119,27 @@ jobs:
       run: cargo build --locked --workspace --exclude ipfs-http --target ${{ matrix.platform.target }}
       # exclude http on other cross compilation targets because openssl
 
-    - name: Rust tests
-      if: matrix.platform.cross == false
+    - name: Rust tests (macos)
+      if: matrix.platform.cross == false && matrix.platform.host == 'macos-latest'
+      run: |
+          ulimit -c unlimited
+          sudo touch /cores/test || { ls -ld /cores; exit 1; }
+          sudo rm /cores/test
+          retval=0
+          cargo test --workspace || retval=$?
+          sudo chmod -R a+rwx /cores
+          exit $retval
+
+    - name: Rust tests (other non-cross targets)
+      if: matrix.platform.cross == false && matrix.platform.host != 'macos-latest'
       run: cargo test --workspace
+
+    - name: Upload crashes (macos)
+      uses: actions/upload-artifact@v2
+      if: matrix.platform.host == 'macos-latest' && ${{ always() }}
+      with:
+        name: macos.crashes
+        path: /cores
 
   lint-rust:
     runs-on: ubuntu-latest


### PR DESCRIPTION
With core dumps we should be able to see which causes the sigsegv and sigabrt. They of course don't seem to happen anymore, but #187 has links to past logs.