### PR TITLE
Assorted improvements, continued

### DIFF
--- a/bitswap/src/protocol.rs
+++ b/bitswap/src/protocol.rs
@@ -18,8 +18,8 @@ const MAX_BUF_SIZE: usize = 524_288;
 
 type FutureResult<T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send>>;
 
-#[derive(Clone, Debug, Default)]
-pub struct BitswapConfig {}
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BitswapConfig;
 
 impl UpgradeInfo for BitswapConfig {
     type Info = &'static [u8];

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -114,7 +114,7 @@ pub struct RmResponse {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct EmptyResponse {}
+pub struct EmptyResponse;
 
 pub fn rm<T: IpfsTypes>(
     ipfs: &Ipfs<T>,

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -335,7 +335,7 @@ mod tests {
 
     #[async_std::test]
     #[cfg(feature = "rocksdb")]
-    fn test_rocks_datastore() {
+    async fn test_rocks_datastore() {
         let mut tmp = temp_dir();
         tmp.push("datastore1");
         std::fs::remove_dir_all(&tmp).ok();

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -2,9 +2,9 @@
 use crate::error::Error;
 use crate::repo::{BlockPut, BlockStore, Column, DataStore};
 use async_std::path::PathBuf;
-use async_std::sync::Mutex;
 use async_trait::async_trait;
 use bitswap::Block;
+use futures::lock::Mutex;
 use libipld::cid::Cid;
 
 use super::{BlockRm, BlockRmError};

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -164,12 +164,6 @@ impl<TResult> Subscription<TResult> {
     }
 }
 
-impl<TResult: Clone> Subscription<TResult> {
-    pub fn result(&self) -> Option<TResult> {
-        self.result.clone()
-    }
-}
-
 impl<TResult> Default for Subscription<TResult> {
     fn default() -> Self {
         Self {
@@ -193,8 +187,8 @@ impl<TResult: Clone> Future for SubscriptionFuture<TResult> {
             return Poll::Ready(Err(Cancelled));
         }
 
-        if let Some(result) = subscription.result() {
-            Poll::Ready(Ok(result))
+        if let Some(ref result) = subscription.result {
+            Poll::Ready(Ok(result.clone()))
         } else {
             subscription.add_waker(&context.waker());
             Poll::Pending

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -158,10 +158,6 @@ impl<TResult> Subscription<TResult> {
             waker.wake();
         }
     }
-
-    pub fn is_cancelled(&self) -> bool {
-        self.cancelled
-    }
 }
 
 impl<TResult> Default for Subscription<TResult> {
@@ -183,7 +179,7 @@ impl<TResult: Clone> Future for SubscriptionFuture<TResult> {
 
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
         let mut subscription = self.subscription.lock().unwrap();
-        if subscription.is_cancelled() {
+        if subscription.cancelled {
             return Poll::Ready(Err(Cancelled));
         }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -5,6 +5,7 @@ use core::hash::Hash;
 use core::pin::Pin;
 use std::collections::HashMap;
 use std::fmt;
+use std::mem;
 use std::sync::{Arc, Mutex};
 
 pub struct SubscriptionRegistry<TReq: Debug + Eq + Hash, TRes: Debug> {
@@ -112,60 +113,37 @@ impl fmt::Display for Cancelled {
 
 impl std::error::Error for Cancelled {}
 
-pub struct Subscription<TResult> {
-    result: Option<TResult>,
-    wakers: Vec<Waker>,
-    cancelled: bool,
-}
-
-impl<TResult> fmt::Debug for Subscription<TResult> {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            fmt,
-            "Subscription<{}>(result: {}, wakers: {}, cancelled: {})",
-            std::any::type_name::<TResult>(),
-            if self.result.is_some() {
-                "Some(_)"
-            } else {
-                "None"
-            },
-            self.wakers.len(),
-            self.cancelled
-        )
-    }
+#[derive(Debug)]
+pub enum Subscription<TResult> {
+    Ready(TResult),
+    Pending { wakers: Vec<Waker> },
+    Cancelled,
 }
 
 impl<TResult> Subscription<TResult> {
-    pub fn add_waker(&mut self, waker: &Waker) {
-        if !self.wakers.iter().any(|w| w.will_wake(waker)) {
-            self.wakers.push(waker.clone());
-        }
-    }
-
     pub fn wake(&mut self, result: TResult) {
-        self.result = Some(result);
-        for waker in self.wakers.drain(..) {
-            waker.wake();
+        let mut former_self = mem::replace(self, Subscription::Ready(result));
+        if let Subscription::Pending { ref mut wakers } = former_self {
+            for waker in wakers.drain(..) {
+                waker.wake();
+            }
         }
     }
 
     pub fn cancel(&mut self) {
-        if self.cancelled {
-            return;
-        }
-        self.cancelled = true;
-        for waker in self.wakers.drain(..) {
-            waker.wake();
+        let mut former_self = mem::replace(self, Subscription::Cancelled);
+        if let Subscription::Pending { ref mut wakers } = former_self {
+            for waker in wakers.drain(..) {
+                waker.wake();
+            }
         }
     }
 }
 
 impl<TResult> Default for Subscription<TResult> {
     fn default() -> Self {
-        Self {
-            result: Default::default(),
+        Self::Pending {
             wakers: Default::default(),
-            cancelled: false,
         }
     }
 }
@@ -179,15 +157,17 @@ impl<TResult: Clone> Future for SubscriptionFuture<TResult> {
 
     fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
         let mut subscription = self.subscription.lock().unwrap();
-        if subscription.cancelled {
-            return Poll::Ready(Err(Cancelled));
-        }
 
-        if let Some(ref result) = subscription.result {
-            Poll::Ready(Ok(result.clone()))
-        } else {
-            subscription.add_waker(&context.waker());
-            Poll::Pending
+        match &mut *subscription {
+            Subscription::Cancelled => Poll::Ready(Err(Cancelled)),
+            Subscription::Pending { ref mut wakers } => {
+                let waker = context.waker();
+                if !wakers.iter().any(|w| w.will_wake(waker)) {
+                    wakers.push(waker.clone());
+                }
+                Poll::Pending
+            }
+            Subscription::Ready(result) => Poll::Ready(Ok(result.clone())),
         }
     }
 }


### PR DESCRIPTION
~~Builds on https://github.com/rs-ipfs/rust-ipfs/pull/226, only the last 5 commits are new.~~
The commit messages describe the specific changes, of which the following are the most interesting:
- don't clone the `Subscription`'s result unless it's ready
- enum-ify the `Subscription` object