### PR TITLE
ipfs-unixfs: Hide FileReader

### DIFF
--- a/unixfs/CHANGELOG.md
+++ b/unixfs/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Next
+
+* Hide `ipfs_unixfs::file::reader` to hide non-exported type on pub fn [#203]
+
+[#203]: https://github.com/rs-ipfs/rust-ipfs/pull/203
+
 # 0.0.1
 
 Initial release.

--- a/unixfs/src/file.rs
+++ b/unixfs/src/file.rs
@@ -8,7 +8,7 @@ use std::borrow::Cow;
 use std::fmt;
 
 /// Low level UnixFS file descriptor reader support.
-pub mod reader;
+mod reader;
 
 /// Higher level API for visiting the file tree.
 pub mod visit;

--- a/unixfs/src/file/reader.rs
+++ b/unixfs/src/file/reader.rs
@@ -182,11 +182,6 @@ impl<'a> FileReader<'a> {
 
         (fc, traversal)
     }
-
-    /// Returns the total size of the file.
-    pub fn file_size(&self) -> u64 {
-        self.file_size
-    }
 }
 
 /// Carrier of validation data used between blocks during a walk on the merkle tree.
@@ -244,6 +239,7 @@ where
     Links(I),
 }
 
+#[cfg(test)]
 impl<'a, I> FileContent<'a, I>
 where
     I: Iterator<Item = (PBLink<'a>, Range<u64>)>,


### PR DESCRIPTION
Fixes #202. Includes minor touchup to also remove further unused parts.