### PR TITLE
Initial content discovery

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,8 +777,11 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                 // exhaust the swarm before possibly causing the swarm to do more work by popping
                 // off the events from Ipfs and ... this looping goes on for a while.
                 done = false;
-                if let SwarmEvent::NewListenAddr(addr) = inner {
-                    self.complete_listening_address_adding(addr);
+                match inner {
+                    SwarmEvent::NewListenAddr(addr) => {
+                        self.complete_listening_address_adding(addr);
+                    }
+                    _ => println!("{:?}", inner),
                 }
             }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -965,6 +965,10 @@ mod node {
     impl Node {
         pub async fn new() -> Self {
             let opts = IpfsOptions::inmemory_with_generated_keys();
+            Node::with_options(opts).await
+        }
+
+        pub async fn with_options(opts: IpfsOptions<TestTypes>) -> Self {
             let (ipfs, fut) = UninitializedIpfs::new(opts)
                 .await
                 .start()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -781,7 +781,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                     SwarmEvent::NewListenAddr(addr) => {
                         self.complete_listening_address_adding(addr);
                     }
-                    _ => println!("{:?}", inner),
+                    _ => trace!("{:?}", inner),
                 }
             }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -95,7 +95,11 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                             info!("kad: peer {} is close", peer);
                         }
                     }
-                    GetProviders(Ok(GetProvidersOk { key, providers, closest_peers })) => {
+                    GetProviders(Ok(GetProvidersOk {
+                        key,
+                        providers,
+                        closest_peers,
+                    })) => {
                         let key = multibase::encode(Base::Base32Lower, key);
                         if providers.is_empty() && closest_peers.is_empty() {
                             warn!("kad: could not find a provider for {}", key);
@@ -257,9 +261,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
             BitswapEvent::ReceivedWant(peer_id, cid, priority) => {
                 info!(
                     "Peer {} wants block {} with priority {}",
-                    peer_id,
-                    cid,
-                    priority
+                    peer_id, cid, priority
                 );
 
                 let queued_blocks = self.bitswap().queued_blocks.clone();
@@ -435,7 +437,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         match self.kademlia.start_providing(key.clone().into()) {
             Ok(_id) => {
                 // Ok(self.kad_subscriptions.create_subscription(id.into(), None))
-            },
+            }
             Err(e) => {
                 error!("kad: can't provide block {}: {:?}", cid, e);
                 // Err(anyhow!("kad: can't provide block {}", key))

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -434,7 +434,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     // Ipfs and IpfsFuture objects - it would currently require some extra back-and-forth
     pub fn provide_block(&mut self, cid: Cid) {
         let key = cid.to_bytes();
-        match self.kademlia.start_providing(key.clone().into()) {
+        match self.kademlia.start_providing(key.into()) {
             Ok(_id) => {
                 // Ok(self.kad_subscriptions.create_subscription(id.into(), None))
             }

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -2,14 +2,14 @@ use async_std::future::timeout;
 use cid::Cid;
 use ipfs::{IpfsOptions, Node};
 use libp2p::{Multiaddr, PeerId};
-use log::LevelFilter;
+use log::{LevelFilter, SetLoggerError};
 use std::time::Duration;
 
-fn init_test_logging() {
+fn init_test_logging() -> Result<(), SetLoggerError> {
     env_logger::builder()
         .is_test(true)
         .filter(Some("async_std"), LevelFilter::Error)
-        .init()
+        .try_init()
 }
 
 #[async_std::test]
@@ -17,7 +17,7 @@ async fn kademlia_local_peer_discovery() {
     const BOOTSTRAPPER_COUNT: usize = 20;
 
     // set up logging
-    init_test_logging();
+    let _ = init_test_logging();
 
     // start up PEER_COUNT bootstrapper nodes
     let mut bootstrappers = Vec::with_capacity(BOOTSTRAPPER_COUNT);
@@ -67,7 +67,7 @@ async fn kademlia_local_peer_discovery() {
 #[async_std::test]
 async fn kademlia_popular_content_discovery() {
     // set up logging
-    init_test_logging();
+    let _ = init_test_logging();
 
     let (bootstrapper_id, bootstrapper_addr): (PeerId, Multiaddr) = (
         "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -1,6 +1,6 @@
 use async_std::future::timeout;
 use cid::Cid;
-use ipfs::Node;
+use ipfs::{IpfsOptions, Node};
 use libp2p::{Multiaddr, PeerId};
 use log::LevelFilter;
 use std::time::Duration;
@@ -76,8 +76,13 @@ async fn kademlia_popular_content_discovery() {
         "/ip4/104.131.131.82/tcp/4001".parse().unwrap(),
     );
 
-    // introduce a peer and connect it to one of the well-known bootstrappers
-    let peer = Node::new().await;
+    // introduce a peer and specify the Kademlia protocol to it
+    // without a specified protocol, the test will not complete
+    let mut opts = IpfsOptions::inmemory_with_generated_keys();
+    opts.kad_protocol = Some("/ipfs/lan/kad/1.0.0".to_owned());
+    let peer = Node::with_options(opts).await;
+
+    // connect it to one of the well-known bootstrappers
     assert!(peer
         .add_peer(bootstrapper_id, bootstrapper_addr)
         .await

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -1,76 +1,94 @@
 use async_std::future::timeout;
-use cid::{Cid, Codec};
-use ipfs::{Block, Node};
-use libp2p::PeerId;
+use cid::Cid;
+use ipfs::Node;
+use libp2p::{Multiaddr, PeerId};
 use log::LevelFilter;
-use multihash::Sha2_256;
 use std::time::Duration;
 
-const PEER_COUNT: usize = 20;
-
-#[async_std::test]
-async fn kademlia() {
-    let _ = env_logger::builder()
+fn init_test_logging() {
+    env_logger::builder()
         .is_test(true)
         .filter(Some("async_std"), LevelFilter::Error)
-        .init();
+        .init()
+}
+
+#[async_std::test]
+async fn kademlia_local_peer_discovery() {
+    const BOOTSTRAPPER_COUNT: usize = 20;
+
+    // set up logging
+    init_test_logging();
 
     // start up PEER_COUNT bootstrapper nodes
-    let mut nodes = Vec::with_capacity(PEER_COUNT);
-    for _ in 0..PEER_COUNT {
-        nodes.push(Node::new().await);
+    let mut bootstrappers = Vec::with_capacity(BOOTSTRAPPER_COUNT);
+    for _ in 0..BOOTSTRAPPER_COUNT {
+        bootstrappers.push(Node::new().await);
     }
 
     // register the bootstrappers' ids and addresses
-    let mut peers = Vec::with_capacity(PEER_COUNT);
-    for node in &nodes {
-        let (id, addrs) = node.identity().await.unwrap();
+    let mut bootstrapper_ids = Vec::with_capacity(BOOTSTRAPPER_COUNT);
+    for bootstrapper in &bootstrappers {
+        let (id, addrs) = bootstrapper.identity().await.unwrap();
         let id = PeerId::from_public_key(id);
 
-        peers.push((id, addrs));
+        bootstrapper_ids.push((id, addrs));
     }
 
     // connect all the bootstrappers to one another
-    for (i, (node_id, _)) in peers.iter().enumerate() {
-        for (peer_id, addrs) in peers.iter().filter(|(peer_id, _)| peer_id != node_id) {
-            nodes[i]
-                .add_peer(peer_id.clone(), addrs[0].clone())
+    for (i, (node_id, _)) in bootstrapper_ids.iter().enumerate() {
+        for (bootstrapper_id, addrs) in bootstrapper_ids
+            .iter()
+            .filter(|(peer_id, _)| peer_id != node_id)
+        {
+            bootstrappers[i]
+                .add_peer(bootstrapper_id.clone(), addrs[0].clone())
                 .await
                 .unwrap();
         }
     }
 
-    // introduce an extra peer and connect it to one of the bootstrappers
-    let extra_peer = Node::new().await;
-    assert!(extra_peer
-        .add_peer(peers[0].0.clone(), peers[0].1[0].clone())
+    // introduce a peer and connect it to one of the bootstrappers
+    let peer = Node::new().await;
+    assert!(peer
+        .add_peer(
+            bootstrapper_ids[0].0.clone(),
+            bootstrapper_ids[0].1[0].clone()
+        )
         .await
         .is_ok());
 
     // check that kad::bootstrap works
-    assert!(extra_peer.bootstrap().await.is_ok());
+    assert!(peer.bootstrap().await.is_ok());
 
     // check that kad::get_closest_peers works
-    assert!(nodes[0].get_closest_peers().await.is_ok());
+    assert!(peer.get_closest_peers().await.is_ok());
+}
 
-    // add a Block to the extra peer
-    let data = Box::from(&b"hello block\n"[..]);
-    let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
-    extra_peer.put_block(Block {
-        cid: cid.clone(),
-        data: data.clone(),
-    })
-    .await
-    .unwrap();
+#[async_std::test]
+async fn kademlia_popular_content_discovery() {
+    // set up logging
+    init_test_logging();
 
-    async_std::task::spawn(async { async_std::task::sleep(Duration::from_secs(1)).await }).await;
+    let (bootstrapper_id, bootstrapper_addr): (PeerId, Multiaddr) = (
+        "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
+            .parse()
+            .unwrap(),
+        "/ip4/104.131.131.82/tcp/4001".parse().unwrap(),
+    );
 
-    // add another peer, bootstrap it and try to get that Block
-    let extra_peer2 = Node::new(false).await;
-    assert!(extra_peer2
-        .add_peer(peers[0].0.clone(), peers[0].1[0].clone())
+    // introduce a peer and connect it to one of the well-known bootstrappers
+    let peer = Node::new().await;
+    assert!(peer
+        .add_peer(bootstrapper_id, bootstrapper_addr)
         .await
         .is_ok());
 
-    assert!(timeout(Duration::from_secs(10), extra_peer2.get_block(&cid)).await.is_ok());
+    // the Cid of the docs.ipfs.io website
+    let cid: Cid = "bafybeicfjz7woevc5dxvsskibxpxpofkrdjyslbggvvr3d66ddqu744nne"
+        .parse()
+        .unwrap();
+
+    assert!(timeout(Duration::from_secs(10), peer.get_block(&cid))
+        .await
+        .is_ok());
 }

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -88,8 +88,8 @@ async fn kademlia_popular_content_discovery() {
         .await
         .is_ok());
 
-    // the Cid of the docs.ipfs.io website
-    let cid: Cid = "bafybeicfjz7woevc5dxvsskibxpxpofkrdjyslbggvvr3d66ddqu744nne"
+    // the Cid of the IPFS logo
+    let cid: Cid = "bafkreicncneocapbypwwe3gl47bzvr3pkpxmmobzn7zr2iaz67df4kjeiq"
         .parse()
         .unwrap();
 


### PR DESCRIPTION
An initial implementation of content discovery via DHT, where a `get_block` request that doesn't succeed locally results in a call to `Kademlia::get_providers`. It also fixes (AKA fixes in most cases) the previously prototyped display of Kademlia content keys, in this case `Cid`s.

cc https://github.com/rs-ipfs/rust-ipfs/issues/10