### PR TITLE
ci: use vcpkg for openssl on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,27 +76,15 @@ jobs:
       if: matrix.platform.host == 'macos-latest'
       run: brew install llvm openssl
 
-    - name: Cache windows (openssl)
-      id: windows-openssl-cache
+    - name: Install dependencies windows (openssl)
+      uses: lukka/run-vcpkg@v3
+      id: windows-runvcpkg
       if: matrix.platform.host == 'windows-latest'
-      uses: actions/cache@v2
       with:
-        path: 'C:\vcpkg\installed\x64-windows'
-        key: ${{ runner.os }}-${{ hashFiles('C:\vcpkg\installed\x64-windows\bin\libcrypto.dll', 'C:\vcpkg\installed\x64-windows\bin\libssl.dll') }}
-
-    - name: Install dependencies windows (slow)
-      if: matrix.platform.host == 'windows-latest' && steps.windows-openssl-cache.outputs.cache-hit != 'true'
-      run: |
-        choco install llvm
-
-    - name: Install dependencies windows
-      if: matrix.platform.host == 'windows-latest'
-      run: |
-        vcpkg integrate install
-        vcpkg install openssl:x64-windows
-        Copy-Item C:\vcpkg\installed\x64-windows\bin\libcrypto-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libcrypto.dll
-        Copy-Item C:\vcpkg\installed\x64-windows\bin\libssl-1_1-x64.dll C:\vcpkg\installed\x64-windows\bin\libssl.dll
-        Get-ChildItem C:\vcpkg\installed\x64-windows\lib
+        vcpkgDirectory: '${{ runner.workspace }}/vcpkg'
+        vcpkgTriplet: 'x64-windows'
+        vcpkgArguments: 'openssl'
+        vcpkgGitCommitId: 'ffa41582f78478812c836a6e8ce315fb27431182'  # ok for openssl-sys v0.9.58
 
     - name: Install rust toolchain
       uses: hecrj/setup-rust-action@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,9 +2510,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.28"
+version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "973293749822d7dd6370d6da1e523b0d1db19f06c459134c658b2a4261378b52"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -2524,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.54"
+version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1024c0a59774200a555087a6da3f253a9095a5f344e353b212ac4c8b8e450986"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
 dependencies = [
  "autocfg 1.0.0",
  "cc",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -21,7 +21,7 @@ log = "0.4.8"
 multibase = "0.8.0"
 multihash = "0.11"
 # openssl is required for rsa keygen but not used by the rust-ipfs or it's dependencies
-openssl = "0.10.28"
+openssl = "0.10.30"
 percent-encoding = "2.1.0"
 prost = "0.6.1"
 serde = { version = "1.0.106", features = ["derive"] }


### PR DESCRIPTION
Hoping to find something to help with #261:
 - switch to using [lukka/run-vcpkg](https://github.com/lukka/run-vcpkg)
 - get rid of the llvm dependency on windows (it was not needed)
 - update openssl dep to 0.10.30