### PR TITLE
Fix bitswap ready block wakeup

### DIFF
--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -113,6 +113,9 @@ impl Bitswap {
     /// Sends the wantlist to the peer.
     fn send_want_list(&mut self, peer_id: PeerId) {
         if !self.wanted_blocks.is_empty() {
+            // FIXME: this can produce a too long message
+            // FIXME: we should shard these across all of our peers by some logic; also peers may
+            // have been discovered with providing some specific wantlist item
             let mut message = Message::default();
             for (cid, priority) in &self.wanted_blocks {
                 message.want_block(cid, *priority);

--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -113,9 +113,9 @@ impl Bitswap {
     /// Sends the wantlist to the peer.
     fn send_want_list(&mut self, peer_id: PeerId) {
         if !self.wanted_blocks.is_empty() {
-            // FIXME: this can produce a too long message
-            // FIXME: we should shard these across all of our peers by some logic; also peers may
-            // have been discovered with providing some specific wantlist item
+            // FIXME: this can produce too long a message
+            // FIXME: we should shard these across all of our peers by some logic; also, peers may
+            // have been discovered to provide some specific wantlist item
             let mut message = Message::default();
             for (cid, priority) in &self.wanted_blocks {
                 message.want_block(cid, *priority);

--- a/bitswap/src/ledger.rs
+++ b/bitswap/src/ledger.rs
@@ -108,6 +108,7 @@ impl Ledger {
         if self.message.is_empty() {
             return None;
         }
+        // FIXME: this might produce too large message
         for cid in self.message.cancel() {
             self.sent_want_list.remove(cid);
         }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -134,13 +134,13 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
                     priority
                 );
 
-                let queued_blocks = Arc::clone(&self.bitswap().queued_blocks);
+                let queued_blocks = self.bitswap().queued_blocks.clone();
                 let ipfs = self.ipfs.clone();
 
                 task::spawn(async move {
                     match ipfs.repo.get_block_now(&cid).await {
                         Ok(Some(block)) => {
-                            queued_blocks.lock().unwrap().push((peer_id, block));
+                            let _ = queued_blocks.unbounded_send((peer_id, block));
                         }
                         Ok(None) => {}
                         Err(err) => {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -259,9 +259,9 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
     }
 
     /// Retrives a block from the block store if it's available locally.
-    pub fn get_block_now(&self, cid: &Cid) -> Result<Option<Block>, Error> {
+    pub async fn get_block_now(&self, cid: &Cid) -> Result<Option<Block>, Error> {
         let upgraded = cid.as_upgraded_cid();
-        if let Some(Block { data, .. }) = task::block_on(self.block_store.get(&upgraded))? {
+        if let Some(Block { data, .. }) = self.block_store.get(&upgraded).await? {
             Ok(Some(Block {
                 data,
                 // give back using the requested cid which may have been cidv0

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -3,7 +3,7 @@ use crate::error::Error;
 use crate::path::IpfsPath;
 use crate::subscription::{RequestKind, SubscriptionRegistry};
 use crate::IpfsOptions;
-use async_std::{path::PathBuf, task};
+use async_std::path::PathBuf;
 use async_trait::async_trait;
 use bitswap::Block;
 use cid::{self, Cid};


### PR DESCRIPTION
The previous version relied on block_on for the block reads, lets see if this still timeouts on `exchange_block`.

This changes the `queued_blocks` to be `UnboundedSender<(PeerId, Block)>` instead of `Arc<Mutex<Vec<(PeerId, Block)>>>`. An alternative would had been to store the waker but we concluded the channel would be more appropriate.