### PR TITLE
introduce a local get_block_now functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -617,12 +617,6 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         // ignoring the error because it'd mean that the background task had already been dropped
         let _ = self.to_task.clone().try_send(IpfsEvent::Exit);
     }
-
-    /// Obtain the locked collection of all the subscriptions for blocks.
-    #[doc(hidden)]
-    pub fn get_subscriptions(&self) -> &futures::lock::Mutex<subscription::Subscriptions<Block>> {
-        &self.repo.subscriptions.subscriptions
-    }
 }
 
 /// Background task of `Ipfs` created when calling `UninitializedIpfs::start`.
@@ -936,7 +930,7 @@ impl From<(bitswap::Stats, Vec<PeerId>, Vec<(Cid, bitswap::Priority)>)> for Bits
 pub use node::Node;
 
 mod node {
-    use super::{Ipfs, IpfsOptions, TestTypes, UninitializedIpfs};
+    use super::{subscription, Block, Ipfs, IpfsOptions, TestTypes, UninitializedIpfs};
 
     /// Node encapsulates everything to setup a testing instance so that multi-node tests become
     /// easier.
@@ -960,6 +954,12 @@ mod node {
                 ipfs,
                 background_task: jh,
             }
+        }
+
+        pub fn get_subscriptions(
+            &self,
+        ) -> &futures::lock::Mutex<subscription::Subscriptions<Block>> {
+            &self.ipfs.repo.subscriptions.subscriptions
         }
 
         pub async fn shutdown(self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -617,6 +617,12 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         // ignoring the error because it'd mean that the background task had already been dropped
         let _ = self.to_task.clone().try_send(IpfsEvent::Exit);
     }
+
+    /// Obtain the locked collection of all the subscriptions for blocks.
+    #[doc(hidden)]
+    pub fn get_subscriptions(&self) -> &futures::lock::Mutex<subscription::Subscriptions<Block>> {
+        &self.repo.subscriptions.subscriptions
+    }
 }
 
 /// Background task of `Ipfs` created when calling `UninitializedIpfs::start`.

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -138,25 +138,25 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
                     priority
                 );
 
-                let ipfs = self.ipfs.clone();
-                let queued_blocks = Arc::clone(&self.bitswap().queued_blocks);
-                task::spawn(async move {
-                    // FIXME: need a better API to `get_block_now` or without waiting.
-                    let block = match ipfs.repo.get_block(&cid).await {
-                        Ok(block) => block,
-                        Err(err) => {
-                            warn!(
-                                "Peer {} wanted block {} but we failed: {}",
-                                peer_id.to_base58(),
-                                cid,
-                                err,
-                            );
-                            return;
-                        }
-                    };
-
-                    queued_blocks.lock().unwrap().push((peer_id, block));
-                });
+                match self.ipfs.repo.get_block_now(&cid) {
+                    Ok(Some(block)) => {
+                        self.bitswap()
+                            .queued_blocks
+                            .lock()
+                            .unwrap()
+                            .push((peer_id, block));
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        warn!(
+                            "Peer {} wanted block {} but we failed: {}",
+                            peer_id.to_base58(),
+                            cid,
+                            err,
+                        );
+                        return;
+                    }
+                };
             }
             BitswapEvent::ReceivedCancel(..) => {}
         }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -154,7 +154,6 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
                             cid,
                             err,
                         );
-                        return;
                     }
                 };
             }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -3,7 +3,7 @@ use crate::error::Error;
 use crate::path::IpfsPath;
 use crate::subscription::{RequestKind, SubscriptionRegistry};
 use crate::IpfsOptions;
-use async_std::path::PathBuf;
+use async_std::{path::PathBuf, task};
 use async_trait::async_trait;
 use bitswap::Block;
 use core::convert::TryFrom;
@@ -255,6 +255,20 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
                 .await
                 .ok();
             Ok(subscription.await?)
+        }
+    }
+
+    /// Retrives a block from the block store if it's available locally.
+    pub fn get_block_now(&self, cid: &Cid) -> Result<Option<Block>, Error> {
+        let upgraded = cid.as_upgraded_cid();
+        if let Some(Block { data, .. }) = task::block_on(self.block_store.get(&upgraded))? {
+            Ok(Some(Block {
+                data,
+                // give back using the requested cid which may have been cidv0
+                cid: cid.clone(),
+            }))
+        } else {
+            Ok(None)
         }
     }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -103,7 +103,7 @@ pub struct Repo<TRepoTypes: RepoTypes> {
     block_store: TRepoTypes::TBlockStore,
     data_store: TRepoTypes::TDataStore,
     events: Sender<RepoEvent>,
-    subscriptions: SubscriptionRegistry<Block>,
+    pub(crate) subscriptions: SubscriptionRegistry<Block>,
 }
 
 #[derive(Clone, Debug)]

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -72,11 +72,11 @@ impl fmt::Display for RequestKind {
 type SubscriptionId = u64;
 
 /// The specific collection used to hold all the `Subscription`s.
-type Subscriptions<T> = HashMap<RequestKind, HashMap<SubscriptionId, Subscription<T>>>;
+pub type Subscriptions<T> = HashMap<RequestKind, HashMap<SubscriptionId, Subscription<T>>>;
 
 /// A collection of all the live `Subscription`s.
 pub struct SubscriptionRegistry<TRes: Debug + Clone + PartialEq> {
-    subscriptions: Arc<Mutex<Subscriptions<TRes>>>,
+    pub(crate) subscriptions: Arc<Mutex<Subscriptions<TRes>>>,
     shutting_down: AtomicBool,
 }
 

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -86,7 +86,7 @@ async fn wantlist_cancellation() {
     let ipfs_clone = ipfs.clone();
     let cid_clone = cid.clone();
     let get_request2 = ipfs_clone.get_block(&cid_clone);
-    let get_timeout = timeout(Duration::from_millis(200), pending::<()>());
+    let get_timeout = timeout(Duration::from_millis(500), pending::<()>());
     let get_request2 = match select(get_timeout.boxed(), get_request2.boxed()).await {
         Either::Left((_, fut)) => fut,
         Either::Right(_) => unreachable!(),
@@ -99,7 +99,7 @@ async fn wantlist_cancellation() {
     let ipfs_clone = ipfs.clone();
     let cid_clone = cid.clone();
     let get_request3 = ipfs_clone.get_block(&cid_clone);
-    let get_timeout = timeout(Duration::from_millis(200), pending::<()>());
+    let get_timeout = timeout(Duration::from_millis(500), pending::<()>());
     let get_request3 = match select(get_timeout.boxed(), get_request3.boxed()).await {
         Either::Left((_, fut)) => fut,
         Either::Right(_) => unreachable!(),

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -4,7 +4,7 @@ use async_std::{
 };
 use futures::future::{select, Either, FutureExt};
 use futures::future::{AbortHandle, Abortable};
-use ipfs::{Ipfs, IpfsOptions, IpfsTypes, UninitializedIpfs};
+use ipfs::Node;
 use libipld::Cid;
 
 use std::{
@@ -36,7 +36,7 @@ where
     Err(started.elapsed())
 }
 
-async fn check_cid_subscriptions<T: IpfsTypes>(ipfs: &Ipfs<T>, cid: &Cid, expected_count: usize) {
+async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) {
     let subs = ipfs.get_subscriptions().lock().await;
     if expected_count > 0 {
         assert_eq!(subs.len(), 1);
@@ -49,9 +49,7 @@ async fn check_cid_subscriptions<T: IpfsTypes>(ipfs: &Ipfs<T>, cid: &Cid, expect
 #[async_std::test]
 async fn wantlist_cancellation() {
     // start a single node
-    let opts = IpfsOptions::inmemory_with_generated_keys(false);
-    let (ipfs, ipfs_fut) = UninitializedIpfs::new(opts).await.start().await.unwrap();
-    let _fut_task = task::spawn(ipfs_fut);
+    let ipfs = Node::new(false).await;
 
     // execute a get_block request
     let cid = Cid::try_from("QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KaGa").unwrap();


### PR DESCRIPTION
This allows us not to call the `async` counterpart (that spawns a potentially long-lasting `SubscriptionFuture`) when being asked for a `Cid` by other peers.

In addition, expand the `wantlist_cancellation` test a little bit - these changes don't affect it after all, but the extra checks are useful.