### PR TITLE
ci: caching updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: conformance/node_modules
-        key: ${{ runner.os }}-npm-${{ hashFiles('conformance/package*.json', 'conformance/patches/**', 'conformance/setup.sh') }}
+        key: ${{ matrix.platform.target }}-npm-${{ hashFiles('conformance/package*.json', 'conformance/patches/**', 'conformance/setup.sh') }}
 
     - name: Install dependencies ubuntu
       if: matrix.platform.host == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,14 +72,16 @@ jobs:
 
     - name: Get npm cache directory
       id: npm-cache
+      if: matrix.platform.cross == false
       run: |
         echo "::set-output name=dir::$(npm config get cache)"
 
-    - name: Cache npm
+    - name: Cache npm (non-cross targets)
       uses: actions/cache@v2
+      if: matrix.platform.cross == false
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json', '**/setup.sh') }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json', '**/setup.sh', '**/*.patch') }}
         restore-keys: |
           ${{ runner.os }}-node-
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo
-        key: lint-cargo
+        key: lint-cargo-${{ hashFiles('Cargo.lock') }}
 
     - name: Install rust toolchain
       uses: hecrj/setup-rust-action@v1
@@ -184,7 +184,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo
-        key: readme-doctest
+        key: readme-doctest-${{ hashFiles('Cargo.lock') }}
 
     - name: Install rust toolchain
       uses: hecrj/setup-rust-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,13 +63,13 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache cargo folder
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cargo
         key: ${{ matrix.platform.target }}-cargo-${{ hashFiles('Cargo.lock') }}
 
     - name: Cache node modules
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: conformance/node_modules
         key: ${{ matrix.platform.target }}-npm-${{ hashFiles('conformance/package*.json', 'conformance/patches/**', 'conformance/setup.sh') }}
@@ -157,7 +157,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache cargo folder
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cargo
         key: lint-cargo-${{ hashFiles('Cargo.lock') }}
@@ -181,7 +181,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache cargo folder
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       with:
         path: ~/.cargo
         key: readme-doctest-${{ hashFiles('Cargo.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,8 @@ jobs:
       run: |
         echo "::set-output name=dir::$(npm config get cache)"
 
-    - uses: actions/cache@v2
+    - name: Cache npm
+      uses: actions/cache@v2
       with:
         path: ${{ steps.npm-cache.outputs.dir }}
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json', '**/setup.sh') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.cargo
-        key: ${{ matrix.platform.target }}-cargo-${{ hashFiles('Cargo.lock') }}
+        key: ${{ matrix.platform.target }}-dot-cargo-${{ hashFiles('Cargo.lock') }}
 
     - name: Get npm cache directory
       id: npm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,9 @@ jobs:
     - name: Cache cargo folder
       uses: actions/cache@v2
       with:
-        path: ~/.cargo
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
         key: ${{ matrix.platform.target }}-dot-cargo-${{ hashFiles('Cargo.lock') }}
 
     - name: Get npm cache directory

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,12 @@ jobs:
         path: ~/.cargo
         key: ${{ matrix.platform.target }}-cargo-${{ matrix.toolchain.rust }}
 
+    - name: Cache node modules
+      uses: actions/cache@v1
+      with:
+        path: conformance/node_modules
+        key: ${{ runner.os }}-npm-${{ hashFiles('conformance/package*.json', 'conformance/patches/**', 'conformance/setup.sh') }}
+
     - name: Install dependencies ubuntu
       if: matrix.platform.host == 'ubuntu-latest'
       run: sudo apt-get install llvm-dev libssl-dev pkg-config

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,17 @@ jobs:
         path: ~/.cargo
         key: ${{ matrix.platform.target }}-cargo-${{ hashFiles('Cargo.lock') }}
 
-    - name: Cache node modules
-      uses: actions/cache@v2
+    - name: Get npm cache directory
+      id: npm-cache
+      run: |
+        echo "::set-output name=dir::$(npm config get cache)"
+
+    - uses: actions/cache@v2
       with:
-        path: conformance/node_modules
-        key: ${{ matrix.platform.target }}-npm-${{ hashFiles('conformance/package*.json', 'conformance/patches/**', 'conformance/setup.sh') }}
+        path: ${{ steps.npm-cache.outputs.dir }}
+        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json', '**/setup.sh') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
 
     - name: Install dependencies ubuntu
       if: matrix.platform.host == 'ubuntu-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         path: |
           ~/.cargo/registry
           ~/.cargo/git
-        key: ${{ matrix.platform.target }}-dot-cargo-${{ hashFiles('Cargo.lock') }}
+        key: ${{ matrix.platform.target }}-dot-cargo-parts-${{ hashFiles('Cargo.lock') }}
 
     - name: Get npm cache directory
       id: npm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo
-        key: ${{ matrix.platform.target }}-cargo-${{ matrix.toolchain.rust }}
+        key: ${{ matrix.platform.target }}-cargo-${{ hashFiles('Cargo.lock') }}
 
     - name: Cache node modules
       uses: actions/cache@v1

--- a/conformance/setup.sh
+++ b/conformance/setup.sh
@@ -8,6 +8,11 @@ if ! [ -f "./package.json" ]; then
     exit 1
 fi
 
+if [ -d "node_modules" ]; then
+    echo "Directory exists already: node_modules/" >&2
+    exit 1
+fi
+
 # production will skip the dev dependencies
 npm install --production
 

--- a/conformance/setup.sh
+++ b/conformance/setup.sh
@@ -21,9 +21,6 @@ if [ -d "patches" ]; then
     # as we want to apply the patches create in a js-ipfs checkout to our node_modules
     # we'll need to remove a few leading path segments to match
     # a/packages/interface-ipfs-core/src/refs.js to node_modules/interface-ipfs-core/src/refs.js
-    #
-    # cannot use git automation any longer as it will skip any ignored file apparently,
-    # and node_modules are ignored.
     for p in patches/*; do
         echo "Applying $(basename "$p")..." >&2
         patch -d node_modules/ -p1 < "$p"


### PR DESCRIPTION
node_modules: It's quite slow on windows (about 3min), linux (50s) and mac is in the between. This is a bit hacky given the patching and whatnot, but I think the hashFiles combination is good.

~/.cargo: this was never cached, but now it should be cached correctly `hashFiles(Cargo.lock)`.