### PR TITLE
Finishing subscriptions should update the wantlist

### DIFF
--- a/bitswap/src/ledger.rs
+++ b/bitswap/src/ledger.rs
@@ -6,7 +6,7 @@ use cid::Cid;
 use core::convert::TryFrom;
 use prost::Message as ProstMessage;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     mem,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -127,7 +127,7 @@ pub struct Message {
     /// List of wanted blocks.
     want: HashMap<Cid, Priority>,
     /// List of blocks to cancel.
-    cancel: Vec<Cid>,
+    cancel: HashSet<Cid>,
     /// Wheather it is the full list of wanted blocks.
     full: bool,
     /// List of blocks to send.
@@ -151,7 +151,7 @@ impl Message {
     }
 
     /// Returns the list of cancelled blocks.
-    pub fn cancel(&self) -> &[Cid] {
+    pub fn cancel(&self) -> &HashSet<Cid> {
         &self.cancel
     }
 
@@ -172,7 +172,7 @@ impl Message {
 
     /// Adds a block to the cancel list.
     pub fn cancel_block(&mut self, cid: &Cid) {
-        self.cancel.push(cid.to_owned());
+        self.cancel.insert(cid.to_owned());
     }
 
     /// Removes the block from the want list.

--- a/bitswap/src/protocol.rs
+++ b/bitswap/src/protocol.rs
@@ -12,7 +12,7 @@ use futures::io::{AsyncRead, AsyncWrite};
 use libp2p_core::{upgrade, InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use std::io;
 
-// Undocumented, but according to JS we our messages have a max size of 512*1024
+// Undocumented, but according to JS the bitswap messages have a max size of 512*1024 bytes
 // https://github.com/ipfs/js-ipfs-bitswap/blob/d8f80408aadab94c962f6b88f343eb9f39fa0fcc/src/decision-engine/index.js#L16
 const MAX_BUF_SIZE: usize = 524_288;
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -307,8 +307,8 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         &mut self.pubsub
     }
 
-    pub fn bitswap(&self) -> &Bitswap {
-        &self.bitswap
+    pub fn bitswap(&mut self) -> &mut Bitswap {
+        &mut self.bitswap
     }
 }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -40,8 +40,7 @@ impl<TRepoTypes: RepoTypes> From<&IpfsOptions<TRepoTypes>> for RepoOptions<TRepo
 pub fn create_repo<TRepoTypes: RepoTypes>(
     options: RepoOptions<TRepoTypes>,
 ) -> (Repo<TRepoTypes>, Receiver<RepoEvent>) {
-    let (repo, ch) = Repo::new(options);
-    (repo, ch)
+    Repo::new(options)
 }
 
 /// Describes the outcome of `BlockStore::put_block`

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -17,10 +17,8 @@ impl<TReq: Debug + Eq + Hash, TRes: Debug> fmt::Debug for SubscriptionRegistry<T
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(
             fmt,
-            "{}<{}, {}>(subscriptions: {:?})",
+            "{}(subscriptions: {:?})",
             std::any::type_name::<Self>(),
-            std::any::type_name::<TReq>(),
-            std::any::type_name::<TRes>(),
             self.subscriptions
         )
     }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -199,7 +199,7 @@ mod tests {
         let mut registry = SubscriptionRegistry::<u32, u32>::default();
         let s1 = registry.create_subscription(0);
         drop(registry);
-        s1.await.unwrap_err();
+        assert_eq!(s1.await, Err(Cancelled));
     }
 
     #[async_std::test]
@@ -207,7 +207,7 @@ mod tests {
         let mut registry = SubscriptionRegistry::<u32, u32>::default();
         let s1 = registry.create_subscription(0);
         registry.shutdown();
-        s1.await.unwrap_err();
+        assert_eq!(s1.await, Err(Cancelled));
     }
 
     #[async_std::test]
@@ -215,7 +215,7 @@ mod tests {
         let mut registry = SubscriptionRegistry::<u32, u32>::default();
         registry.shutdown();
         let s1 = registry.create_subscription(0);
-        s1.await.unwrap_err();
+        assert_eq!(s1.await, Err(Cancelled));
     }
 
     #[async_std::test]
@@ -227,7 +227,7 @@ mod tests {
         let s1 = timeout(Duration::from_millis(1), registry.create_subscription(0));
         let s2 = registry.create_subscription(0);
 
-        // make sure it timeouted but had time to register the waker
+        // make sure it timed out but had time to register the waker
         s1.await.unwrap_err();
 
         // this will cause a call to waker installed by s1, but it shouldn't be a problem.


### PR DESCRIPTION
This can be achieved by taking advantage of the `RepoEvent::ProvideBlock` that always follows a finished subscription.

In addition there are a few other self-contained drive-by changes, described in their respective commit messages.