### PR TITLE
Fix the test timeout

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -628,6 +628,13 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     }
 }
 
+impl<T: IpfsTypes> Drop for Ipfs<T> {
+    fn drop(&mut self) {
+        self.repo.shutdown();
+        let _ = self.to_task.clone().try_send(IpfsEvent::Exit);
+    }
+}
+
 /// Background task of `Ipfs` created when calling `UninitializedIpfs::start`.
 // The receivers are Fuse'd so that we don't have to manage state on them being exhausted.
 struct IpfsFuture<Types: IpfsTypes> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -890,7 +890,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                         let _ = ret.send(future);
                     }
                     IpfsEvent::Exit => {
-                        // FIXME: we could do a proper teardown
+                        self.swarm.shutdown();
                         return Poll::Ready(());
                     }
                 }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -420,6 +420,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     }
 
     pub fn shutdown(&mut self) {
+        self.kad_subscriptions.shutdown();
         self.swarm.shutdown()
     }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -419,6 +419,10 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         self.swarm.disconnect(addr)
     }
 
+    pub fn shutdown(&mut self) {
+        self.swarm.shutdown()
+    }
+
     pub fn want_block(&mut self, cid: Cid) {
         //let hash = Multihash::from_bytes(cid.to_bytes()).unwrap();
         //self.kademlia.get_providers(hash);

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -6,6 +6,7 @@ use libp2p::swarm::protocols_handler::{
 };
 use libp2p::swarm::{self, NetworkBehaviour, PollParameters, Swarm};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::mem;
 use std::time::Duration;
 
 /// A description of currently active connection.
@@ -120,6 +121,14 @@ impl SwarmApi {
             self.connections.remove(&address);
         }
         self.roundtrip_times.remove(peer_id);
+    }
+
+    pub fn shutdown(&mut self) {
+        self.connect_registry.shutdown();
+
+        for (addr, _) in mem::take(&mut self.connections).into_iter() {
+            self.disconnect(addr);
+        }
     }
 }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -317,6 +317,10 @@ impl<TRes: Debug + PartialEq> Drop for SubscriptionFuture<TRes> {
             // check if this is the last subscription to this resource
             let is_last = related_subs.is_empty();
 
+            if is_last {
+                subscriptions.remove(&self.kind);
+            }
+
             (sub, is_last)
         });
 

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -1,120 +1,113 @@
 use async_std::task;
 
 /// Make sure two instances of ipfs can be connected.
-#[test]
-fn connect_two_nodes() {
+#[async_std::test]
+async fn connect_two_nodes() {
     // env_logger::init();
 
     let (tx, rx) = futures::channel::oneshot::channel();
 
-    let node_a = task::spawn(async move {
-        let opts = ipfs::IpfsOptions::inmemory_with_generated_keys();
-        let (ipfs, fut) = ipfs::UninitializedIpfs::new(opts)
-            .await
-            .start()
-            .await
-            .unwrap();
+    let opts = ipfs::IpfsOptions::inmemory_with_generated_keys();
+    let (ipfs, fut) = ipfs::UninitializedIpfs::new(opts)
+        .await
+        .start()
+        .await
+        .unwrap();
 
-        let jh = task::spawn(fut);
+    let jh = task::spawn(fut);
 
-        let (pk, addrs) = ipfs
-            .identity()
-            .await
-            .expect("failed to read identity() on node_a");
-        assert!(!addrs.is_empty());
-        tx.send((pk, addrs, ipfs, jh)).unwrap();
-    });
+    let (pk, addrs) = ipfs
+        .identity()
+        .await
+        .expect("failed to read identity() on node_a");
+    assert!(!addrs.is_empty());
+    tx.send((pk, addrs, ipfs, jh)).unwrap();
 
-    task::block_on(async move {
-        let (other_pk, other_addrs, other_ipfs, other_jh) = rx.await.unwrap();
+    let (other_pk, other_addrs, other_ipfs, other_jh) = rx.await.unwrap();
 
-        println!("got back from the other node: {:?}", other_addrs);
+    println!("got back from the other node: {:?}", other_addrs);
 
-        let opts = ipfs::IpfsOptions::inmemory_with_generated_keys();
-        let (ipfs, fut) = ipfs::UninitializedIpfs::new(opts)
-            .await
-            .start()
-            .await
-            .unwrap();
-        let jh = task::spawn(fut);
+    let opts = ipfs::IpfsOptions::inmemory_with_generated_keys();
+    let (ipfs, fut) = ipfs::UninitializedIpfs::new(opts)
+        .await
+        .start()
+        .await
+        .unwrap();
+    let jh = task::spawn(fut);
 
-        let _other_peerid = other_pk.into_peer_id();
+    let _other_peerid = other_pk.into_peer_id();
 
-        let mut connected = None;
+    let mut connected = None;
 
-        for addr in other_addrs {
-            println!("trying {}", addr);
-            match ipfs.connect(addr.clone()).await {
-                Ok(_) => {
-                    connected = Some(addr);
-                    break;
-                }
-                Err(e) => {
-                    println!("Failed connecting to {}: {}", addr, e);
-                }
+    for addr in other_addrs {
+        println!("trying {}", addr);
+        match ipfs.connect(addr.clone()).await {
+            Ok(_) => {
+                connected = Some(addr);
+                break;
+            }
+            Err(e) => {
+                println!("Failed connecting to {}: {}", addr, e);
             }
         }
+    }
 
-        let connected = connected.expect("Failed to connect to anything");
-        println!("connected to {}", connected);
+    let connected = connected.expect("Failed to connect to anything");
+    println!("connected to {}", connected);
 
-        other_ipfs.exit_daemon().await;
-        other_jh.await;
-        node_a.await;
+    other_ipfs.exit_daemon().await;
+    other_jh.await;
 
-        ipfs.exit_daemon().await;
-        jh.await;
-    });
+    ipfs.exit_daemon().await;
+    jh.await;
 }
 
 /// More complicated one to the above; first node will have two listening addresses and the second
 /// one should dial both of the addresses, resulting in two connections.
-#[test]
-fn connect_two_nodes_with_two_connections_doesnt_panic() {
-    task::block_on(async move {
-        let node_a = ipfs::Node::new().await;
-        let node_b = ipfs::Node::new().await;
+#[async_std::test]
+async fn connect_two_nodes_with_two_connections_doesnt_panic() {
+    let node_a = ipfs::Node::new().await;
+    let node_b = ipfs::Node::new().await;
 
-        node_a
-            .add_listening_address(libp2p::build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(0u16)))
-            .await
-            .unwrap();
+    node_a
+        .add_listening_address(libp2p::build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(0u16)))
+        .await
+        .unwrap();
 
-        let addresses = node_a.addrs_local().await.unwrap();
-        assert_eq!(
-            addresses.len(),
-            2,
-            "there should had been two local addresses, found {:?}",
-            addresses
-        );
+    let addresses = node_a.addrs_local().await.unwrap();
+    assert_eq!(
+        addresses.len(),
+        2,
+        "there should had been two local addresses, found {:?}",
+        addresses
+    );
 
-        for addr in addresses {
-            node_b.connect(addr).await.unwrap();
-        }
+    for addr in addresses {
+        node_b.connect(addr).await.unwrap();
+    }
 
-        // not too sure on this, since there'll be a single peer but two connections; the return
-        // type is `Vec<Connection>` but it's peer with any connection.
-        let mut peers = node_a.peers().await.unwrap();
-        assert_eq!(
-            peers.len(),
-            1,
-            "there should had been one peer, found {:?}",
-            peers
-        );
+    // not too sure on this, since there'll be a single peer but two connections; the return
+    // type is `Vec<Connection>` but it's peer with any connection.
+    let mut peers = node_a.peers().await.unwrap();
+    assert_eq!(
+        peers.len(),
+        1,
+        "there should had been one peer, found {:?}",
+        peers
+    );
 
-        // sadly we are unable to currently verify that there exists two connections for the node_b
-        // peer..
+    // sadly we are unable to currently verify that there exists two connections for the node_b
+    // peer..
 
-        node_a
-            .disconnect(peers.remove(0).address)
-            .await
-            .expect("failed to disconnect peer_b at peer_a");
+    node_a
+        .disconnect(peers.remove(0).address)
+        .await
+        .expect("failed to disconnect peer_b at peer_a");
 
-        let peers = node_a.peers().await.unwrap();
-        assert!(
-            peers.is_empty(),
-            "node_b was still connected after disconnect: {:?}",
-            peers
-        );
-    });
+    let peers = node_a.peers().await.unwrap();
+    assert!(
+        peers.is_empty(),
+        "node_b was still connected after disconnect: {:?}",
+        peers
+    );
 }

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -42,8 +42,10 @@ async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) 
     if expected_count > 0 {
         assert_eq!(subs.len(), 1);
     }
-    let subscription_count = subs.get(&cid.clone().into()).map(|l| l.len());
-    assert_eq!(subscription_count, Some(expected_count));
+    match subs.get(&cid.clone().into()).map(|l| l.len()) {
+        Some(sub_count) => assert_eq!(sub_count, expected_count),
+        None => assert_eq!(0, expected_count),
+    }
 }
 
 /// Check if canceling a Cid affects the wantlist.


### PR DESCRIPTION
Or rather a handful of drive-bys accumulated while trying to fix it thus far.

While the root cause still eludes me, I've come to a point where `exchange_block` is reliably failing, improving further test conditions. At this point I'm preeetty sure it's not the `SubscriptionRegistry` (which got a fix - the keys for complete `Subscription`s were leaking); for instance, during my fix attempts I had changed the custom `Subscription::Cancelled` value to an `Abortable<SubscriptionFuture<T>>` setup and changed the `Arc` in the `SubscriptionFuture` to a `Weak`, both to no avail.

I'm also confident that it is not fixed with any dependency updates; I was initially testing on top of https://github.com/rs-ipfs/rust-ipfs/pull/261.

My next attempt is probably going to be changing the `Arc` related to the `Ipfs` object to a `Weak` in the `IpfsFuture`, which is now my primary suspect - I think something goes wrong while it is being dropped.

cc https://github.com/rs-ipfs/rust-ipfs/issues/248 (during some fix attempts the `connect_two` tests were failing, hence https://github.com/rs-ipfs/rust-ipfs/commit/8569c9a7038504f5bcd70a770e76e3025e006ddf)