### PR TITLE
Add http timeouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 1.3.0",
  "log 0.4.8",
  "regex",
  "termcolor",
@@ -1329,6 +1329,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+
+[[package]]
 name = "hyper"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,6 +1439,7 @@ dependencies = [
  "futures 0.3.4",
  "hex",
  "hex-literal",
+ "humantime 2.0.1",
  "hyper",
  "ipfs",
  "libipld",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -36,6 +36,7 @@ tar = { version = "0.4.28", default-features = false }
 bytes = "0.5.4"
 mpart-async = { git = "https://github.com/koivunej/mpart-async", branch = "fix_7" }
 mime = "0.3.16"
+humantime = "2.0.1"
 
 [dev-dependencies]
 hex = "0.4.2"

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -17,13 +17,18 @@ use warp::{http::Response, path, query, reply, Filter, Rejection, Reply};
 mod options;
 use options::RmOptions;
 
+// This is parsed for both `block/get` and `block/stat`. Should there be any need to add stuff to
+// either which isn't relevant in the other, go ahead and split these again.
 #[derive(Debug, Deserialize)]
-pub struct GetQuery {
+pub struct GetStatOptions {
     arg: String,
     timeout: Option<StringSerialized<humantime::Duration>>,
 }
 
-async fn get_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: GetQuery) -> Result<impl Reply, Rejection> {
+async fn get_query<T: IpfsTypes>(
+    ipfs: Ipfs<T>,
+    query: GetStatOptions,
+) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
     let data = ipfs
         .get_block(&cid)
@@ -42,7 +47,7 @@ pub fn get<T: IpfsTypes>(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "get")
         .and(with_ipfs(ipfs))
-        .and(query::<GetQuery>())
+        .and(query::<GetStatOptions>())
         .and_then(get_query)
 }
 
@@ -208,12 +213,6 @@ async fn rm_query<T: IpfsTypes>(
     Ok(StreamResponse(st))
 }
 
-#[derive(Debug, Deserialize)]
-pub struct StatQuery {
-    arg: String,
-    timeout: Option<StringSerialized<humantime::Duration>>,
-}
-
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct StatResponse {
@@ -223,7 +222,7 @@ pub struct StatResponse {
 
 async fn stat_query<T: IpfsTypes>(
     ipfs: Ipfs<T>,
-    query: StatQuery,
+    query: GetStatOptions,
 ) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
     let block = ipfs
@@ -245,6 +244,6 @@ pub fn stat<T: IpfsTypes>(
 ) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "stat")
         .and(with_ipfs(ipfs))
-        .and(query::<StatQuery>())
+        .and(query::<GetStatOptions>())
         .and_then(stat_query)
 }

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -213,13 +213,6 @@ async fn rm_query<T: IpfsTypes>(
     Ok(StreamResponse(st))
 }
 
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "PascalCase")]
-pub struct StatResponse {
-    key: String,
-    size: usize,
-}
-
 async fn stat_query<T: IpfsTypes>(
     ipfs: Ipfs<T>,
     query: GetStatOptions,
@@ -232,11 +225,10 @@ async fn stat_query<T: IpfsTypes>(
         .map_err(StringError::from)?
         .map_err(StringError::from)?;
 
-    let response = StatResponse {
-        key: query.arg,
-        size: block.data().len(),
-    };
-    Ok(reply::json(&response))
+    Ok(reply::json(&serde_json::json!({
+        "Key": query.arg,
+        "Size": block.data().len(),
+    })))
 }
 
 pub fn stat<T: IpfsTypes>(

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -1,4 +1,7 @@
-use crate::v0::support::{try_only_named_multipart, with_ipfs, NotImplemented, StringError};
+use crate::v0::support::{
+    try_only_named_multipart, with_ipfs, MaybeTimeoutExt, NotImplemented, StringError,
+    StringSerialized,
+};
 use futures::stream::Stream;
 use ipfs::{Ipfs, IpfsTypes};
 use libipld::cid::{Cid, Codec};
@@ -109,9 +112,7 @@ pub fn resolve<T: IpfsTypes>(
 #[derive(Debug, Deserialize)]
 struct ResolveOptions {
     arg: String,
-    // with local_resolve, we should not start to fetch the block ever, this is available in
-    // (js-)ipfs-http-client >= 44.0.0 and the last failing test.
-    // TODO: #[serde(rename = "localResolve")] local_resolve: bool
+    timeout: Option<StringSerialized<humantime::Duration>>,
 }
 
 async fn inner_resolve<T: IpfsTypes>(
@@ -123,7 +124,11 @@ async fn inner_resolve<T: IpfsTypes>(
 
     let path = IpfsPath::try_from(opts.arg.as_str()).map_err(StringError::from)?;
 
-    let (current, _, remaining) = walk_path(&ipfs, path).await.map_err(StringError::from)?;
+    let (current, _, remaining) = walk_path(&ipfs, path)
+        .maybe_timeout(opts.timeout.map(StringSerialized::into_inner))
+        .await
+        .map_err(StringError::from)?
+        .map_err(StringError::from)?;
 
     let remaining = {
         let slashes = remaining.len();

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -1,4 +1,4 @@
-use crate::v0::support::{maybe_timeout, with_ipfs, StringError};
+use crate::v0::support::{with_ipfs, MaybeTimeoutExt, StringError};
 use futures::stream;
 use futures::stream::Stream;
 use ipfs::{Block, Error};

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -14,7 +14,7 @@ mod body;
 pub use body::{try_only_named_multipart, OnlyMultipartFailure};
 
 mod timeout;
-pub use timeout::{maybe_timeout, MaybeTimeoutExt};
+pub use timeout::MaybeTimeoutExt;
 
 mod serdesupport;
 pub use serdesupport::StringSerialized;

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -13,6 +13,9 @@ pub use stream::StreamResponse;
 mod body;
 pub use body::{try_only_named_multipart, OnlyMultipartFailure};
 
+mod timeout;
+pub use timeout::{maybe_timeout, MaybeTimeoutExt};
+
 mod serdesupport;
 pub use serdesupport::StringSerialized;
 

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -13,6 +13,9 @@ pub use stream::StreamResponse;
 mod body;
 pub use body::{try_only_named_multipart, OnlyMultipartFailure};
 
+mod serdesupport;
+pub use serdesupport::StringSerialized;
+
 /// The common responses apparently returned by the go-ipfs HTTP api on errors.
 /// See also: https://github.com/ferristseng/rust-ipfs-api/blob/master/ipfs-api/src/response/error.rs
 #[derive(Debug, Serialize)]

--- a/http/src/v0/support/option_parsing.rs
+++ b/http/src/v0/support/option_parsing.rs
@@ -7,6 +7,7 @@ pub enum ParseError<'a> {
     MissingArg,
     InvalidNumber(Cow<'a, str>, Cow<'a, str>),
     InvalidBoolean(Cow<'a, str>, Cow<'a, str>),
+    InvalidDuration(Cow<'a, str>, humantime::DurationError),
 }
 
 impl<'a> fmt::Display for ParseError<'a> {
@@ -17,6 +18,9 @@ impl<'a> fmt::Display for ParseError<'a> {
             MissingArg => write!(fmt, "required field \"arg\" missing"),
             InvalidNumber(ref k, ref v) => write!(fmt, "field {:?} invalid number: {:?}", *k, *v),
             InvalidBoolean(ref k, ref v) => write!(fmt, "field {:?} invalid boolean: {:?}", *k, *v),
+            InvalidDuration(ref field, ref e) => {
+                write!(fmt, "field {:?} invalid duration: {:?}", field, e)
+            }
         }
     }
 }

--- a/http/src/v0/support/serdesupport.rs
+++ b/http/src/v0/support/serdesupport.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display};
 use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
-/// Wrapper for anything which implements FromStr to get make it serde::Deserialize. Will turn
+/// A wrapper for anything that implements FromStr to make it serde::Deserialize. Will turn
 /// Display to serde::Serialize. Probably should be used with Cid, PeerId and such.
 ///
 /// Monkeyd from: https://github.com/serde-rs/serde/issues/1316

--- a/http/src/v0/support/serdesupport.rs
+++ b/http/src/v0/support/serdesupport.rs
@@ -1,0 +1,53 @@
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+pub struct StringSerialized<T>(pub T);
+
+impl<T> StringSerialized<T> {
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> From<T> for StringSerialized<T> {
+    fn from(t: T) -> Self {
+        StringSerialized(t)
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for StringSerialized<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
+
+impl<T: fmt::Display> fmt::Display for StringSerialized<T> {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(fmt)
+    }
+}
+
+impl<T: Display> serde::Serialize for StringSerialized<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de, T: FromStr> serde::Deserialize<'de> for StringSerialized<T>
+where
+    <T as FromStr>::Err: Display,
+    T: Sized,
+{
+    fn deserialize<D>(deserializer: D) -> Result<StringSerialized<T>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map(StringSerialized)
+            .map_err(serde::de::Error::custom)
+    }
+}

--- a/http/src/v0/support/serdesupport.rs
+++ b/http/src/v0/support/serdesupport.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
+#[derive(Clone, Copy)]
 pub struct StringSerialized<T>(pub T);
 
 impl<T> StringSerialized<T> {

--- a/http/src/v0/support/serdesupport.rs
+++ b/http/src/v0/support/serdesupport.rs
@@ -1,6 +1,11 @@
 use std::fmt::{self, Display};
+use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 
+/// Wrapper for anything which implements FromStr to get make it serde::Deserialize. Will turn
+/// Display to serde::Serialize. Probably should be used with Cid, PeerId and such.
+///
+/// Monkeyd from: https://github.com/serde-rs/serde/issues/1316
 #[derive(Clone, Copy)]
 pub struct StringSerialized<T>(pub T);
 
@@ -13,6 +18,20 @@ impl<T> StringSerialized<T> {
 impl<T> From<T> for StringSerialized<T> {
     fn from(t: T) -> Self {
         StringSerialized(t)
+    }
+}
+
+impl<T> Deref for StringSerialized<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for StringSerialized<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
     }
 }
 

--- a/http/src/v0/support/timeout.rs
+++ b/http/src/v0/support/timeout.rs
@@ -10,32 +10,30 @@ use tokio::time::{timeout, Elapsed, Timeout};
 pub type MaybeTimeout<F> =
     Either<Timeout<F>, Map<F, fn(<F as Future>::Output) -> Result<<F as Future>::Output, Elapsed>>>;
 
-pub fn maybe_timeout<F: Future>(
-    maybe_timeout: Option<impl Into<Duration>>,
-    fut: F,
-) -> MaybeTimeout<F>
-where
-{
-    use futures::future::FutureExt;
-    let maybe_timeout: Option<Duration> = maybe_timeout.map(|to_d| to_d.into());
-
-    if let Some(dur) = maybe_timeout {
-        Either::Left(timeout(dur, fut))
-    } else {
-        Either::Right(fut.map(ok_never_elapsed))
-    }
-}
-
 fn ok_never_elapsed<V>(v: V) -> Result<V, Elapsed> {
     Ok(v)
 }
 
+/// Extends futures with `maybe_timeout` which allows timeouting based on the repeated `timeout:
+/// Option<StringSerialized<humantime::Duration>>` field in the API method options.
 pub trait MaybeTimeoutExt {
+    /// Possibly wraps this future in a timeout, depending of whether the duration is given or not.
+    ///
+    /// Returns a wrapper which will always return whatever the this future returned, wrapped in a
+    /// Result with the possibility of elapsing the `maybe_duration`.
     fn maybe_timeout<D: Into<Duration>>(self, maybe_duration: Option<D>) -> MaybeTimeout<Self>
     where
         Self: Future + Sized,
     {
-        maybe_timeout(maybe_duration, self)
+        use futures::future::FutureExt;
+
+        let maybe_duration: Option<Duration> = maybe_duration.map(|to_d| to_d.into());
+
+        if let Some(dur) = maybe_duration {
+            Either::Left(timeout(dur, self))
+        } else {
+            Either::Right(self.map(ok_never_elapsed))
+        }
     }
 }
 

--- a/http/src/v0/support/timeout.rs
+++ b/http/src/v0/support/timeout.rs
@@ -1,0 +1,42 @@
+//! Quite complex implementation for possibly timed out operation. Needed to be this complex so
+//! that any Unpin traits and such the inner future might have are properly reimplemented (by
+//! leveraging futures combinators).
+
+use futures::future::{Either, Map};
+use std::future::Future;
+use std::time::Duration;
+use tokio::time::{timeout, Elapsed, Timeout};
+
+pub type MaybeTimeout<F> =
+    Either<Timeout<F>, Map<F, fn(<F as Future>::Output) -> Result<<F as Future>::Output, Elapsed>>>;
+
+pub fn maybe_timeout<F: Future>(
+    maybe_timeout: Option<impl Into<Duration>>,
+    fut: F,
+) -> MaybeTimeout<F>
+where
+{
+    use futures::future::FutureExt;
+    let maybe_timeout: Option<Duration> = maybe_timeout.map(|to_d| to_d.into());
+
+    if let Some(dur) = maybe_timeout {
+        Either::Left(timeout(dur, fut))
+    } else {
+        Either::Right(fut.map(ok_never_elapsed))
+    }
+}
+
+fn ok_never_elapsed<V>(v: V) -> Result<V, Elapsed> {
+    Ok(v)
+}
+
+pub trait MaybeTimeoutExt {
+    fn maybe_timeout<D: Into<Duration>>(self, maybe_duration: Option<D>) -> MaybeTimeout<Self>
+    where
+        Self: Future + Sized,
+    {
+        maybe_timeout(maybe_duration, self)
+    }
+}
+
+impl<T: Future> MaybeTimeoutExt for T {}


### PR DESCRIPTION
Related to #228, this adds timeout handling to:

 * `block/get`
 * `dag/resolve`
 * `refs` (partial)
 * `cat` (partial)
 * `get` (partial)

Partial means only the initial step of at minimum path walking has the timeout. We cannot yet return errors from streamed bodies because of the lack of `Trailer` support in hyper, so no "request timeout" is enforced once we get to streaming the body.