### PR TITLE
cleanups: simplify ledger::Message

### DIFF
--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -6,7 +6,7 @@
 //! The `Bitswap` struct implements the `NetworkBehaviour` trait. When used, it
 //! will allow providing and reciving IPFS blocks.
 use crate::block::Block;
-use crate::ledger::{Ledger, Message, Priority, I, O};
+use crate::ledger::{Ledger, Message, Priority};
 use crate::protocol::BitswapConfig;
 use crate::strategy::{Strategy, StrategyEvent};
 use fnv::FnvHashSet;
@@ -23,7 +23,7 @@ use std::collections::{HashMap, VecDeque};
 /// Network behaviour that handles sending and receiving IPFS blocks.
 pub struct Bitswap<TStrategy> {
     /// Queue of events to report to the user.
-    events: VecDeque<NetworkBehaviourAction<Message<O>, ()>>,
+    events: VecDeque<NetworkBehaviourAction<Message, ()>>,
     /// List of peers to send messages to.
     target_peers: FnvHashSet<PeerId>,
     /// Ledger
@@ -185,7 +185,7 @@ impl<TStrategy> Bitswap<TStrategy> {
 }
 
 impl<TStrategy: Strategy> NetworkBehaviour for Bitswap<TStrategy> {
-    type ProtocolsHandler = OneShotHandler<BitswapConfig, Message<O>, InnerMessage>;
+    type ProtocolsHandler = OneShotHandler<BitswapConfig, Message, InnerMessage>;
     type OutEvent = ();
 
     fn new_handler(&mut self) -> Self::ProtocolsHandler {
@@ -315,14 +315,14 @@ impl<TStrategy: Strategy> NetworkBehaviour for Bitswap<TStrategy> {
 #[derive(Debug)]
 pub enum InnerMessage {
     /// We received a `Message` from a remote.
-    Rx(Message<I>),
+    Rx(Message),
     /// We successfully sent a `Message`.
     Tx,
 }
 
-impl From<Message<I>> for InnerMessage {
+impl From<Message> for InnerMessage {
     #[inline]
-    fn from(message: Message<I>) -> InnerMessage {
+    fn from(message: Message) -> InnerMessage {
         InnerMessage::Rx(message)
     }
 }

--- a/bitswap/src/protocol.rs
+++ b/bitswap/src/protocol.rs
@@ -4,7 +4,7 @@ use crate::error::BitswapError;
 /// The protocol works the following way:
 ///
 /// - TODO
-use crate::ledger::{Message, I, O};
+use crate::ledger::Message;
 use core::future::Future;
 use core::iter;
 use core::pin::Pin;
@@ -33,7 +33,7 @@ impl<TSocket> InboundUpgrade<TSocket> for BitswapConfig
 where
     TSocket: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
-    type Output = Message<I>;
+    type Output = Message;
     type Error = BitswapError;
     #[allow(clippy::type_complexity)]
     type Future = Pin<Box<dyn Future<Output = Result<Self::Output, Self::Error>> + Send>>;
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl UpgradeInfo for Message<O> {
+impl UpgradeInfo for Message {
     type Info = &'static [u8];
     type InfoIter = iter::Once<Self::Info>;
 
@@ -60,7 +60,7 @@ impl UpgradeInfo for Message<O> {
     }
 }
 
-impl<TSocket> OutboundUpgrade<TSocket> for Message<O>
+impl<TSocket> OutboundUpgrade<TSocket> for Message
 where
     TSocket: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {


### PR DESCRIPTION
It seems to me that we don't need `ledger::Message` to be generic; I get the point behind the tag, but IMO its handling is simple enough to not require it at all.

Originally I also removed what vscode suggested to be an unused import, but my trust in it seems to have been misplaced :laughing:.