### PR TITLE
chore: use released mpart-async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2243,8 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "mpart-async"
-version = "0.4.0"
-source = "git+https://github.com/koivunej/mpart-async?branch=fix_7#df6e44c8089ce28f9283fe7bf173781ffc4ff8d5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea338ffba87fdaaea364b314301ead2ee38e584a7a7b06e881ca101a2a059d0f"
 dependencies = [
  "anyhow",
  "bytes 0.5.4",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -34,7 +34,7 @@ pin-project = "0.4.8"
 url = "2.1.1"
 tar = { version = "0.4.28", default-features = false }
 bytes = "0.5.4"
-mpart-async = { git = "https://github.com/koivunej/mpart-async", branch = "fix_7" }
+mpart-async = "0.4.1"
 mime = "0.3.16"
 humantime = "2.0.1"
 


### PR DESCRIPTION
0.4.1 with fix_7 was released just now.