### PR TITLE
cancel Blocks from the wantlist when all their Subscriptions die

### DIFF
--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -179,6 +179,8 @@ impl NetworkBehaviour for Bitswap {
         );
         debug!("{:?}", message);
 
+        let current_wantlist = self.local_wantlist();
+
         let ledger = self
             .connected_peers
             .get_mut(&source)
@@ -194,7 +196,11 @@ impl NetworkBehaviour for Bitswap {
         }
 
         // Process the incoming wantlist.
-        for (cid, priority) in message.want() {
+        for (cid, priority) in message
+            .want()
+            .iter()
+            .filter(|&(cid, _)| !current_wantlist.iter().map(|(c, _)| c).any(|c| c == cid))
+        {
             ledger.received_want_list.insert(cid.to_owned(), *priority);
 
             let event = BitswapEvent::ReceivedWant(source.clone(), cid.clone(), *priority);

--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -30,8 +30,6 @@ pub enum BitswapEvent {
     ReceivedCancel(PeerId, Cid),
 }
 
-pub type SubscriberCount = usize;
-
 /// Network behaviour that handles sending and receiving IPFS blocks.
 #[derive(Default)]
 pub struct Bitswap {
@@ -42,7 +40,7 @@ pub struct Bitswap {
     /// Ledger
     pub connected_peers: HashMap<PeerId, Ledger>,
     /// Wanted blocks
-    wanted_blocks: HashMap<Cid, (Priority, SubscriberCount)>,
+    wanted_blocks: HashMap<Cid, Priority>,
     /// Blocks queued to be sent
     pub queued_blocks: Arc<Mutex<Vec<(PeerId, Block)>>>,
 }
@@ -52,7 +50,7 @@ impl Bitswap {
     pub fn local_wantlist(&self) -> Vec<(Cid, Priority)> {
         self.wanted_blocks
             .iter()
-            .map(|(cid, (prio, _))| (cid.clone(), *prio))
+            .map(|(cid, prio)| (cid.clone(), *prio))
             .collect()
     }
 
@@ -107,7 +105,7 @@ impl Bitswap {
         debug!("bitswap: send_want_list");
         if !self.wanted_blocks.is_empty() {
             let mut message = Message::default();
-            for (cid, (priority, _)) in &self.wanted_blocks {
+            for (cid, priority) in &self.wanted_blocks {
                 message.want_block(cid, *priority);
             }
             debug!("  queuing wanted blocks");
@@ -129,13 +127,7 @@ impl Bitswap {
             ledger.want_block(&cid, priority);
             debug!("  queuing want for {}", peer_id.to_base58());
         }
-        self.wanted_blocks
-            .entry(cid)
-            .and_modify(|(prio, subs)| {
-                *prio = priority;
-                *subs += 1;
-            })
-            .or_insert((priority, 1));
+        self.wanted_blocks.insert(cid, priority);
         debug!("");
     }
 
@@ -150,16 +142,6 @@ impl Bitswap {
         }
         self.wanted_blocks.remove(cid);
         debug!("");
-    }
-
-    pub fn cancel_subscription(&mut self, cid: &Cid) -> bool {
-        if let Some((_prio, ref mut subs)) = self.wanted_blocks.get_mut(cid) {
-            *subs -= 1;
-            if *subs == 0 {
-                return true;
-            }
-        }
-        false
     }
 }
 

--- a/bitswap/src/ledger.rs
+++ b/bitswap/src/ledger.rs
@@ -251,7 +251,7 @@ impl TryFrom<&[u8]> for Message {
             let cid = prefix.to_cid(&payload.data)?;
             let block = Block {
                 cid,
-                data: payload.data.to_vec().into_boxed_slice(),
+                data: payload.data.into_boxed_slice(),
             };
             message.add_block(block);
         }

--- a/bitswap/src/protocol.rs
+++ b/bitswap/src/protocol.rs
@@ -40,12 +40,10 @@ where
     type Future = FutureResult<Self::Output, Self::Error>;
 
     #[inline]
-    fn upgrade_inbound(self, mut socket: TSocket, info: Self::Info) -> Self::Future {
+    fn upgrade_inbound(self, mut socket: TSocket, _info: Self::Info) -> Self::Future {
         Box::pin(async move {
-            debug!("upgrade_inbound: {}", std::str::from_utf8(info).unwrap());
             let packet = upgrade::read_one(&mut socket, MAX_BUF_SIZE).await?;
             let message = Message::from_bytes(&packet)?;
-            debug!("inbound message: {:?}", message);
             Ok(message)
         })
     }

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -127,7 +127,7 @@ impl From<StringError> for warp::Rejection {
 
 impl<D: std::fmt::Display> From<D> for StringError {
     fn from(d: D) -> Self {
-        Self(format!("{}", d).into())
+        Self(d.to_string().into())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -881,6 +881,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
             while let Poll::Ready(Some(evt)) = Pin::new(&mut self.repo_events).poll_next(ctx) {
                 match evt {
                     RepoEvent::WantBlock(cid) => self.swarm.want_block(cid),
+                    RepoEvent::UnwantBlock(cid) => self.swarm.bitswap().cancel_block(&cid),
                     RepoEvent::ProvideBlock(cid) => {
                         // TODO: consider if cancel is applicable in cases where we provide the
                         // associated Block ourselves

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -881,11 +881,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
             while let Poll::Ready(Some(evt)) = Pin::new(&mut self.repo_events).poll_next(ctx) {
                 match evt {
                     RepoEvent::WantBlock(cid) => self.swarm.want_block(cid),
-                    RepoEvent::UnwantBlock(cid) => {
-                        if self.swarm.bitswap().cancel_subscription(&cid) {
-                            self.swarm.bitswap().cancel_block(&cid)
-                        }
-                    }
+                    RepoEvent::UnwantBlock(cid) => self.swarm.bitswap().cancel_block(&cid),
                     RepoEvent::ProvideBlock(cid) => {
                         // TODO: consider if cancel is applicable in cases where we provide the
                         // associated Block ourselves

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -612,7 +612,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     pub async fn exit_daemon(self) {
         // FIXME: this is a stopgap measure needed while repo is part of the struct Ipfs instead of
         // the background task or stream. After that this could be handled by dropping.
-        self.repo.shutdown().await;
+        self.repo.shutdown();
 
         // ignoring the error because it'd mean that the background task had already been dropped
         let _ = self.to_task.clone().try_send(IpfsEvent::Exit);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -881,7 +881,11 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
             while let Poll::Ready(Some(evt)) = Pin::new(&mut self.repo_events).poll_next(ctx) {
                 match evt {
                     RepoEvent::WantBlock(cid) => self.swarm.want_block(cid),
-                    RepoEvent::UnwantBlock(cid) => self.swarm.bitswap().cancel_block(&cid),
+                    RepoEvent::UnwantBlock(cid) => {
+                        if self.swarm.bitswap().cancel_subscription(&cid) {
+                            self.swarm.bitswap().cancel_block(&cid)
+                        }
+                    }
                     RepoEvent::ProvideBlock(cid) => {
                         // TODO: consider if cancel is applicable in cases where we provide the
                         // associated Block ourselves

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -134,7 +134,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
                 info!(
                     "Peer {} wants block {} with priority {}",
                     peer_id.to_base58(),
-                    cid.to_string(),
+                    cid,
                     priority
                 );
 
@@ -285,7 +285,6 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     }
 
     pub fn want_block(&mut self, cid: Cid) {
-        info!("Want block {}", cid.to_string());
         //let hash = Multihash::from_bytes(cid.to_bytes()).unwrap();
         //self.kademlia.get_providers(hash);
         self.bitswap.want_block(cid, 1);

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -204,7 +204,7 @@ impl NetworkBehaviour for SwarmApi {
     ) {
         log::trace!("inject_addr_reach_failure {} {}", addr, error);
         self.connect_registry
-            .finish_subscription(&addr.clone().into(), Err(format!("{}", error)));
+            .finish_subscription(&addr.clone().into(), Err(error.to_string()));
     }
 
     fn poll(

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -156,7 +156,7 @@ impl NetworkBehaviour for SwarmApi {
 
         self.connections.insert(addr.clone(), peer_id.clone());
         self.connect_registry
-            .finish_subscription(&addr.clone().into(), Ok(()));
+            .finish_subscription(addr.clone().into(), Ok(()));
     }
 
     fn inject_connected(&mut self, _peer_id: &PeerId) {
@@ -185,7 +185,7 @@ impl NetworkBehaviour for SwarmApi {
         self.connections.remove(closed_addr);
         // FIXME: should be an error
         self.connect_registry
-            .finish_subscription(&closed_addr.clone().into(), Ok(()));
+            .finish_subscription(closed_addr.clone().into(), Ok(()));
     }
 
     fn inject_disconnected(&mut self, peer_id: &PeerId) {
@@ -204,7 +204,7 @@ impl NetworkBehaviour for SwarmApi {
     ) {
         log::trace!("inject_addr_reach_failure {} {}", addr, error);
         self.connect_registry
-            .finish_subscription(&addr.clone().into(), Err(error.to_string()));
+            .finish_subscription(addr.clone().into(), Err(error.to_string()));
     }
 
     fn poll(

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -134,7 +134,7 @@ trait CidUpgrade: Sized {
 }
 
 /// Extension trait similar to [`CidUpgrade`] but for non-owned types.
-trait CidUpgradedRef: Sized {
+pub trait CidUpgradedRef: Sized {
     /// Returns the otherwise the equivalent value from `&self` but with Cid version 1
     fn as_upgraded_cid(&self) -> Self;
 }
@@ -221,8 +221,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
         self.subscriptions
             .lock()
             .await
-            // subscriptions are per cidv1
-            .finish_subscription(&cid.clone().into(), block);
+            .finish_subscription(&original_cid.clone().into(), block);
         // sending only fails if no one is listening anymore
         // and that is okay with us.
         self.events
@@ -249,8 +248,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
                 .subscriptions
                 .lock()
                 .await
-                // subscribe always by using the cidv1
-                .create_subscription(upgraded.clone().into(), Some(self.events.clone()));
+                .create_subscription(cid.clone().into(), Some(self.events.clone()));
             // sending only fails if no one is listening anymore
             // and that is okay with us.
             self.events

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -1,7 +1,7 @@
 //! IPFS repo
 use crate::error::Error;
 use crate::path::IpfsPath;
-use crate::subscription::{Request, SubscriptionRegistry};
+use crate::subscription::{Request, RequestKind, SubscriptionRegistry};
 use crate::IpfsOptions;
 use async_std::path::PathBuf;
 use async_trait::async_trait;
@@ -116,7 +116,11 @@ pub enum RepoEvent {
 
 impl From<Request> for RepoEvent {
     fn from(req: Request) -> Self {
-        if let Request::GetBlock(cid) = req {
+        if let Request {
+            kind: RequestKind::GetBlock(cid),
+            ..
+        } = req
+        {
             RepoEvent::UnwantBlock(cid)
         } else {
             panic!("logic error: RepoEvent can only be created from a Request::GetBlock");
@@ -134,7 +138,7 @@ trait CidUpgrade: Sized {
 }
 
 /// Extension trait similar to [`CidUpgrade`] but for non-owned types.
-pub trait CidUpgradedRef: Sized {
+trait CidUpgradedRef: Sized {
     /// Returns the otherwise the equivalent value from `&self` but with Cid version 1
     fn as_upgraded_cid(&self) -> Self;
 }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -225,7 +225,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
         let block = block.with_upgraded_cid();
         let (cid, res) = self.block_store.put(block.clone()).await?;
         self.subscriptions
-            .finish_subscription(&original_cid.clone().into(), block);
+            .finish_subscription(original_cid.clone().into(), block);
         // sending only fails if no one is listening anymore
         // and that is okay with us.
         self.events

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -6,6 +6,7 @@ use crate::IpfsOptions;
 use async_std::path::PathBuf;
 use async_trait::async_trait;
 use bitswap::Block;
+use core::convert::TryFrom;
 use core::fmt::Debug;
 use core::marker::PhantomData;
 use futures::channel::mpsc::{channel, Receiver, Sender};
@@ -113,16 +114,18 @@ pub enum RepoEvent {
     UnprovideBlock(Cid),
 }
 
-impl From<Request> for RepoEvent {
-    fn from(req: Request) -> Self {
+impl TryFrom<Request> for RepoEvent {
+    type Error = &'static str;
+
+    fn try_from(req: Request) -> Result<Self, Self::Error> {
         if let Request {
             kind: RequestKind::GetBlock(cid),
             ..
         } = req
         {
-            RepoEvent::UnwantBlock(cid)
+            Ok(RepoEvent::UnwantBlock(cid))
         } else {
-            panic!("logic error: RepoEvent can only be created from a Request::GetBlock");
+            Err("logic error: RepoEvent can only be created from a Request::GetBlock")
         }
     }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -119,7 +119,9 @@ impl<TRes: Debug + Clone + PartialEq> SubscriptionRegistry<TRes> {
         log::debug!("Shutting down {:?}", self);
 
         let mut cancelled = 0;
-        let mut subscriptions = task::block_on(async { self.subscriptions.lock().await });
+        let mut subscriptions = mem::take(&mut *task::block_on(async {
+            self.subscriptions.lock().await
+        }));
 
         for (_idx, mut sub) in subscriptions.drain() {
             sub.cancel(true);

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -9,6 +9,7 @@ use futures::lock::Mutex;
 use libipld::Cid;
 use libp2p::Multiaddr;
 use std::collections::HashMap;
+use std::convert::TryFrom;
 use std::fmt;
 use std::mem;
 use std::sync::{
@@ -243,7 +244,7 @@ impl<TRes> Subscription<TRes> {
             // to be updated
             if is_last {
                 if let Some(mut sender) = cancel_notifier {
-                    let _ = sender.try_send(RepoEvent::from(request));
+                    let _ = sender.try_send(RepoEvent::try_from(request).unwrap());
                 }
             }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -220,9 +220,7 @@ impl<TRes: Clone + Debug> Future for SubscriptionFuture<TRes> {
         match subscription {
             Subscription::Cancelled => Poll::Ready(Err(Cancelled)),
             Subscription::Pending { ref mut waker, .. } => {
-                if waker.is_none() {
-                    *waker = Some(context.waker().clone());
-                }
+                *waker = Some(context.waker().clone());
                 Poll::Pending
             }
             Subscription::Ready(result) => Poll::Ready(Ok(result.clone())),

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -306,11 +306,11 @@ impl<TRes: Debug + PartialEq> Drop for SubscriptionFuture<TRes> {
 
         if let Some(sub) = sub {
             if let Subscription::Pending { ref request, .. } = sub {
-                debug!("Dropping subscription {}", request.id);
+                debug!("Dropping subscription {} to {}", request.id, request.kind);
             }
             // don't bother updating anything that isn't `Pending`
             if let mut sub @ Subscription::Pending { .. } = sub {
-                debug!("It was the last subscription to a resource, sending a cancel notification");
+                debug!("It was the last related subscription, sending a cancel notification");
                 sub.cancel(is_last);
             }
         }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -70,6 +70,13 @@ impl From<Cid> for RequestKind {
     }
 }
 
+#[cfg(test)]
+impl From<u32> for RequestKind {
+    fn from(num: u32) -> Self {
+        Self::Num(num)
+    }
+}
+
 impl fmt::Display for RequestKind {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -358,7 +365,7 @@ mod tests {
         let s1 = registry.create_subscription(0.into(), None);
         let s2 = registry.create_subscription(0.into(), None);
         let s3 = registry.create_subscription(0.into(), None);
-        registry.finish_subscription(&0.into(), 10);
+        registry.finish_subscription(0.into(), 10);
         assert_eq!(s1.await.unwrap(), 10);
         assert_eq!(s2.await.unwrap(), 10);
         assert_eq!(s3.await.unwrap(), 10);
@@ -404,7 +411,7 @@ mod tests {
         s1.await.unwrap_err();
 
         // this will cause a call to waker installed by s1, but it shouldn't be a problem.
-        registry.finish_subscription(&0.into(), 0);
+        registry.finish_subscription(0.into(), 0);
 
         assert_eq!(s2.await.unwrap(), 0);
     }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -216,13 +216,12 @@ impl<TRes: Clone> Future for SubscriptionFuture<TRes> {
 
 impl<TRes> Drop for SubscriptionFuture<TRes> {
     fn drop(&mut self) {
-        let strong_refs = Arc::strong_count(&self.subscription);
-
+        // if a pending subscription is dropped, it either means that the caller doesn't care
+        // about the associated value (even if others are still active) or that all of them
+        // are being dropped due to an abort/shutdown; either way, cancel the associated
+        // wantlist entry when this happens
         if let sub @ Subscription::Pending { .. } = &mut *self.subscription.lock().unwrap() {
-            // if this is the last future related to the request, cancel the subscription
-            if strong_refs == 2 {
-                sub.cancel();
-            }
+            sub.cancel();
         }
     }
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -180,12 +180,13 @@ impl<TRes: PartialEq> PartialEq for Subscription<TRes> {
         match self {
             Self::Pending { request: req1, .. } => {
                 if let Self::Pending { request: req2, .. } = other {
-                    req1 == req2
+                    req1.kind == req2.kind
                 } else {
                     false
                 }
             }
-            done => done == other,
+            Self::Cancelled => false,
+            ready @ Self::Ready(_) => ready == other,
         }
     }
 }

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -1,0 +1,94 @@
+use async_std::{
+    future::{pending, timeout},
+    task,
+};
+use futures::future::select;
+use futures::future::FutureExt;
+use libipld::Cid;
+
+use std::{convert::TryFrom, future::Future, time::Duration};
+
+fn bounded_retry<Fun, Fut, F, T>(
+    n_times: usize,
+    sleep_between: Duration,
+    mut future: Fun,
+    check: F,
+) -> Result<usize, Duration>
+where
+    Fun: FnMut() -> Fut,
+    Fut: Future<Output = T>,
+    F: Fn(T) -> bool,
+{
+    let started = std::time::Instant::now();
+    for n in 0..n_times {
+        if check(futures::executor::block_on(future())) {
+            return Ok(n);
+        }
+        std::thread::sleep(sleep_between);
+    }
+
+    Err(started.elapsed())
+}
+
+/// Check if canceling a Cid affects the wantlist.
+#[async_std::test]
+async fn wantlist_cancellation() {
+    // start a single node
+    let opts = ipfs::IpfsOptions::inmemory_with_generated_keys(false);
+    let (ipfs, ipfs_fut) = ipfs::UninitializedIpfs::new(opts)
+        .await
+        .start()
+        .await
+        .unwrap();
+    let _fut_task = task::spawn(ipfs_fut);
+
+    // execute a get_block request
+    let cid = Cid::try_from("QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KaGa").unwrap();
+    let ipfs_clone = ipfs.clone();
+    let cid_clone = cid.clone();
+
+    // start a get_request future and give it some time
+    let get_request1 = ipfs_clone.get_block(&cid_clone);
+    let get_timeout = timeout(Duration::from_millis(200), pending::<()>());
+    let get_request1 = select(get_timeout.boxed(), get_request1.boxed()).await;
+
+    // verify that the requested Cid is in the wantlist
+    let wantlist = ipfs.bitswap_wantlist(None).await;
+    assert!(wantlist
+        .iter()
+        .map(|list| list.iter())
+        .flatten()
+        .any(|(c, _)| *c == cid));
+
+    // fire up an additional get request
+    let get_request2 = ipfs_clone.get_block(&cid_clone);
+    let get_timeout = timeout(Duration::from_millis(200), pending::<()>());
+    let get_request2 = select(get_timeout.boxed(), get_request2.boxed()).await;
+
+    // cancel the first requested Cid
+    drop(get_request1);
+
+    // verify that the requested Cid is STILL in the wantlist
+    let wantlist = ipfs.bitswap_wantlist(None).await;
+    assert!(wantlist
+        .iter()
+        .map(|list| list.iter())
+        .flatten()
+        .any(|(c, _)| *c == cid));
+
+    // cancel the second requested Cid
+    drop(get_request2);
+
+    // verify that the requested Cid is no longer in the wantlist
+    let wantlist_cleared = bounded_retry(
+        3,
+        Duration::from_millis(200),
+        || ipfs.bitswap_wantlist(None),
+        |ret| ret.unwrap().is_empty(),
+    );
+
+    assert!(
+        wantlist_cleared.is_ok(),
+        "a block was not removed from the wantlist after all its subscriptions had died"
+    );
+}

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -1,3 +1,5 @@
+use ipfs::repo::CidUpgradedRef;
+
 use async_std::{
     future::{pending, timeout},
     task,


### PR DESCRIPTION
I'd have split these changes into more commits, but a lot has changed in the meantime - this was not a trivial thing to do right, that's for sure :dizzy_face:.

~~In any case, it is _almost_ done: the last thing left is to make sure the `Cid` in the wantlist and the subscription list matches, as now we upgrade the latter, which makes the test loop indefinitely if the `Cid` differs between versions.~~ deferred

~~partially solves https://github.com/rs-ipfs/rust-ipfs/issues/236; the functionality is there, but the JS conformance test doesn't pass - might need patching~~
actually closes https://github.com/rs-ipfs/rust-ipfs/issues/236