### PR TITLE
ci: stop building pushes to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 on:
   push:
     branches:
-      - master
       - trying
       - staging
   pull_request:


### PR DESCRIPTION
bors should only fast forward or reset the master to HEAD of staging at the end of each run, so if there is a credit system on GH we are just wasting those credits on each merged PR.

if nothing else, this should be more energy efficient :) if bors fast forwarded something the commit should have the status badge.