### PR TITLE
move the Repo from Ipfs to IpfsFuture

### DIFF
--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU16;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-use ipfs::{Ipfs, IpfsOptions, IpfsTypes, UninitializedIpfs};
+use ipfs::{Ipfs, IpfsOptions, UninitializedIpfs};
 use ipfs_http::{config, v0};
 
 #[derive(Debug, StructOpt)]
@@ -176,9 +176,7 @@ fn main() {
     println!("Shutdown complete");
 }
 
-fn serve<Types: IpfsTypes>(
-    ipfs: &Ipfs<Types>,
-) -> (std::net::SocketAddr, impl std::future::Future<Output = ()>) {
+fn serve(ipfs: &Ipfs) -> (std::net::SocketAddr, impl std::future::Future<Output = ()>) {
     use tokio::stream::StreamExt;
     use warp::Filter;
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel::<()>(1);

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -1,4 +1,4 @@
-use ipfs::{Ipfs, IpfsTypes};
+use ipfs::Ipfs;
 use std::convert::Infallible;
 use warp::{query, Filter};
 
@@ -44,8 +44,8 @@ macro_rules! boxed_on_debug {
     };
 }
 
-pub fn routes<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn routes(
+    ipfs: &Ipfs,
     shutdown_tx: tokio::sync::mpsc::Sender<()>,
 ) -> impl warp::Filter<Extract = impl warp::Reply, Error = Infallible> + Clone {
     let mount = warp::path("api").and(warp::path("v0"));

--- a/http/src/v0/bitswap.rs
+++ b/http/src/v0/bitswap.rs
@@ -1,5 +1,5 @@
 use crate::v0::support::{with_ipfs, InvalidPeerId, StringError};
-use ipfs::{BitswapStats, Ipfs, IpfsTypes};
+use ipfs::{BitswapStats, Ipfs};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use warp::{path, query, reply, Filter, Rejection, Reply};
@@ -15,10 +15,7 @@ pub struct WantlistResponse {
     keys: Vec<Value>,
 }
 
-async fn wantlist_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    query: WantlistQuery,
-) -> Result<impl Reply, Rejection> {
+async fn wantlist_query(ipfs: Ipfs, query: WantlistQuery) -> Result<impl Reply, Rejection> {
     let peer_id = if let Some(peer_id) = query.peer {
         let peer_id = peer_id.parse().map_err(|_| InvalidPeerId)?;
         Some(peer_id)
@@ -37,9 +34,7 @@ async fn wantlist_query<T: IpfsTypes>(
     Ok(reply::json(&response))
 }
 
-pub fn wantlist<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn wantlist(ipfs: &Ipfs) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("bitswap" / "wantlist")
         .and(with_ipfs(ipfs))
         .and(query::<WantlistQuery>())
@@ -88,7 +83,7 @@ impl From<BitswapStats> for StatResponse {
     }
 }
 
-async fn stat_query<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejection> {
+async fn stat_query(ipfs: Ipfs) -> Result<impl Reply, Rejection> {
     let stats: StatResponse = ipfs
         .bitswap_stats()
         .await
@@ -97,9 +92,7 @@ async fn stat_query<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl Reply, Rejection
     Ok(reply::json(&stats))
 }
 
-pub fn stat<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn stat(ipfs: &Ipfs) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("bitswap" / "stat")
         .and(with_ipfs(ipfs))
         .and_then(stat_query)

--- a/http/src/v0/block.rs
+++ b/http/src/v0/block.rs
@@ -5,7 +5,7 @@ use crate::v0::support::{
 use bytes::Buf;
 use futures::stream::{FuturesOrdered, Stream, StreamExt};
 use ipfs::error::Error;
-use ipfs::{Ipfs, IpfsTypes};
+use ipfs::Ipfs;
 use libipld::cid::{Cid, Codec, Version};
 use mime::Mime;
 
@@ -25,10 +25,7 @@ pub struct GetStatOptions {
     timeout: Option<StringSerialized<humantime::Duration>>,
 }
 
-async fn get_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    query: GetStatOptions,
-) -> Result<impl Reply, Rejection> {
+async fn get_query(ipfs: Ipfs, query: GetStatOptions) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
     let data = ipfs
         .get_block(&cid)
@@ -42,9 +39,7 @@ async fn get_query<T: IpfsTypes>(
     Ok(response)
 }
 
-pub fn get<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn get(ipfs: &Ipfs) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "get")
         .and(with_ipfs(ipfs))
         .and(query::<GetStatOptions>())
@@ -86,9 +81,7 @@ impl PutQuery {
     }
 }
 
-pub fn put<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn put(ipfs: &Ipfs) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "put")
         .and(with_ipfs(ipfs))
         .and(query::<PutQuery>())
@@ -97,8 +90,8 @@ pub fn put<T: IpfsTypes>(
         .and_then(inner_put)
 }
 
-async fn inner_put<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn inner_put(
+    ipfs: Ipfs,
     opts: PutQuery,
     mime: Mime,
     body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin,
@@ -149,9 +142,7 @@ pub struct RmResponse {
 #[derive(Serialize, Deserialize)]
 pub struct EmptyResponse;
 
-pub fn rm<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn rm(ipfs: &Ipfs) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "rm")
         .and(with_ipfs(ipfs))
         .and(rm_options())
@@ -168,10 +159,7 @@ fn rm_options() -> impl Filter<Extract = (RmOptions,), Error = Rejection> + Clon
     })
 }
 
-async fn rm_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    options: RmOptions,
-) -> Result<impl Reply, Rejection> {
+async fn rm_query(ipfs: Ipfs, options: RmOptions) -> Result<impl Reply, Rejection> {
     use futures::future::TryFutureExt;
 
     let RmOptions { args, force, quiet } = options;
@@ -221,10 +209,7 @@ async fn rm_query<T: IpfsTypes>(
     Ok(StreamResponse(st))
 }
 
-async fn stat_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    query: GetStatOptions,
-) -> Result<impl Reply, Rejection> {
+async fn stat_query(ipfs: Ipfs, query: GetStatOptions) -> Result<impl Reply, Rejection> {
     let cid: Cid = query.arg.parse().map_err(StringError::from)?;
     let block = ipfs
         .get_block(&cid)
@@ -239,9 +224,7 @@ async fn stat_query<T: IpfsTypes>(
     })))
 }
 
-pub fn stat<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn stat(ipfs: &Ipfs) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("block" / "stat")
         .and(with_ipfs(ipfs))
         .and(query::<GetStatOptions>())

--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -4,7 +4,7 @@ use crate::v0::support::{
 };
 use cid::{Cid, Codec};
 use futures::stream::Stream;
-use ipfs::{Ipfs, IpfsTypes};
+use ipfs::Ipfs;
 use mime::Mime;
 
 use serde::Deserialize;
@@ -33,9 +33,7 @@ impl Default for InputEncoding {
     }
 }
 
-pub fn put<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn put(ipfs: &Ipfs) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("dag" / "put")
         .and(with_ipfs(ipfs))
         .and(query::<PutQuery>())
@@ -44,8 +42,8 @@ pub fn put<T: IpfsTypes>(
         .and_then(put_query)
 }
 
-async fn put_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn put_query(
+    ipfs: Ipfs,
     query: PutQuery,
     mime: Mime,
     body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin,
@@ -104,9 +102,7 @@ async fn put_query<T: IpfsTypes>(
 /// Per https://docs-beta.ipfs.io/reference/http/api/#api-v0-block-resolve this endpoint takes in a
 /// path and resolves it to the last block (the cid), and to the path inside the final block
 /// (rempath).
-pub fn resolve<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn resolve(ipfs: &Ipfs) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     path!("dag" / "resolve")
         .and(with_ipfs(ipfs))
         .and(query::<ResolveOptions>())
@@ -119,10 +115,7 @@ struct ResolveOptions {
     timeout: Option<StringSerialized<humantime::Duration>>,
 }
 
-async fn inner_resolve<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    opts: ResolveOptions,
-) -> Result<impl Reply, Rejection> {
+async fn inner_resolve(ipfs: Ipfs, opts: ResolveOptions) -> Result<impl Reply, Rejection> {
     use crate::v0::refs::{walk_path, IpfsPath};
     use std::convert::TryFrom;
 

--- a/http/src/v0/id.rs
+++ b/http/src/v0/id.rs
@@ -1,11 +1,11 @@
 use super::{with_ipfs, InvalidPeerId, NotImplemented, StringError};
-use ipfs::{Ipfs, IpfsTypes, PeerId};
+use ipfs::{Ipfs, PeerId};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
 use warp::{query, Filter};
 
-pub fn identity<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn identity(
+    ipfs: &Ipfs,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("id")
         .and(with_ipfs(ipfs))
@@ -26,8 +26,8 @@ fn optional_peer_id() -> impl Filter<Extract = (Option<PeerId>,), Error = warp::
 // FIXME: /api/v0/id has argument `arg: PeerId` which is not implemented.
 //
 // https://docs.ipfs.io/reference/api/http/#api-v0-id
-async fn identity_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn identity_query(
+    ipfs: Ipfs,
     peer: Option<PeerId>,
 ) -> Result<impl warp::Reply, warp::reject::Rejection> {
     use multibase::Base::Base64Pad;

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -17,7 +17,7 @@ use tokio::stream::StreamExt;
 use tokio::sync::{broadcast, Mutex};
 use tokio::time::timeout;
 
-use ipfs::{Ipfs, IpfsTypes};
+use ipfs::Ipfs;
 
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -41,8 +41,8 @@ pub struct Pubsub {
 }
 
 /// Creates a filter composing pubsub/{peers,ls,pub,sub}.
-pub fn routes<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn routes(
+    ipfs: &Ipfs,
 ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path("pubsub").and(
         peers(ipfs)
@@ -53,8 +53,8 @@ pub fn routes<T: IpfsTypes>(
 }
 
 /// Handling of https://docs-beta.ipfs.io/reference/http/api/#api-v0-pubsub-peers
-pub fn peers<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn peers(
+    ipfs: &Ipfs,
 ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("peers")
         .and(warp::get().or(warp::post()))
@@ -64,8 +64,8 @@ pub fn peers<T: IpfsTypes>(
         .and_then(inner_peers)
 }
 
-async fn inner_peers<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn inner_peers(
+    ipfs: Ipfs,
     topic: Option<String>,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let peers = ipfs
@@ -79,8 +79,8 @@ async fn inner_peers<T: IpfsTypes>(
 }
 
 /// Handling of https://docs-beta.ipfs.io/reference/http/api/#api-v0-pubsub-ls
-pub fn list_subscriptions<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn list_subscriptions(
+    ipfs: &Ipfs,
 ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("ls")
         .and(warp::get().or(warp::post()))
@@ -89,7 +89,7 @@ pub fn list_subscriptions<T: IpfsTypes>(
         .and_then(inner_ls)
 }
 
-async fn inner_ls<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl warp::Reply, warp::Rejection> {
+async fn inner_ls(ipfs: Ipfs) -> Result<impl warp::Reply, warp::Rejection> {
     let topics = ipfs
         .pubsub_subscribed()
         .await
@@ -99,8 +99,8 @@ async fn inner_ls<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl warp::Reply, warp:
 }
 
 /// Handling of https://docs-beta.ipfs.io/reference/http/api/#api-v0-pubsub-pub
-pub fn publish<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn publish(
+    ipfs: &Ipfs,
 ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("pub")
         .and(warp::post())
@@ -109,8 +109,8 @@ pub fn publish<T: IpfsTypes>(
         .and_then(inner_publish)
 }
 
-async fn inner_publish<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn inner_publish(
+    ipfs: Ipfs,
     PublishArgs { topic, message }: PublishArgs,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     ipfs.pubsub_publish(topic, message.into_inner())
@@ -124,8 +124,8 @@ async fn inner_publish<T: IpfsTypes>(
 /// # Panics
 ///
 /// Note the module documentation.
-pub fn subscribe<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn subscribe(
+    ipfs: &Ipfs,
     pubsub: Arc<Pubsub>,
 ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("sub")
@@ -139,8 +139,8 @@ pub fn subscribe<T: IpfsTypes>(
         })
 }
 
-async fn inner_subscribe<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn inner_subscribe(
+    ipfs: Ipfs,
     pubsub: Arc<Pubsub>,
     topic: String,
 ) -> impl TryStream<Ok = PreformattedJsonMessage, Error = StreamError> {
@@ -197,8 +197,8 @@ async fn inner_subscribe<T: IpfsTypes>(
 /// Shovel task takes items from the [`SubscriptionStream`], formats them and passes them on to
 /// response streams. Uses timeouts to attempt dropping subscriptions which no longer have
 /// responses reading from them and resubscribes streams which get new requests.
-async fn shovel<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn shovel(
+    ipfs: Ipfs,
     pubsub: Arc<Pubsub>,
     topic: String,
     mut shoveled: ipfs::SubscriptionStream,

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -326,11 +326,12 @@ mod tests {
     #[tokio::test]
     async fn very_long_file_and_symlink_names() {
         let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
-        let (ipfs, _) = ipfs::UninitializedIpfs::new(options)
+        let (ipfs, fut) = ipfs::UninitializedIpfs::new(options)
             .await
             .start()
             .await
             .unwrap();
+        let _fut = async_std::task::spawn(fut);
 
         let blocks: &[&[u8]] = &[
             // the root, QmdKuCuXDuVTsnGpzPgZEuJmiCEn6LZhGHHHwWPQH28DeD
@@ -387,11 +388,12 @@ mod tests {
     #[tokio::test]
     async fn get_multiblock_file() {
         let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
-        let (ipfs, _) = ipfs::UninitializedIpfs::new(options)
+        let (ipfs, fut) = ipfs::UninitializedIpfs::new(options)
             .await
             .start()
             .await
             .unwrap();
+        let _fut = async_std::task::spawn(fut);
 
         let blocks: &[&[u8]] = &[
             // the root, QmRJHYTNvC3hmd9gJQARxLR1QMEincccBV53bBw524yyq6

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -3,7 +3,7 @@ use crate::v0::support::StringError;
 use bytes::{Buf, Bytes};
 use cid::Cid;
 use futures::stream::{Stream, TryStreamExt};
-use ipfs::{Ipfs, IpfsTypes};
+use ipfs::Ipfs;
 use mime::Mime;
 use mpart_async::server::MultipartStream;
 use serde::Serialize;
@@ -11,8 +11,8 @@ use std::borrow::Cow;
 use std::fmt;
 use warp::{Rejection, Reply};
 
-pub(super) async fn add_inner<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+pub(super) async fn add_inner(
+    ipfs: Ipfs,
     _opts: AddArgs,
     content_type: Mime,
     body: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin,
@@ -102,7 +102,7 @@ pub(super) async fn add_inner<T: IpfsTypes>(
 }
 
 async fn import_all(
-    ipfs: &Ipfs<impl IpfsTypes>,
+    ipfs: &Ipfs,
     iter: impl Iterator<Item = (Cid, Vec<u8>)>,
 ) -> Result<Option<(Cid, u64)>, ipfs::Error> {
     use ipfs::Block;
@@ -198,7 +198,7 @@ mod tests {
         );
     }
 
-    async fn testing_ipfs() -> ipfs::Ipfs<ipfs::TestTypes> {
+    async fn testing_ipfs() -> ipfs::Ipfs {
         let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
         let (ipfs, fut) = ipfs::UninitializedIpfs::new(options)
             .await

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -1,4 +1,4 @@
-use ipfs::{Ipfs, IpfsTypes};
+use ipfs::Ipfs;
 use log::warn;
 use serde::Serialize;
 use std::borrow::Cow;
@@ -66,9 +66,9 @@ impl MessageResponseBuilder {
 }
 
 /// Clones the handle to the filters
-pub fn with_ipfs<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
-) -> impl warp::Filter<Extract = (Ipfs<T>,), Error = std::convert::Infallible> + Clone {
+pub fn with_ipfs(
+    ipfs: &Ipfs,
+) -> impl warp::Filter<Extract = (Ipfs,), Error = std::convert::Infallible> + Clone {
     use warp::Filter;
     let ipfs = ipfs.clone();
     warp::any().map(move || ipfs.clone())

--- a/http/src/v0/swarm.rs
+++ b/http/src/v0/swarm.rs
@@ -1,5 +1,5 @@
 use super::support::{with_ipfs, StringError};
-use ipfs::{Ipfs, IpfsTypes, Multiaddr};
+use ipfs::{Ipfs, Multiaddr};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -10,8 +10,8 @@ struct ConnectQuery {
     arg: Multiaddr,
 }
 
-async fn connect_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn connect_query(
+    ipfs: Ipfs,
     query: ConnectQuery,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     ipfs.connect(query.arg)
@@ -21,8 +21,8 @@ async fn connect_query<T: IpfsTypes>(
     Ok(warp::reply::json(&response))
 }
 
-pub fn connect<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn connect(
+    ipfs: &Ipfs,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("swarm" / "connect")
         .and(with_ipfs(ipfs))
@@ -49,10 +49,7 @@ struct Peer {
     latency: Option<Cow<'static, str>>,
 }
 
-async fn peers_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    query: PeersQuery,
-) -> Result<impl warp::Reply, warp::Rejection> {
+async fn peers_query(ipfs: Ipfs, query: PeersQuery) -> Result<impl warp::Reply, warp::Rejection> {
     let peers = ipfs
         .peers()
         .await
@@ -87,8 +84,8 @@ async fn peers_query<T: IpfsTypes>(
     Ok(warp::reply::json(&response))
 }
 
-pub fn peers<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn peers(
+    ipfs: &Ipfs,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("swarm" / "peers")
         .and(with_ipfs(ipfs))
@@ -102,7 +99,7 @@ struct AddrsResponse {
     addrs: BTreeMap<String, Vec<String>>,
 }
 
-async fn addrs_query<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl warp::Reply, warp::Rejection> {
+async fn addrs_query(ipfs: Ipfs) -> Result<impl warp::Reply, warp::Rejection> {
     let addresses = ipfs
         .addrs()
         .await
@@ -118,8 +115,8 @@ async fn addrs_query<T: IpfsTypes>(ipfs: Ipfs<T>) -> Result<impl warp::Reply, wa
     Ok(warp::reply::json(&response))
 }
 
-pub fn addrs<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn addrs(
+    ipfs: &Ipfs,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("swarm" / "addrs")
         .and(with_ipfs(ipfs))
@@ -137,8 +134,8 @@ struct AddrsLocalResponse {
     strings: Vec<String>,
 }
 
-async fn addrs_local_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn addrs_local_query(
+    ipfs: Ipfs,
     _query: AddrsLocalQuery,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     let addresses = ipfs
@@ -152,8 +149,8 @@ async fn addrs_local_query<T: IpfsTypes>(
     Ok(warp::reply::json(&response))
 }
 
-pub fn addrs_local<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn addrs_local(
+    ipfs: &Ipfs,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("swarm" / "addrs" / "local")
         .and(with_ipfs(ipfs))
@@ -166,8 +163,8 @@ struct DisconnectQuery {
     arg: Multiaddr,
 }
 
-async fn disconnect_query<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
+async fn disconnect_query(
+    ipfs: Ipfs,
     query: DisconnectQuery,
 ) -> Result<impl warp::Reply, warp::Rejection> {
     ipfs.disconnect(query.arg)
@@ -177,8 +174,8 @@ async fn disconnect_query<T: IpfsTypes>(
     Ok(warp::reply::json(&response))
 }
 
-pub fn disconnect<T: IpfsTypes>(
-    ipfs: &Ipfs<T>,
+pub fn disconnect(
+    ipfs: &Ipfs,
 ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
     warp::path!("swarm" / "disconnect")
         .and(with_ipfs(ipfs))

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,23 +1,22 @@
 use crate::error::Error;
 use crate::path::{IpfsPath, IpfsPathError, SubPath};
-use crate::repo::RepoTypes;
-use crate::Ipfs;
+use crate::repo::{Repo, RepoTypes};
+use async_trait::async_trait;
 use bitswap::Block;
 use cid::{Cid, Codec, Version};
 use libipld::block::{decode_ipld, encode_ipld};
 use libipld::ipld::Ipld;
 
-#[derive(Clone, Debug)]
-pub struct IpldDag<Types: RepoTypes> {
-    ipfs: Ipfs<Types>,
+#[async_trait]
+pub trait IpldDag {
+    async fn put_dag(&self, data: Ipld, codec: Codec) -> Result<Cid, Error>;
+
+    async fn get_dag(&self, path: IpfsPath) -> Result<Ipld, Error>;
 }
 
-impl<Types: RepoTypes> IpldDag<Types> {
-    pub fn new(ipfs: Ipfs<Types>) -> Self {
-        IpldDag { ipfs }
-    }
-
-    pub async fn put(&self, data: Ipld, codec: Codec) -> Result<Cid, Error> {
+#[async_trait]
+impl<T: RepoTypes> IpldDag for Repo<T> {
+    async fn put_dag(&self, data: Ipld, codec: Codec) -> Result<Cid, Error> {
         let bytes = encode_ipld(&data, codec)?;
         let hash = multihash::Sha2_256::digest(&bytes);
         let version = if codec == Codec::DagProtobuf {
@@ -27,16 +26,16 @@ impl<Types: RepoTypes> IpldDag<Types> {
         };
         let cid = Cid::new(version, codec, hash)?;
         let block = Block::new(bytes, cid);
-        let (cid, _) = self.ipfs.repo.put_block(block).await?;
+        let (cid, _) = self.put_block(block).await?;
         Ok(cid)
     }
 
-    pub async fn get(&self, path: IpfsPath) -> Result<Ipld, Error> {
+    async fn get_dag(&self, path: IpfsPath) -> Result<Ipld, Error> {
         let cid = match path.root().cid() {
             Some(cid) => cid,
             None => return Err(anyhow::anyhow!("expected cid")),
         };
-        let mut ipld = decode_ipld(&cid, self.ipfs.repo.get_block(&cid).await?.data())?;
+        let mut ipld = decode_ipld(&cid, self.get_block(&cid).await?.data())?;
         for sub_path in path.iter() {
             if !can_resolve(&ipld, sub_path) {
                 let path = sub_path.to_owned();
@@ -44,7 +43,7 @@ impl<Types: RepoTypes> IpldDag<Types> {
             }
             ipld = resolve(ipld, sub_path);
             ipld = match ipld {
-                Ipld::Link(cid) => decode_ipld(&cid, self.ipfs.repo.get_block(&cid).await?.data())?,
+                Ipld::Link(cid) => decode_ipld(&cid, self.get_block(&cid).await?.data())?,
                 ipld => ipld,
             };
         }
@@ -100,21 +99,19 @@ mod tests {
     #[async_std::test]
     async fn test_resolve_root_cid() {
         let ipfs = create_mock_ipfs().await;
-        let dag = IpldDag::new(ipfs);
         let data = ipld!([1, 2, 3]);
-        let cid = dag.put(data.clone(), Codec::DagCBOR).await.unwrap();
-        let res = dag.get(IpfsPath::from(cid)).await.unwrap();
+        let cid = ipfs.put_dag(data.clone()).await.unwrap();
+        let res = ipfs.get_dag(IpfsPath::from(cid)).await.unwrap();
         assert_eq!(res, data);
     }
 
     #[async_std::test]
     async fn test_resolve_array_elem() {
         let ipfs = create_mock_ipfs().await;
-        let dag = IpldDag::new(ipfs);
         let data = ipld!([1, 2, 3]);
-        let cid = dag.put(data.clone(), Codec::DagCBOR).await.unwrap();
-        let res = dag
-            .get(IpfsPath::from(cid).sub_path("1").unwrap())
+        let cid = ipfs.put_dag(data.clone()).await.unwrap();
+        let res = ipfs
+            .get_dag(IpfsPath::from(cid).sub_path("1").unwrap())
             .await
             .unwrap();
         assert_eq!(res, ipld!(2));
@@ -123,11 +120,10 @@ mod tests {
     #[async_std::test]
     async fn test_resolve_nested_array_elem() {
         let ipfs = create_mock_ipfs().await;
-        let dag = IpldDag::new(ipfs);
         let data = ipld!([1, [2], 3,]);
-        let cid = dag.put(data, Codec::DagCBOR).await.unwrap();
-        let res = dag
-            .get(IpfsPath::from(cid).sub_path("1/0").unwrap())
+        let cid = ipfs.put_dag(data).await.unwrap();
+        let res = ipfs
+            .get_dag(IpfsPath::from(cid).sub_path("1/0").unwrap())
             .await
             .unwrap();
         assert_eq!(res, ipld!(2));
@@ -136,13 +132,12 @@ mod tests {
     #[async_std::test]
     async fn test_resolve_object_elem() {
         let ipfs = create_mock_ipfs().await;
-        let dag = IpldDag::new(ipfs);
         let data = ipld!({
             "key": false,
         });
-        let cid = dag.put(data, Codec::DagCBOR).await.unwrap();
-        let res = dag
-            .get(IpfsPath::from(cid).sub_path("key").unwrap())
+        let cid = ipfs.put_dag(data).await.unwrap();
+        let res = ipfs
+            .get_dag(IpfsPath::from(cid).sub_path("key").unwrap())
             .await
             .unwrap();
         assert_eq!(res, ipld!(false));
@@ -151,13 +146,12 @@ mod tests {
     #[async_std::test]
     async fn test_resolve_cid_elem() {
         let ipfs = create_mock_ipfs().await;
-        let dag = IpldDag::new(ipfs);
         let data1 = ipld!([1]);
-        let cid1 = dag.put(data1, Codec::DagCBOR).await.unwrap();
+        let cid1 = ipfs.put_dag(data1).await.unwrap();
         let data2 = ipld!([cid1]);
-        let cid2 = dag.put(data2, Codec::DagCBOR).await.unwrap();
-        let res = dag
-            .get(IpfsPath::from(cid2).sub_path("0/0").unwrap())
+        let cid2 = ipfs.put_dag(data2).await.unwrap();
+        let res = ipfs
+            .get_dag(IpfsPath::from(cid2).sub_path("0/0").unwrap())
             .await
             .unwrap();
         assert_eq!(res, ipld!(1));

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 use crate::error::Error;
 use crate::path::{IpfsPath, PathRoot};
-use crate::repo::RepoTypes;
-use crate::Ipfs;
+use crate::repo::{Repo, RepoTypes};
+use async_trait::async_trait;
 use libp2p::PeerId;
 
 mod dns;
@@ -11,22 +11,23 @@ mod ipns_pb {
     include!(concat!(env!("OUT_DIR"), "/ipns_pb.rs"));
 }
 
-#[derive(Clone, Debug)]
-pub struct Ipns<Types: RepoTypes> {
-    ipfs: Ipfs<Types>,
+#[async_trait]
+pub trait Ipns {
+    async fn resolve_ipns(&self, path: &IpfsPath) -> Result<IpfsPath, Error>;
+
+    async fn publish_ipns(&self, key: &PeerId, path: &IpfsPath) -> Result<IpfsPath, Error>;
+
+    async fn cancel_ipns(&self, key: &PeerId) -> Result<(), Error>;
 }
 
-impl<Types: RepoTypes> Ipns<Types> {
-    pub fn new(ipfs: Ipfs<Types>) -> Self {
-        Ipns { ipfs }
-    }
-
+#[async_trait]
+impl<Types: RepoTypes> Ipns for Repo<Types> {
     /// Resolves a ipns path to an ipld path.
-    pub async fn resolve(&self, path: &IpfsPath) -> Result<IpfsPath, Error> {
+    async fn resolve_ipns(&self, path: &IpfsPath) -> Result<IpfsPath, Error> {
         let path = path.to_owned();
         match path.root() {
             PathRoot::Ipld(_) => Ok(path),
-            PathRoot::Ipns(peer_id) => match self.ipfs.repo.get_ipns(peer_id).await? {
+            PathRoot::Ipns(peer_id) => match self.get_ipns(peer_id).await? {
                 Some(path) => Ok(path),
                 None => Err(anyhow::anyhow!("unimplemented")),
             },
@@ -35,8 +36,8 @@ impl<Types: RepoTypes> Ipns<Types> {
     }
 
     /// Publishes an ipld path.
-    pub async fn publish(&self, key: &PeerId, path: &IpfsPath) -> Result<IpfsPath, Error> {
-        let future = self.ipfs.repo.put_ipns(key, path);
+    async fn publish_ipns(&self, key: &PeerId, path: &IpfsPath) -> Result<IpfsPath, Error> {
+        let future = self.put_ipns(key, path);
         let key = key.to_owned();
         let mut path = path.to_owned();
         future.await?;
@@ -45,8 +46,8 @@ impl<Types: RepoTypes> Ipns<Types> {
     }
 
     /// Cancel an ipns path.
-    pub async fn cancel(&self, key: &PeerId) -> Result<(), Error> {
-        self.ipfs.repo.remove_ipns(key).await?;
+    async fn cancel_ipns(&self, key: &PeerId) -> Result<(), Error> {
+        self.remove_ipns(key).await?;
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@ impl<T: RepoTypes> SwarmTypes for T {}
 impl<T: SwarmTypes + RepoTypes> IpfsTypes for T {}
 
 /// Default IPFS types.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Types;
 impl RepoTypes for Types {
     type TBlockStore = repo::fs::FsBlockStore;
@@ -72,7 +72,7 @@ impl RepoTypes for Types {
 }
 
 /// Testing IPFS types
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TestTypes;
 impl RepoTypes for TestTypes {
     type TBlockStore = repo::mem::MemBlockStore;
@@ -908,7 +908,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                 match inner {
                     IpfsEvent::GetBlock(cid, ccl_notifier, ret) => {
                         self.swarm.want_block(cid.clone()); // FIXME: only do this if we don't have the block
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move {
                             repo.get_block_with_notifier(&cid, Some(ccl_notifier)).await
                         }))
@@ -916,67 +916,67 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                     }
                     IpfsEvent::PutBlock(block, ret) => {
                         self.swarm.provide_block(block.cid.clone());
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.put_block(block).await }))
                             .ok();
                     }
                     IpfsEvent::RemoveBlock(cid, ret) => {
                         self.swarm.stop_providing_block(&cid);
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.remove_block(&cid).await }))
                             .ok();
                     }
                     IpfsEvent::PinBlock(cid, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.pin_block(&cid).await }))
                             .ok();
                     }
                     IpfsEvent::UnpinBlock(cid, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.unpin_block(&cid).await }))
                             .ok();
                     }
                     IpfsEvent::IsBlockPinned(cid, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.is_pinned(&cid).await }))
                             .ok();
                     }
                     IpfsEvent::ListBlocks(ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.list_blocks().await }))
                             .ok();
                     }
                     IpfsEvent::PutDag(ipld, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move {
                             repo.put_dag(ipld, Codec::DagCBOR).await
                         }))
                         .ok();
                     }
                     IpfsEvent::GetDag(path, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.get_dag(path).await }))
                             .ok();
                     }
                     IpfsEvent::ResolveIpns(path, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.resolve_ipns(&path).await }))
                             .ok();
                     }
                     IpfsEvent::PublishIpns(key, path, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(
                             async move { repo.publish_ipns(&key, &path).await },
                         ))
                         .ok();
                     }
                     IpfsEvent::CancelIpns(key, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move { repo.cancel_ipns(&key).await }))
                             .ok();
                     }
                     IpfsEvent::Add(path, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
 
                         ret.send(task::spawn(async move {
                             let file = File::new(path).await?;
@@ -985,14 +985,14 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                         .ok();
                     }
                     IpfsEvent::Get(path, ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(task::spawn(async move {
                             File::get_unixfs_v1(&repo, path).await
                         }))
                         .ok();
                     }
                     IpfsEvent::GetBlockSubscriptions(ret) => {
-                        let repo = self.swarm.repo().clone();
+                        let repo = self.swarm.repo();
                         ret.send(
                             repo.subscriptions
                                 .subscriptions

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -235,7 +235,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
     fn inject_event(&mut self, event: BitswapEvent) {
         match event {
             BitswapEvent::ReceivedBlock(peer_id, block) => {
-                let repo = self.repo().clone();
+                let repo = self.repo();
                 let peer_stats =
                     Arc::clone(&self.bitswap.connected_peers.get(&peer_id).unwrap().stats);
 
@@ -266,7 +266,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<BitswapEvent> for Behaviour<
                 );
 
                 let queued_blocks = self.bitswap().queued_blocks.clone();
-                let repo = self.repo().to_owned();
+                let repo = self.repo();
 
                 task::spawn(async move {
                     match repo.get_block_now(&cid).await {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 #[derive(NetworkBehaviour)]
 pub struct Behaviour<Types: IpfsTypes> {
     #[behaviour(ignore)]
-    repo: Repo<Types>,
+    repo: Arc<Repo<Types>>,
     mdns: Toggle<Mdns>,
     kademlia: Kademlia<MemoryStore>,
     #[behaviour(ignore)]
@@ -372,6 +372,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         );
         let pubsub = Pubsub::new(options.peer_id);
         let swarm = SwarmApi::new();
+        let repo = Arc::new(repo);
 
         Behaviour {
             repo,
@@ -460,8 +461,8 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         &mut self.bitswap
     }
 
-    pub fn repo(&self) -> &Repo<Types> {
-        &self.repo
+    pub fn repo(&self) -> Arc<Repo<Types>> {
+        Arc::clone(&self.repo)
     }
 
     pub fn bootstrap(&mut self) -> Result<SubscriptionFuture<Result<(), String>>, anyhow::Error> {

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,6 +1,5 @@
 //! P2P handling for IPFS nodes.
-use crate::repo::RepoTypes;
-use crate::Ipfs;
+use crate::repo::{Repo, RepoTypes};
 use crate::IpfsOptions;
 use core::marker::PhantomData;
 use libp2p::identity::Keypair;
@@ -49,7 +48,7 @@ impl<TSwarmTypes: SwarmTypes> From<&IpfsOptions<TSwarmTypes>> for SwarmOptions<T
 /// Creates a new IPFS swarm.
 pub async fn create_swarm<TSwarmTypes: SwarmTypes>(
     options: SwarmOptions<TSwarmTypes>,
-    ipfs: Ipfs<TSwarmTypes>,
+    repo: Repo<TSwarmTypes>,
 ) -> TSwarm<TSwarmTypes> {
     let peer_id = options.peer_id.clone();
 
@@ -57,7 +56,7 @@ pub async fn create_swarm<TSwarmTypes: SwarmTypes>(
     let transport = transport::build_transport(options.keypair.clone());
 
     // Create a Kademlia behaviour
-    let behaviour = behaviour::build_behaviour(options, ipfs).await;
+    let behaviour = behaviour::build_behaviour(options, repo).await;
 
     // Create a Swarm
     let mut swarm = libp2p::Swarm::new(transport, behaviour, peer_id);

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -14,13 +14,14 @@ use futures::lock::Mutex;
 use futures::stream::StreamExt;
 use std::collections::HashSet;
 use std::ffi::OsStr;
+use std::sync::Arc;
 
 use super::{BlockRm, BlockRmError, RepoCid};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FsBlockStore {
     path: PathBuf,
-    cids: Mutex<HashSet<RepoCid>>,
+    cids: Arc<Mutex<HashSet<RepoCid>>>,
 }
 
 #[async_trait]

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -14,14 +14,13 @@ use futures::lock::Mutex;
 use futures::stream::StreamExt;
 use std::collections::HashSet;
 use std::ffi::OsStr;
-use std::sync::Arc;
 
 use super::{BlockRm, BlockRmError, RepoCid};
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct FsBlockStore {
     path: PathBuf,
-    cids: Arc<Mutex<HashSet<RepoCid>>>,
+    cids: Mutex<HashSet<RepoCid>>,
 }
 
 #[async_trait]

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -6,16 +6,15 @@ use async_trait::async_trait;
 use bitswap::Block;
 use cid::Cid;
 use futures::lock::Mutex;
-use std::sync::Arc;
 
 use super::{BlockRm, BlockRmError, RepoCid};
 
 // FIXME: Transition to Persistent Map to make iterating more consistent
 use std::collections::HashMap;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct MemBlockStore {
-    blocks: Arc<Mutex<HashMap<RepoCid, Block>>>,
+    blocks: Mutex<HashMap<RepoCid, Block>>,
 }
 
 #[async_trait]
@@ -81,10 +80,10 @@ impl BlockStore for MemBlockStore {
     }
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default)]
 pub struct MemDataStore {
-    ipns: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
-    pin: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
+    ipns: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
+    pin: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
 }
 
 #[async_trait]

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -6,15 +6,16 @@ use async_trait::async_trait;
 use bitswap::Block;
 use cid::Cid;
 use futures::lock::Mutex;
+use std::sync::Arc;
 
 use super::{BlockRm, BlockRmError, RepoCid};
 
 // FIXME: Transition to Persistent Map to make iterating more consistent
 use std::collections::HashMap;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct MemBlockStore {
-    blocks: Mutex<HashMap<RepoCid, Block>>,
+    blocks: Arc<Mutex<HashMap<RepoCid, Block>>>,
 }
 
 #[async_trait]
@@ -80,10 +81,10 @@ impl BlockStore for MemBlockStore {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct MemDataStore {
-    ipns: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
-    pin: Mutex<HashMap<Vec<u8>, Vec<u8>>>,
+    ipns: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
+    pin: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
 }
 
 #[async_trait]

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -12,12 +12,11 @@ use core::marker::PhantomData;
 use futures::channel::mpsc::Sender;
 use libp2p::core::PeerId;
 use std::hash::{Hash, Hasher};
-use std::sync::Arc;
 
 pub mod fs;
 pub mod mem;
 
-pub trait RepoTypes: Send + Sync + Clone + 'static {
+pub trait RepoTypes: Send + Sync + 'static {
     type TBlockStore: BlockStore;
     type TDataStore: DataStore;
 }
@@ -83,7 +82,7 @@ pub enum BlockRmError {
 
 /// This API is being discussed and evolved, which will likely lead to breakage.
 #[async_trait]
-pub trait BlockStore: Debug + Clone + Send + Sync + Unpin + 'static {
+pub trait BlockStore: Debug + Send + Sync + Unpin + 'static {
     fn new(path: PathBuf) -> Self;
     async fn init(&self) -> Result<(), Error>;
     async fn open(&self) -> Result<(), Error>;
@@ -96,7 +95,7 @@ pub trait BlockStore: Debug + Clone + Send + Sync + Unpin + 'static {
 }
 
 #[async_trait]
-pub trait DataStore: Debug + Clone + Send + Sync + Unpin + 'static {
+pub trait DataStore: Debug + Send + Sync + Unpin + 'static {
     fn new(path: PathBuf) -> Self;
     async fn init(&self) -> Result<(), Error>;
     async fn open(&self) -> Result<(), Error>;
@@ -113,11 +112,11 @@ pub enum Column {
     Pin,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Repo<TRepoTypes: RepoTypes> {
     block_store: TRepoTypes::TBlockStore,
     data_store: TRepoTypes::TDataStore,
-    pub(crate) subscriptions: Arc<SubscriptionRegistry<Block>>,
+    pub(crate) subscriptions: SubscriptionRegistry<Block>,
 }
 
 impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -12,6 +12,7 @@ use core::marker::PhantomData;
 use futures::channel::mpsc::Sender;
 use libp2p::core::PeerId;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 pub mod fs;
 pub mod mem;
@@ -116,7 +117,7 @@ pub enum Column {
 pub struct Repo<TRepoTypes: RepoTypes> {
     block_store: TRepoTypes::TBlockStore,
     data_store: TRepoTypes::TDataStore,
-    pub(crate) subscriptions: SubscriptionRegistry<Block>,
+    pub(crate) subscriptions: Arc<SubscriptionRegistry<Block>>,
 }
 
 impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -82,7 +82,7 @@ pub enum BlockRmError {
 
 /// This API is being discussed and evolved, which will likely lead to breakage.
 #[async_trait]
-pub trait BlockStore: Debug + Send + Sync + Unpin + 'static {
+pub trait BlockStore: Debug + Send + Sync + Unpin {
     fn new(path: PathBuf) -> Self;
     async fn init(&self) -> Result<(), Error>;
     async fn open(&self) -> Result<(), Error>;
@@ -95,7 +95,7 @@ pub trait BlockStore: Debug + Send + Sync + Unpin + 'static {
 }
 
 #[async_trait]
-pub trait DataStore: Debug + Send + Sync + Unpin + 'static {
+pub trait DataStore: Debug + Send + Sync + Unpin {
     fn new(path: PathBuf) -> Self;
     async fn init(&self) -> Result<(), Error>;
     async fn open(&self) -> Result<(), Error>;

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -170,7 +170,7 @@ impl<TRes: Debug + Clone> SubscriptionRegistry<TRes> {
             return;
         }
 
-        log::debug!("Shutting down {:?}", self);
+        debug!("Shutting down {:?}", self);
 
         let mut cancelled = 0;
         let mut subscriptions = mem::take(&mut *task::block_on(async {
@@ -184,7 +184,7 @@ impl<TRes: Debug + Clone> SubscriptionRegistry<TRes> {
             }
         }
 
-        log::debug!("Cancelled {} subscriptions", cancelled);
+        debug!("Cancelled {} subscriptions", cancelled);
     }
 }
 

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -1,4 +1,4 @@
-use crate::{Error, Ipfs, IpfsTypes};
+use crate::{Error, Ipfs};
 use async_stream::stream;
 use cid::Cid;
 use futures::stream::Stream;
@@ -13,14 +13,13 @@ use std::ops::Range;
 /// be helpful in some contexts, like the http.
 ///
 /// Returns a stream of bytes on the file pointed with the Cid.
-pub async fn cat<'a, Types, MaybeOwned>(
+pub async fn cat<'a, MaybeOwned>(
     ipfs: MaybeOwned,
     cid: Cid,
     range: Option<Range<u64>>,
 ) -> Result<impl Stream<Item = Result<Vec<u8>, TraversalFailed>> + Send + 'a, TraversalFailed>
 where
-    Types: IpfsTypes,
-    MaybeOwned: Borrow<Ipfs<Types>> + Send + 'a,
+    MaybeOwned: Borrow<Ipfs> + Send + 'a,
 {
     use bitswap::Block;
 

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -33,12 +33,15 @@ where
     }
 }
 
-async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) {
+// FIXME: use #[track_caller] when available
+async fn check_cid_subscriptions(ipfs: &Node, expected_count: usize) {
+    // FIXME: this delay shouldn't be needed
+    task::spawn(task::sleep(Duration::from_millis(100))).await;
     let subs = ipfs.get_subscriptions().await.unwrap();
     if expected_count > 0 {
         assert_eq!(subs.len(), 1);
     }
-    let subscription_count = subs.get(&cid.clone().into()).map(|l| l.len());
+    let subscription_count = subs.get(0).map(|(_kind, subs)| subs.len());
     assert_eq!(subscription_count, Some(expected_count));
 }
 
@@ -75,9 +78,7 @@ async fn wantlist_cancellation() {
     );
 
     // ensure that there is a single related subscription
-    check_cid_subscriptions(&ipfs, &cid, 1).await;
-
-    println!("### GOT HERE");
+    check_cid_subscriptions(&ipfs, 1).await;
 
     // fire up an additional get request
     let ipfs_clone = ipfs.clone();
@@ -89,12 +90,8 @@ async fn wantlist_cancellation() {
     );
     let _get_request2 = task::spawn(abortable_req);
 
-    task::spawn(task::sleep(Duration::from_millis(500))).await;
-
     // ensure that there are 2 related subscriptions
-    check_cid_subscriptions(&ipfs, &cid, 2).await;
-
-    println!("### NOT GETTING HERE");
+    check_cid_subscriptions(&ipfs, 2).await;
 
     // ...and an additional one, for good measure
     let ipfs_clone = ipfs.clone();
@@ -107,9 +104,9 @@ async fn wantlist_cancellation() {
     let _get_request3 = task::spawn(abortable_req);
 
     // ensure that there are 3 related subscription
-    check_cid_subscriptions(&ipfs, &cid, 3).await;
+    check_cid_subscriptions(&ipfs, 3).await;
 
-    // cancel the first requested Cid
+    // cancel the first request
     abort_handle1.abort();
 
     // verify that the requested Cid is still in the wantlist
@@ -125,10 +122,14 @@ async fn wantlist_cancellation() {
         "the wantlist is empty despite there still being 2 live get requests"
     );
 
-    // ensure that there are 2 related subscriptions
-    check_cid_subscriptions(&ipfs, &cid, 2).await;
+    println!("### GETTING HERE");
 
-    // cancel the second requested Cid
+    // ensure that there are 2 related subscriptions
+    check_cid_subscriptions(&ipfs, 2).await;
+
+    println!("### NOT GETTING HERE");
+
+    // cancel the second request
     abort_handle2.abort();
 
     // verify that the requested Cid is STILL in the wantlist
@@ -145,9 +146,9 @@ async fn wantlist_cancellation() {
     );
 
     // ensure that there is a single related subscription
-    check_cid_subscriptions(&ipfs, &cid, 1).await;
+    check_cid_subscriptions(&ipfs, 1).await;
 
-    // cancel the second requested Cid
+    // cancel the third request
     abort_handle3.abort();
 
     // verify that the requested Cid is no longer in the wantlist
@@ -164,5 +165,5 @@ async fn wantlist_cancellation() {
     );
 
     // ensure that there are no related subscriptions
-    check_cid_subscriptions(&ipfs, &cid, 0).await;
+    check_cid_subscriptions(&ipfs, 0).await;
 }

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -38,7 +38,7 @@ where
 }
 
 async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) {
-    let subs = ipfs.get_subscriptions().lock().await;
+    let subs = ipfs.get_subscriptions().await.unwrap();
     if expected_count > 0 {
         assert_eq!(subs.len(), 1);
     }


### PR DESCRIPTION
As far as I can tell from the comments, this has been the plan / target design for a while now. These changes carry a few important improvements:
- `Ipfs` is no longer generic :tada: (a huge advantage for IPFS-as-a-library)
- no more back-and-forth between `Ipfs` and `IpfsFuture` via `RepoEvent`s
- the `Ipfs` methods become uniform in the way they work
- there is no longer a need for `Ipfs` to be within an `Arc` (though it might be preferable for future-proofing)

This is still a work in progress, as: 
- [x] 2 `Ipfs` methods remain to be converted
- [x] 2 `RepoEvent` functionalities need to be re-introduced
- [x] the crate tests need to be adjusted
- [x] the `wantlist_and_cancellation` test needs to be fixed

The conformance tests (excluding the aforementioned missing bits) agree with these changes.