### PR TITLE
Migrating http symlink creation to conformance/setup.sh + CI Update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,15 +109,15 @@ jobs:
       if: contains(matrix.platform.target, 'android')
       run: cargo install cargo-ndk
 
+    - name: Build (others)
+      if: matrix.platform.cross == false
+      run: cargo build --locked --workspace --all-targets
+
     - name: Setup conformance tests (non-cross targets)
       if: matrix.platform.cross == false
       run: ./setup.sh
       shell: bash
       working-directory: ./conformance
-
-    - name: Build (others)
-      if: matrix.platform.cross == false
-      run: cargo build --locked --workspace --all-targets
 
     - name: Build (android)
       if: contains(matrix.platform.target, 'android')

--- a/conformance/http
+++ b/conformance/http
@@ -1,1 +1,0 @@
-../target/debug/ipfs-http

--- a/conformance/setup.sh
+++ b/conformance/setup.sh
@@ -24,3 +24,10 @@ if [ -d "patches" ]; then
         patch -d node_modules/ -p1 < "$p"
     done
 fi
+
+if ! [ -f "../target/debug/ipfs-http" ]; then
+    echo "Please build a debug version of Rust IPFS first via `cargo build --workspace` in the project root first." >&2
+    exit 1
+fi
+
+ln -s ../target/debug/ipfs-http http


### PR DESCRIPTION
This PR removes the symlink from source control, and adds some lines to validate and create the symlink to `conformance/setup.sh`. It also updates CI to build the project _before_ trying to create the symlink, as per the warning in `setup.sh`

The reasoning behind this is for GitHub Pages + Jekyll, which will break upon encountering a symlink that doesn't resolve properly in the repo.