### PR TITLE
Streaming multiparts at block/put and dag/put

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,8 +2237,7 @@ dependencies = [
 [[package]]
 name = "mpart-async"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "204b55792fd08d8181a67b2987c65902ac652d07ae01b77ede7f1a76a1baeb88"
+source = "git+https://github.com/koivunej/mpart-async?branch=fix_7#df6e44c8089ce28f9283fe7bf173781ffc4ff8d5"
 dependencies = [
  "anyhow",
  "bytes 0.5.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,8 @@ dependencies = [
  "ipfs",
  "libipld",
  "log 0.4.8",
+ "mime 0.3.16",
+ "mpart-async",
  "multibase",
  "multihash 0.10.1",
  "openssl",
@@ -2233,6 +2235,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpart-async"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "204b55792fd08d8181a67b2987c65902ac652d07ae01b77ede7f1a76a1baeb88"
+dependencies = [
+ "anyhow",
+ "bytes 0.5.4",
+ "futures 0.3.4",
+ "http",
+ "httparse",
+ "log 0.4.8",
+ "mime_guess 2.0.3",
+ "rand 0.7.3",
+ "thiserror",
+ "tokio 0.2.16",
+ "tokio-util",
+ "twoway 0.2.1",
+]
+
+[[package]]
 name = "multibase"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,7 +2316,7 @@ dependencies = [
  "rand 0.6.5",
  "safemem",
  "tempfile",
- "twoway",
+ "twoway 0.1.8",
 ]
 
 [[package]]
@@ -3763,6 +3785,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "twoway"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b40075910de3a912adbd80b5d8bad6ad10a23eeb1f5bf9d4006839e899ba5bc"
+dependencies = [
+ "memchr",
+ "unchecked-index",
+]
+
+[[package]]
 name = "typenum"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3779,6 +3811,12 @@ dependencies = [
  "rustc-hex",
  "static_assertions",
 ]
+
+[[package]]
+name = "unchecked-index"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeba86d422ce181a719445e51872fa30f1f7413b62becb52e95ec91aa262d85c"
 
 [[package]]
 name = "unicase"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -34,7 +34,7 @@ pin-project = "0.4.8"
 url = "2.1.1"
 tar = { version = "0.4.28", default-features = false }
 bytes = "0.5.4"
-mpart-async = "0.4.0"
+mpart-async = { git = "https://github.com/koivunej/mpart-async", branch = "fix_7" }
 mime = "0.3.16"
 
 [dev-dependencies]

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -34,6 +34,8 @@ pin-project = "0.4.8"
 url = "2.1.1"
 tar = { version = "0.4.28", default-features = false }
 bytes = "0.5.4"
+mpart-async = "0.4.0"
+mime = "0.3.16"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -1,11 +1,13 @@
-use crate::v0::support::{with_ipfs, HandledErr, StreamResponse, StringError};
+use crate::v0::support::{
+    try_only_named_multipart, with_ipfs, HandledErr, StreamResponse, StringError,
+};
 use bytes::Buf;
-use futures::stream::{FuturesOrdered, Stream, StreamExt, TryStreamExt};
+use futures::stream::{FuturesOrdered, Stream, StreamExt};
 use ipfs::error::Error;
 use ipfs::{Ipfs, IpfsTypes};
 use libipld::cid::{Cid, Codec, Version};
 use mime::Mime;
-use mpart_async::server::MultipartStream;
+
 use multihash::Multihash;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
@@ -116,79 +118,6 @@ async fn inner_put<T: IpfsTypes>(
         "Key": key,
         "Size": size,
     })))
-}
-
-pub async fn try_only_named_multipart<'a>(
-    allowed_names: &'a [impl AsRef<str> + 'a],
-    size_limit: usize,
-    boundary: String,
-    st: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin + 'a,
-) -> Result<Vec<u8>, Rejection> {
-    use bytes::Bytes;
-    let mut stream =
-        MultipartStream::new(Bytes::from(boundary), st.map_ok(|mut buf| buf.to_bytes()));
-
-    // store the first good field here; optimally this would just be an Option but couldn't figure
-    // out a way to handle the "field matched", "field not matched" cases while supporting empty
-    // fields.
-    let mut buffer = Vec::new();
-    let mut matched = false;
-
-    while let Some(mut field) = stream.try_next().await.map_err(StringError::from)? {
-        // [ipfs http api] says we should expect a "data" but examples use "file" as the
-        // form field name. newer conformance tests also use former, older latter.
-        //
-        // [ipfs http api]: https://docs.ipfs.io/reference/http/api/#api-v0-block-put
-
-        let name = field
-            .name()
-            .map_err(|_| StringError::from("invalid field name"))?;
-
-        let mut target = if allowed_names.iter().any(|s| s.as_ref() == name) {
-            Some(&mut buffer)
-        } else {
-            None
-        };
-
-        if matched {
-            // per spec: only one block should be uploaded at once
-            return Err(StringError::from("multiple blocks (expecting at most one)").into());
-        }
-
-        matched = target.is_some();
-
-        loop {
-            let next = field.try_next().await.map_err(|e| {
-                StringError::from(format!("IO error while reading field bytes: {}", e))
-            })?;
-
-            match (next, target.as_mut()) {
-                (Some(bytes), Some(target)) => {
-                    if target.len() + bytes.len() > size_limit {
-                        return Err(StringError::from("block is too large").into());
-                    } else if target.is_empty() {
-                        target.reserve(size_limit);
-                    }
-                    target.extend_from_slice(bytes.as_ref());
-                }
-                (Some(bytes), None) => {
-                    // noop: we must fully consume the part before moving on to next.
-                    if bytes.is_empty() {
-                        // this technically shouldn't be happening any more but erroring
-                        // out instead of spinning wildly is much better.
-                        return Err(StringError::from("internal error: zero read").into());
-                    }
-                }
-                (None, _) => break,
-            }
-        }
-    }
-
-    if !matched {
-        return Err(StringError::from("missing field: \"data\" (or \"file\")").into());
-    }
-
-    Ok(buffer)
 }
 
 #[derive(Debug, Serialize)]

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -12,6 +12,22 @@ use warp::{path, query, reply, Buf, Filter, Rejection, Reply};
 pub struct PutQuery {
     format: Option<String>,
     hash: Option<String>,
+    #[serde(rename = "input-enc", default)]
+    encoding: InputEncoding,
+}
+
+#[derive(PartialEq, Eq, Debug, Deserialize)]
+pub enum InputEncoding {
+    #[serde(rename = "raw")]
+    Raw,
+    #[serde(rename = "json")]
+    Json,
+}
+
+impl Default for InputEncoding {
+    fn default() -> Self {
+        InputEncoding::Json
+    }
 }
 
 async fn put_query<T: IpfsTypes>(
@@ -21,6 +37,10 @@ async fn put_query<T: IpfsTypes>(
     body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin,
 ) -> Result<impl Reply, Rejection> {
     use multihash::{Multihash, Sha2_256, Sha2_512, Sha3_512};
+
+    if query.encoding != InputEncoding::Raw {
+        return Err(NotImplemented.into());
+    }
 
     let (format, v0_fmt) = match query.format.as_deref().unwrap_or("dag-cbor") {
         "dag-cbor" => (Codec::DagCBOR, false),

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -1,10 +1,12 @@
-use crate::v0::support::{with_ipfs, InvalidMultipartFormData, StringError};
-use futures::stream::StreamExt;
+use crate::v0::support::{try_only_named_multipart, with_ipfs, NotImplemented, StringError};
+use futures::stream::Stream;
 use ipfs::{Ipfs, IpfsTypes};
 use libipld::cid::{Cid, Codec};
+use mime::Mime;
+
 use serde::Deserialize;
 use serde_json::json;
-use warp::{multipart, path, query, reply, Buf, Filter, Rejection, Reply};
+use warp::{path, query, reply, Buf, Filter, Rejection, Reply};
 
 #[derive(Debug, Deserialize)]
 pub struct PutQuery {
@@ -15,7 +17,8 @@ pub struct PutQuery {
 async fn put_query<T: IpfsTypes>(
     ipfs: Ipfs<T>,
     query: PutQuery,
-    mut form: multipart::FormData,
+    mime: Mime,
+    body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin,
 ) -> Result<impl Reply, Rejection> {
     use multihash::{Multihash, Sha2_256, Sha2_512, Sha3_512};
 
@@ -26,22 +29,22 @@ async fn put_query<T: IpfsTypes>(
         "raw" => (Codec::Raw, false),
         _ => return Err(StringError::from("unknown codec").into()),
     };
+
     let (hasher, v0_hash) = match query.hash.as_deref().unwrap_or("sha2-256") {
         "sha2-256" => (Sha2_256::digest as fn(&[u8]) -> Multihash, true),
         "sha2-512" => (Sha2_512::digest as fn(&[u8]) -> Multihash, false),
         "sha3-512" => (Sha3_512::digest as fn(&[u8]) -> Multihash, false),
         _ => return Err(StringError::from("unknown hash").into()),
     };
-    let buf = form
-        .next()
-        .await
-        .ok_or(InvalidMultipartFormData)?
-        .map_err(|_| InvalidMultipartFormData)?
-        .data()
-        .await
-        .ok_or(InvalidMultipartFormData)?
-        .map_err(|_| InvalidMultipartFormData)?;
-    let data = Box::from(buf.bytes());
+
+    let boundary = mime
+        .get_param("boundary")
+        .map(|v| v.to_string())
+        .ok_or_else(|| StringError::from("missing 'boundary' on content-type"))?;
+
+    let buf = try_only_named_multipart(&["data", "file"], 1024 * 1024, boundary, body).await?;
+
+    let data = buf.into_boxed_slice();
     let digest = hasher(&data);
     let cid = if v0_fmt && v0_hash {
         // this is quite ugly way but apparently js-ipfs generates a v0 cid for this combination
@@ -64,7 +67,8 @@ pub fn put<T: IpfsTypes>(
     path!("dag" / "put")
         .and(with_ipfs(ipfs))
         .and(query::<PutQuery>())
-        .and(multipart::form())
+        .and(warp::header::<Mime>("content-type")) // TODO: rejects if missing
+        .and(warp::body::stream())
         .and_then(put_query)
 }
 

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -135,7 +135,7 @@ pub async fn recover_as_message_response(
     err: warp::reject::Rejection,
 ) -> Result<impl warp::Reply, Infallible> {
     use warp::http::StatusCode;
-    use warp::reject::{InvalidQuery, MethodNotAllowed};
+    use warp::reject::{InvalidQuery, LengthRequired, MethodNotAllowed};
 
     let resp: Box<dyn warp::Reply>;
     let status;
@@ -195,6 +195,14 @@ pub async fn recover_as_message_response(
         // go-ipfs sends back a "404 Not Found" with body "404 page not found"
         resp = Box::new("404 page not found");
         status = StatusCode::NOT_FOUND;
+    } else if err.find::<LengthRequired>().is_some() {
+        resp = Box::new(
+            MessageKind::Error
+                .with_code(0)
+                .with_message("Missing header: content-length")
+                .to_json_reply(),
+        );
+        status = StatusCode::BAD_REQUEST;
     } else {
         // FIXME: use log
         warn!("unhandled rejection: {:?}", err);

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -10,6 +10,9 @@ pub mod option_parsing;
 mod stream;
 pub use stream::StreamResponse;
 
+mod body;
+pub use body::try_only_named_multipart;
+
 /// The common responses apparently returned by the go-ipfs HTTP api on errors.
 /// See also: https://github.com/ferristseng/rust-ipfs-api/blob/master/ipfs-api/src/response/error.rs
 #[derive(Debug, Serialize)]

--- a/http/src/v0/support/body.rs
+++ b/http/src/v0/support/body.rs
@@ -1,0 +1,78 @@
+use crate::v0::support::StringError;
+use bytes::Buf;
+use futures::stream::{Stream, TryStreamExt};
+use mpart_async::server::MultipartStream;
+use warp::Rejection;
+
+pub async fn try_only_named_multipart<'a>(
+    allowed_names: &'a [impl AsRef<str> + 'a],
+    size_limit: usize,
+    boundary: String,
+    st: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin + 'a,
+) -> Result<Vec<u8>, Rejection> {
+    use bytes::Bytes;
+    let mut stream =
+        MultipartStream::new(Bytes::from(boundary), st.map_ok(|mut buf| buf.to_bytes()));
+
+    // store the first good field here; optimally this would just be an Option but couldn't figure
+    // out a way to handle the "field matched", "field not matched" cases while supporting empty
+    // fields.
+    let mut buffer = Vec::new();
+    let mut matched = false;
+
+    while let Some(mut field) = stream.try_next().await.map_err(StringError::from)? {
+        // [ipfs http api] says we should expect a "data" but examples use "file" as the
+        // form field name. newer conformance tests also use former, older latter.
+        //
+        // [ipfs http api]: https://docs.ipfs.io/reference/http/api/#api-v0-block-put
+
+        let name = field
+            .name()
+            .map_err(|_| StringError::from("invalid field name"))?;
+
+        let mut target = if allowed_names.iter().any(|s| s.as_ref() == name) {
+            Some(&mut buffer)
+        } else {
+            None
+        };
+
+        if matched {
+            // per spec: only one block should be uploaded at once
+            return Err(StringError::from("multiple blocks (expecting at most one)").into());
+        }
+
+        matched = target.is_some();
+
+        loop {
+            let next = field.try_next().await.map_err(|e| {
+                StringError::from(format!("IO error while reading field bytes: {}", e))
+            })?;
+
+            match (next, target.as_mut()) {
+                (Some(bytes), Some(target)) => {
+                    if target.len() + bytes.len() > size_limit {
+                        return Err(StringError::from("block is too large").into());
+                    } else if target.is_empty() {
+                        target.reserve(size_limit);
+                    }
+                    target.extend_from_slice(bytes.as_ref());
+                }
+                (Some(bytes), None) => {
+                    // noop: we must fully consume the part before moving on to next.
+                    if bytes.is_empty() {
+                        // this technically shouldn't be happening any more but erroring
+                        // out instead of spinning wildly is much better.
+                        return Err(StringError::from("internal error: zero read").into());
+                    }
+                }
+                (None, _) => break,
+            }
+        }
+    }
+
+    if !matched {
+        return Err(StringError::from("missing field: \"data\" (or \"file\")").into());
+    }
+
+    Ok(buffer)
+}


### PR DESCRIPTION
Supercedes #225 to cover `dag/put`. I'll close the earlier and keep this as a draft while the temp git dependency is in place.

This allows accepting multipart bodies without Content-Length header by using mpart-async. Uploads are limited to 1MB.

As minor fixes this includes checking `dag/put?input-enc=raw` as we don't support any other input-enc at the moment (rust-ipld could read dag-json, this was implemented during phase1 already).

As more minor fixes this includes transformation of LengthRequired rejection to "Missing header: content-length" instead of "UNHANDLED REJECTION".

Fix is needed for #228.