### PR TITLE
Split Entry into two different enums to remove unnecessary expects

### DIFF
--- a/unixfs/examples/get.rs
+++ b/unixfs/examples/get.rs
@@ -52,7 +52,7 @@ fn main() {
 }
 
 fn walk(blocks: ShardedBlockStore, start: &Cid) -> Result<(), Error> {
-    use ipfs_unixfs::walk::{ContinuedWalk, Walker};
+    use ipfs_unixfs::walk::{ContinuedWalk, Entry, MetadataEntry, Walker};
 
     let mut buf = Vec::new();
     let mut cache = None;
@@ -72,56 +72,45 @@ fn walk(blocks: ShardedBlockStore, start: &Cid) -> Result<(), Error> {
         // items.
         visit = match walker.continue_walk(&buf, &mut cache)? {
             ContinuedWalk::File(segment, item) => {
-                let entry = item.as_entry();
-                let total_size = entry.total_file_size().expect("all files have total size");
-                // metadata is picked up from the root file and carried until the last block
-                let metadata = entry.metadata().expect("all files have metadata");
+                if let Entry::Metadata(MetadataEntry::File(.., path, md, size)) = item.as_entry() {
+                    if segment.is_first() {
+                        // this is set on the root block, no actual bytes are present for multiblock
+                        // files
+                    }
 
-                if segment.is_first() {
-                    // this is set on the root block, no actual bytes are present for multiblock
-                    // files
+                    if segment.is_last() {
+                        let mode = md.mode().unwrap_or(0o0644) & 0o7777;
+                        let (seconds, _) = md.mtime().unwrap_or((0, 0));
+                        println!("f {:o} {:>12} {:>16} {:?}", mode, seconds, size, path);
+                    }
                 }
-
-                if segment.is_last() {
-                    let path = entry.path();
-                    let mode = metadata.mode().unwrap_or(0o0644) & 0o7777;
-                    let (seconds, _) = metadata.mtime().unwrap_or((0, 0));
-
-                    println!("f {:o} {:>12} {:>16} {:?}", mode, seconds, total_size, path);
-                }
-
-                // continue the walk
                 item.into_inner()
             }
             ContinuedWalk::Directory(item) => {
                 // presense of metadata can be used to determine if this is the first apperiance of
                 // a directory by looking at the metadata: sibling hamt shard buckets do not have
                 // metadata.
-                if let Some(metadata) = item.as_entry().metadata() {
+                if let Entry::Metadata(metadata_entry) = item.as_entry() {
+                    let metadata = metadata_entry.metadata();
                     let path = item.as_entry().path();
-
                     let mode = metadata.mode().unwrap_or(0o0755) & 0o7777;
                     let (seconds, _) = metadata.mtime().unwrap_or((0, 0));
-
                     println!("d {:o} {:>12} {:>16} {:?}", mode, seconds, "-", path);
                 }
-
                 item.into_inner()
             }
             ContinuedWalk::Symlink(bytes, item) => {
-                let entry = item.as_entry();
-                let metadata = entry.metadata().expect("symlink must have metadata");
-
-                let path = entry.path();
-                let target = Path::new(std::str::from_utf8(bytes).unwrap());
-                let mode = metadata.mode().unwrap_or(0o0755) & 0o7777;
-                let (seconds, _) = metadata.mtime().unwrap_or((0, 0));
-
-                println!(
-                    "s {:o} {:>12} {:>16} {:?} -> {:?}",
-                    mode, seconds, "-", path, target
-                );
-
+                if let Entry::Metadata(metadata_entry) = item.as_entry() {
+                    let metadata = metadata_entry.metadata();
+                    let path = metadata_entry.path();
+                    let target = Path::new(std::str::from_utf8(bytes).unwrap());
+                    let mode = metadata.mode().unwrap_or(0o0755) & 0o7777;
+                    let (seconds, _) = metadata.mtime().unwrap_or((0, 0));
+                    println!(
+                        "s {:o} {:>12} {:>16} {:?} -> {:?}",
+                        mode, seconds, "-", path, target
+                    );
+                }
                 item.into_inner()
             }
         };


### PR DESCRIPTION
Second take on #200 

`Entry` is now composed of `Bucket(...)` and `Metadata(MetadataEntry { ... })` to separate things that have and doesn't have metadata, which avoids returning optional values derived from a single entry-point.

Next PR will address the newly introduced double matching while iterating over `continue_walk` but it will require deeper logical changes.