### PR TITLE
improved tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ fn main() {
 
     task::block_on(async move {
         // Start daemon and initialize repo
-        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
+        let (ipfs, fut) = UninitializedIpfs::new(options, None).await.start().await.unwrap();
         task::spawn(fut);
 
         // Create a DAG

--- a/examples/client1.rs
+++ b/examples/client1.rs
@@ -9,7 +9,11 @@ fn main() {
     let options = IpfsOptions::<Types>::default();
 
     task::block_on(async move {
-        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
+        let (ipfs, fut) = UninitializedIpfs::new(options, None)
+            .await
+            .start()
+            .await
+            .unwrap();
         task::spawn(fut);
 
         let f1 = ipfs.put_dag(ipld!("block1"));

--- a/examples/client2.rs
+++ b/examples/client2.rs
@@ -11,7 +11,11 @@ fn main() {
         IpfsPath::from_str("/ipfs/zdpuB1caPcm4QNXeegatVfLQ839Lmprd5zosXGwRUBJHwj66X").unwrap();
 
     task::block_on(async move {
-        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
+        let (ipfs, fut) = UninitializedIpfs::new(options, None)
+            .await
+            .start()
+            .await
+            .unwrap();
         task::spawn(fut);
 
         let f1 = ipfs.get_dag(path.sub_path("0").unwrap());

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -40,7 +40,11 @@ fn main() {
 
     async_std::task::block_on(async move {
         // Start daemon and initialize repo
-        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
+        let (ipfs, fut) = UninitializedIpfs::new(options, None)
+            .await
+            .start()
+            .await
+            .unwrap();
         async_std::task::spawn(fut);
 
         let (public_key, addresses) = ipfs.identity().await.unwrap();

--- a/examples/ipfs_bitswap_test.rs
+++ b/examples/ipfs_bitswap_test.rs
@@ -16,7 +16,11 @@ fn main() {
 
     task::block_on(async move {
         // Start daemon and initialize repo
-        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
+        let (ipfs, fut) = UninitializedIpfs::new(options, None)
+            .await
+            .start()
+            .await
+            .unwrap();
         task::spawn(fut);
 
         let data = b"block-want\n".to_vec().into_boxed_slice();

--- a/examples/ipfs_ipns_test.rs
+++ b/examples/ipfs_ipns_test.rs
@@ -9,7 +9,11 @@ fn main() {
 
     task::block_on(async move {
         // Start daemon and initialize repo
-        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
+        let (ipfs, fut) = UninitializedIpfs::new(options, None)
+            .await
+            .start()
+            .await
+            .unwrap();
         task::spawn(fut);
 
         // Create a Block

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -134,8 +134,14 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
-        let opts: IpfsOptions<ipfs::TestTypes> =
-            IpfsOptions::new(home.clone().into(), keypair, Vec::new(), false, None);
+        let opts: IpfsOptions<ipfs::TestTypes> = IpfsOptions::new(
+            "local_node",
+            home.clone().into(),
+            keypair,
+            Vec::new(),
+            false,
+            None,
+        );
 
         let (ipfs, task) = UninitializedIpfs::new(opts)
             .await

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -134,16 +134,10 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
-        let opts: IpfsOptions<ipfs::TestTypes> = IpfsOptions::new(
-            "local_node",
-            home.clone().into(),
-            keypair,
-            Vec::new(),
-            false,
-            None,
-        );
+        let opts: IpfsOptions<ipfs::TestTypes> =
+            IpfsOptions::new(home.clone().into(), keypair, Vec::new(), false, None);
 
-        let (ipfs, task) = UninitializedIpfs::new(opts)
+        let (ipfs, task) = UninitializedIpfs::new(opts, None)
             .await
             .start()
             .await

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -119,7 +119,7 @@ mod tests {
         use super::routes;
         use ipfs::{IpfsOptions, UninitializedIpfs};
 
-        let options = IpfsOptions::inmemory_with_generated_keys();
+        let options = IpfsOptions::inmemory_with_generated_keys("test_node");
 
         let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
         drop(fut);

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -119,12 +119,14 @@ mod tests {
         use super::routes;
         use ipfs::{IpfsOptions, UninitializedIpfs};
 
-        let options = IpfsOptions::inmemory_with_generated_keys("test_node");
+        let options = IpfsOptions::inmemory_with_generated_keys();
+        let (ipfs, _) = UninitializedIpfs::new(options, None)
+            .await
+            .start()
+            .await
+            .unwrap();
 
-        let (ipfs, fut) = UninitializedIpfs::new(options).await.start().await.unwrap();
-        drop(fut);
-        let (shutdown_tx, shutdown_rx) = tokio::sync::mpsc::channel::<()>(1);
-        drop(shutdown_rx);
+        let (shutdown_tx, _) = tokio::sync::mpsc::channel::<()>(1);
 
         routes(&ipfs, shutdown_tx)
     }

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -806,7 +806,7 @@ mod tests {
     }
 
     async fn preloaded_testing_ipfs() -> Ipfs<ipfs::TestTypes> {
-        let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
+        let options = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
         let (ipfs, _) = ipfs::UninitializedIpfs::new(options)
             .await
             .start()

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -680,10 +680,7 @@ mod tests {
 
     #[tokio::test]
     async fn all_refs_from_root() {
-        let Node {
-            ipfs,
-            background_task: _bt,
-        } = preloaded_testing_ipfs().await;
+        let Node { ipfs, bg_task: _bt } = preloaded_testing_ipfs().await;
 
         let (root, dag0, unixfs0, dag1, unixfs1) = (
             // this is the dag with content: [dag0, unixfs0, dag1, unixfs1]
@@ -724,10 +721,7 @@ mod tests {
 
     #[tokio::test]
     async fn all_unique_refs_from_root() {
-        let Node {
-            ipfs,
-            background_task: _bt,
-        } = preloaded_testing_ipfs().await;
+        let Node { ipfs, bg_task: _bt } = preloaded_testing_ipfs().await;
 
         let (root, dag0, unixfs0, dag1, unixfs1) = (
             // this is the dag with content: [dag0, unixfs0, dag1, unixfs1]

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -334,7 +334,7 @@ mod tests {
 
     #[tokio::test]
     async fn very_long_file_and_symlink_names() {
-        let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
+        let options = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
         let (ipfs, _) = ipfs::UninitializedIpfs::new(options)
             .await
             .start()
@@ -395,7 +395,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_multiblock_file() {
-        let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
+        let options = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
         let (ipfs, _) = ipfs::UninitializedIpfs::new(options)
             .await
             .start()

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -282,7 +282,7 @@ impl std::error::Error for GetError {
 mod tests {
     use futures::stream::{FuturesOrdered, TryStreamExt};
     use hex_literal::hex;
-    use ipfs::{Block, Ipfs, IpfsTypes};
+    use ipfs::{Block, Ipfs, IpfsTypes, Node};
     use libipld::cid::Cid;
     use multihash::Sha2_256;
     use std::convert::TryFrom;
@@ -334,12 +334,7 @@ mod tests {
 
     #[tokio::test]
     async fn very_long_file_and_symlink_names() {
-        let options = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
-        let (ipfs, _) = ipfs::UninitializedIpfs::new(options)
-            .await
-            .start()
-            .await
-            .unwrap();
+        let ipfs = Node::new("test_node").await;
 
         let blocks: &[&[u8]] = &[
             // the root, QmdKuCuXDuVTsnGpzPgZEuJmiCEn6LZhGHHHwWPQH28DeD
@@ -395,12 +390,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_multiblock_file() {
-        let options = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
-        let (ipfs, _) = ipfs::UninitializedIpfs::new(options)
-            .await
-            .start()
-            .await
-            .unwrap();
+        let ipfs = Node::new("test_node").await;
 
         let blocks: &[&[u8]] = &[
             // the root, QmRJHYTNvC3hmd9gJQARxLR1QMEincccBV53bBw524yyq6

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -169,7 +169,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_single_block_file() {
-        let ipfs = testing_ipfs().await;
+        let ipfs = tokio_ipfs().await;
 
         // this is from interface-ipfs-core, pretty much simplest add a buffer test case
         // but the body content is from the pubsub test case I copied this from
@@ -198,7 +198,7 @@ mod tests {
         );
     }
 
-    async fn testing_ipfs() -> ipfs::Ipfs<ipfs::TestTypes> {
+    async fn tokio_ipfs() -> ipfs::Ipfs<ipfs::TestTypes> {
         let options = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
         let (ipfs, fut) = ipfs::UninitializedIpfs::new(options)
             .await

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -199,7 +199,7 @@ mod tests {
     }
 
     async fn testing_ipfs() -> ipfs::Ipfs<ipfs::TestTypes> {
-        let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
+        let options = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
         let (ipfs, fut) = ipfs::UninitializedIpfs::new(options)
             .await
             .start()

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -199,8 +199,8 @@ mod tests {
     }
 
     async fn tokio_ipfs() -> ipfs::Ipfs<ipfs::TestTypes> {
-        let options = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
-        let (ipfs, fut) = ipfs::UninitializedIpfs::new(options)
+        let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
+        let (ipfs, fut) = ipfs::UninitializedIpfs::new(options, None)
             .await
             .start()
             .await

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -94,12 +94,12 @@ fn resolve(ipld: Ipld, sub_path: &SubPath) -> Ipld {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::create_mock_ipfs;
+    use crate::Node;
     use libipld::ipld;
 
     #[async_std::test]
     async fn test_resolve_root_cid() {
-        let ipfs = create_mock_ipfs().await;
+        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data = ipld!([1, 2, 3]);
         let cid = dag.put(data.clone(), Codec::DagCBOR).await.unwrap();
@@ -109,7 +109,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_resolve_array_elem() {
-        let ipfs = create_mock_ipfs().await;
+        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data = ipld!([1, 2, 3]);
         let cid = dag.put(data.clone(), Codec::DagCBOR).await.unwrap();
@@ -122,7 +122,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_resolve_nested_array_elem() {
-        let ipfs = create_mock_ipfs().await;
+        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data = ipld!([1, [2], 3,]);
         let cid = dag.put(data, Codec::DagCBOR).await.unwrap();
@@ -135,7 +135,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_resolve_object_elem() {
-        let ipfs = create_mock_ipfs().await;
+        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data = ipld!({
             "key": false,
@@ -150,7 +150,7 @@ mod tests {
 
     #[async_std::test]
     async fn test_resolve_cid_elem() {
-        let ipfs = create_mock_ipfs().await;
+        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data1 = ipld!([1]);
         let cid1 = dag.put(data1, Codec::DagCBOR).await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ impl<Types: IpfsTypes> Clone for Ipfs<Types> {
 /// for interacting with IPFS.
 #[derive(Debug)]
 pub struct IpfsInner<Types: IpfsTypes> {
-    span: Span,
+    pub span: Span,
     repo: Repo<Types>,
     keys: DebuggableKeypair<Keypair>,
     to_task: Sender<IpfsEvent>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -281,6 +281,11 @@ pub struct UninitializedIpfs<Types: IpfsTypes> {
 
 impl<Types: IpfsTypes> UninitializedIpfs<Types> {
     /// Configures a new UninitializedIpfs with from the given options and optionally a span.
+    /// If the span is not given, it is defaulted to `tracing::trace_span!("ipfs")`.
+    ///
+    /// The span is attached to all operations called on the later created `Ipfs` along with all
+    /// operations done in the background task as well as tasks spawned by the underlying
+    /// `libp2p::Swarm`.
     pub async fn new(options: IpfsOptions<Types>, span: Option<Span>) -> Self {
         let repo_options = RepoOptions::<Types>::from(&options);
         let (repo, repo_events) = create_repo(repo_options);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -971,8 +971,8 @@ mod node {
     /// Node encapsulates everything to setup a testing instance so that multi-node tests become
     /// easier.
     pub struct Node {
-        ipfs: Ipfs<TestTypes>,
-        background_task: async_std::task::JoinHandle<()>,
+        pub ipfs: Ipfs<TestTypes>,
+        pub background_task: async_std::task::JoinHandle<()>,
     }
 
     impl Node {

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -71,12 +71,12 @@ impl Into<String> for File {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::create_mock_ipfs;
+    use crate::Node;
     use core::convert::TryFrom;
 
     #[async_std::test]
     async fn test_file_cid() {
-        let ipfs = create_mock_ipfs().await;
+        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let file = File::from("\u{8}\u{2}\u{12}\u{12}Here is some data\n\u{18}\u{12}");
         let cid = Cid::try_from("QmSy5pnHk1EnvE5dmJSyFKG5unXLGjPpBuJJCBQkBTvBaW").unwrap();

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -1,44 +1,19 @@
-use async_std::task;
+use ipfs::Node;
 
 // Make sure two instances of ipfs can be connected.
 #[async_std::test]
 async fn connect_two_nodes() {
-    let (tx, rx) = futures::channel::oneshot::channel();
+    let node_a = Node::new("a").await;
+    let node_b = Node::new("b").await;
 
-    let node_a = task::spawn(async move {
-        let opts = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
-        let (ipfs, fut) = ipfs::UninitializedIpfs::new(opts)
-            .await
-            .start()
-            .await
-            .unwrap();
+    let (_, b_addrs) = node_b.identity().await.unwrap();
+    assert!(!b_addrs.is_empty());
 
-        let jh = task::spawn(fut);
-
-        let (pk, addrs) = ipfs
-            .identity()
-            .await
-            .expect("failed to read identity() on node_a");
-        assert!(!addrs.is_empty());
-        tx.send((pk, addrs, ipfs, jh)).unwrap();
-    });
-
-    let (_other_pk, other_addrs, other_ipfs, other_jh) = rx.await.unwrap();
-
-    println!("got back from the other node: {:?}", other_addrs);
-
-    let opts = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
-    let (ipfs, fut) = ipfs::UninitializedIpfs::new(opts)
-        .await
-        .start()
-        .await
-        .unwrap();
-    let jh = task::spawn(fut);
     let mut connected = None;
 
-    for addr in other_addrs {
+    for addr in b_addrs {
         println!("trying {}", addr);
-        match ipfs.connect(addr.clone()).await {
+        match node_a.connect(addr.clone()).await {
             Ok(_) => {
                 connected = Some(addr);
                 break;
@@ -51,21 +26,14 @@ async fn connect_two_nodes() {
 
     let connected = connected.expect("Failed to connect to anything");
     println!("connected to {}", connected);
-
-    other_ipfs.exit_daemon().await;
-    other_jh.await;
-    node_a.await;
-
-    ipfs.exit_daemon().await;
-    jh.await;
 }
 
 // More complicated one to the above; first node will have two listening addresses and the second
 // one should dial both of the addresses, resulting in two connections.
 #[async_std::test]
 async fn connect_two_nodes_with_two_connections_doesnt_panic() {
-    let node_a = ipfs::Node::new("a").await;
-    let node_b = ipfs::Node::new("b").await;
+    let node_a = Node::new("a").await;
+    let node_b = Node::new("b").await;
 
     node_a
         .add_listening_address(libp2p::build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(0u16)))

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -6,7 +6,7 @@ async fn connect_two_nodes() {
     let (tx, rx) = futures::channel::oneshot::channel();
 
     let node_a = task::spawn(async move {
-        let opts = ipfs::IpfsOptions::inmemory_with_generated_keys();
+        let opts = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
         let (ipfs, fut) = ipfs::UninitializedIpfs::new(opts)
             .await
             .start()
@@ -27,7 +27,7 @@ async fn connect_two_nodes() {
 
     println!("got back from the other node: {:?}", other_addrs);
 
-    let opts = ipfs::IpfsOptions::inmemory_with_generated_keys();
+    let opts = ipfs::IpfsOptions::inmemory_with_generated_keys("test_node");
     let (ipfs, fut) = ipfs::UninitializedIpfs::new(opts)
         .await
         .start()
@@ -64,8 +64,8 @@ async fn connect_two_nodes() {
 // one should dial both of the addresses, resulting in two connections.
 #[async_std::test]
 async fn connect_two_nodes_with_two_connections_doesnt_panic() {
-    let node_a = ipfs::Node::new().await;
-    let node_b = ipfs::Node::new().await;
+    let node_a = ipfs::Node::new("a").await;
+    let node_b = ipfs::Node::new("b").await;
 
     node_a
         .add_listening_address(libp2p::build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(0u16)))

--- a/tests/exchange_block.rs
+++ b/tests/exchange_block.rs
@@ -11,8 +11,8 @@ async fn exchange_block() {
     let data = b"hello block\n".to_vec().into_boxed_slice();
     let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
 
-    let a = Node::new().await;
-    let b = Node::new().await;
+    let a = Node::new("a").await;
+    let b = Node::new("b").await;
 
     let (_, mut addrs) = b.identity().await.unwrap();
 

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -64,7 +64,7 @@ async fn kademlia_popular_content_discovery() {
 
     // introduce a peer and specify the Kademlia protocol to it
     // without a specified protocol, the test will not complete
-    let mut opts = IpfsOptions::inmemory_with_generated_keys("test_node");
+    let mut opts = IpfsOptions::inmemory_with_generated_keys();
     opts.kad_protocol = Some("/ipfs/lan/kad/1.0.0".to_owned());
     let peer = Node::with_options(opts).await;
 

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -10,8 +10,8 @@ async fn kademlia_local_peer_discovery() {
 
     // start up PEER_COUNT bootstrapper nodes
     let mut bootstrappers = Vec::with_capacity(BOOTSTRAPPER_COUNT);
-    for _ in 0..BOOTSTRAPPER_COUNT {
-        bootstrappers.push(Node::new().await);
+    for i in 0..BOOTSTRAPPER_COUNT {
+        bootstrappers.push(Node::new(format!("bootstrapper_{}", i)).await);
     }
 
     // register the bootstrappers' ids and addresses
@@ -37,7 +37,7 @@ async fn kademlia_local_peer_discovery() {
     }
 
     // introduce a peer and connect it to one of the bootstrappers
-    let peer = Node::new().await;
+    let peer = Node::new("peer").await;
     assert!(peer
         .add_peer(
             bootstrapper_ids[0].0.clone(),
@@ -64,7 +64,7 @@ async fn kademlia_popular_content_discovery() {
 
     // introduce a peer and specify the Kademlia protocol to it
     // without a specified protocol, the test will not complete
-    let mut opts = IpfsOptions::inmemory_with_generated_keys();
+    let mut opts = IpfsOptions::inmemory_with_generated_keys("test_node");
     opts.kad_protocol = Some("/ipfs/lan/kad/1.0.0".to_owned());
     let peer = Node::with_options(opts).await;
 

--- a/tests/multiple_listening_addresses.rs
+++ b/tests/multiple_listening_addresses.rs
@@ -1,6 +1,6 @@
 #[async_std::test]
 async fn multiple_consecutive_ephemeral_listening_addresses() {
-    let node = ipfs::Node::new().await;
+    let node = ipfs::Node::new("test_node").await;
 
     let target = libp2p::build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(0u16));
 
@@ -14,7 +14,7 @@ async fn multiple_consecutive_ephemeral_listening_addresses() {
 
 #[async_std::test]
 async fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
-    let node = ipfs::Node::new().await;
+    let node = ipfs::Node::new("test_node").await;
 
     let target = libp2p::build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(0u16));
 
@@ -44,7 +44,7 @@ async fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
 #[async_std::test]
 #[cfg(not(target_os = "macos"))]
 async fn multiple_concurrent_ephemeral_listening_addresses_on_different_ip() {
-    let node = ipfs::Node::new().await;
+    let node = ipfs::Node::new("test_node").await;
 
     // it doesnt work on mac os x as 127.0.0.2 is not enabled by default.
     let first =
@@ -61,7 +61,7 @@ async fn multiple_concurrent_ephemeral_listening_addresses_on_different_ip() {
 
 #[async_std::test]
 async fn adding_unspecified_addr_resolves_with_first() {
-    let node = ipfs::Node::new().await;
+    let node = ipfs::Node::new("test_node").await;
     // there is no test in trying to match this with others as ... that would be quite
     // perilous.
     node.add_listening_address(libp2p::build_multiaddr!(Ip4([0, 0, 0, 0]), Tcp(0u16)))
@@ -71,7 +71,7 @@ async fn adding_unspecified_addr_resolves_with_first() {
 
 #[async_std::test]
 async fn listening_for_multiple_unspecified_addresses() {
-    let node = ipfs::Node::new().await;
+    let node = ipfs::Node::new("test_node").await;
     // there is no test in trying to match this with others as ... that would be quite
     // perilous.
     let target = libp2p::build_multiaddr!(Ip4([0, 0, 0, 0]), Tcp(0u16));
@@ -95,7 +95,7 @@ async fn listening_for_multiple_unspecified_addresses() {
 
 #[async_std::test]
 async fn remove_listening_address() {
-    let node = ipfs::Node::new().await;
+    let node = ipfs::Node::new("test_node").await;
 
     let unbound = libp2p::build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(0u16));
     let first = node.add_listening_address(unbound.clone()).await.unwrap();

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -5,14 +5,14 @@ use std::time::Duration;
 
 #[async_std::test]
 async fn subscribe_only_once() {
-    let a = Node::new().await;
+    let a = Node::new("test_node").await;
     let _stream = a.pubsub_subscribe("some_topic".into()).await.unwrap();
     a.pubsub_subscribe("some_topic".into()).await.unwrap_err();
 }
 
 #[async_std::test]
 async fn resubscribe_after_unsubscribe() {
-    let a = Node::new().await;
+    let a = Node::new("test_node").await;
 
     let mut stream = a.pubsub_subscribe("topic".into()).await.unwrap();
     a.pubsub_unsubscribe("topic").await.unwrap();
@@ -24,7 +24,7 @@ async fn resubscribe_after_unsubscribe() {
 
 #[async_std::test]
 async fn unsubscribe_via_drop() {
-    let a = Node::new().await;
+    let a = Node::new("test_node").await;
 
     let msgs = a.pubsub_subscribe("topic".into()).await.unwrap();
     assert_eq!(a.pubsub_subscribed().await.unwrap(), &["topic"]);
@@ -37,7 +37,7 @@ async fn unsubscribe_via_drop() {
 
 #[async_std::test]
 async fn can_publish_without_subscribing() {
-    let a = Node::new().await;
+    let a = Node::new("test_node").await;
     a.pubsub_publish("topic".into(), b"foobar".to_vec())
         .await
         .unwrap()
@@ -132,8 +132,8 @@ async fn publish_between_two_nodes() {
 }
 
 async fn two_connected_nodes() -> ((Node, PeerId), (Node, PeerId)) {
-    let a = Node::new().await;
-    let b = Node::new().await;
+    let a = Node::new("a").await;
+    let b = Node::new("b").await;
 
     let (a_pk, _) = a.identity().await.unwrap();
     let a_id = a_pk.into_peer_id();

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -50,6 +50,8 @@ async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) 
 /// Check if canceling a Cid affects the wantlist.
 #[async_std::test]
 async fn wantlist_cancellation() {
+    tracing_subscriber::fmt::init();
+
     // start a single node
     let ipfs = Node::new("test_node").await;
 

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -51,7 +51,7 @@ async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) 
 #[async_std::test]
 async fn wantlist_cancellation() {
     // start a single node
-    let ipfs = Node::new().await;
+    let ipfs = Node::new("test_node").await;
 
     // execute a get_block request
     let cid = Cid::try_from("QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KaGa").unwrap();


### PR DESCRIPTION
An attempt to have enhanced tracing capabilities, especially for test purposes; not everything is nicely assigned to a specific node, but it is definitely an improvement over what we have now.

This change allows us to see the following output in e.g. `exchange_block`:
```
running 1 test
Jul 30 16:13:42.567  INFO start{node="a"}: ipfs::p2p::behaviour: net: starting with peer id 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox
Jul 30 16:13:42.577 DEBUG start{node="a"}: bitswap::behaviour: bitswap: new_handler
Jul 30 16:13:42.577 TRACE start{node="a"}: ipfs::p2p::swarm: new_handler
Jul 30 16:13:42.578 DEBUG bgtask{node="a"}: libp2p_tcp: Listening on "/ip4/127.0.0.1/tcp/35821"    
Jul 30 16:13:42.579  INFO start{node="b"}: ipfs::p2p::behaviour: net: starting with peer id 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc
Jul 30 16:13:42.579 DEBUG bgtask{node="a"}: libp2p_swarm: Listener ListenerId(1); New address: "/ip4/127.0.0.1/tcp/35821"    
Jul 30 16:13:42.589 DEBUG start{node="b"}: bitswap::behaviour: bitswap: new_handler
Jul 30 16:13:42.589 TRACE start{node="b"}: ipfs::p2p::swarm: new_handler
Jul 30 16:13:42.590 DEBUG bgtask{node="b"}: libp2p_tcp: Listening on "/ip4/127.0.0.1/tcp/43797"    
Jul 30 16:13:42.590 DEBUG bgtask{node="b"}: libp2p_swarm: Listener ListenerId(1); New address: "/ip4/127.0.0.1/tcp/43797"    
Jul 30 16:13:42.590 TRACE bgtask{node="a"}: ipfs::p2p::swarm: starting to connect to /ip4/127.0.0.1/tcp/43797
Jul 30 16:13:42.590 DEBUG bgtask{node="a"}: ipfs::subscription: Creating subscription 0 to Connect to /ip4/127.0.0.1/tcp/43797
Jul 30 16:13:42.590 DEBUG bgtask{node="a"}: bitswap::behaviour: bitswap: new_handler
Jul 30 16:13:42.590 TRACE bgtask{node="a"}: ipfs::p2p::swarm: new_handler
Jul 30 16:13:42.590 DEBUG bgtask{node="a"}: libp2p_tcp: Dialing /ip4/127.0.0.1/tcp/43797    
Jul 30 16:13:42.591 TRACE bgtask{node="b"}: libp2p_tcp: Incoming connection from /ip4/127.0.0.1/tcp/51178 at /ip4/127.0.0.1/tcp/43797    
Jul 30 16:13:42.591 DEBUG bgtask{node="b"}: bitswap::behaviour: bitswap: new_handler
Jul 30 16:13:42.591 TRACE bgtask{node="b"}: ipfs::p2p::swarm: new_handler
Jul 30 16:13:42.591 TRACE bgtask{node="b"}: ipfs: IncomingConnection { local_addr: "/ip4/127.0.0.1/tcp/43797", send_back_addr: "/ip4/127.0.0.1/tcp/51178" }
Jul 30 16:13:42.595 DEBUG bgtask{node="b"}: libp2p_swarm: Connection established: Connected { endpoint: Listener { local_addr: "/ip4/127.0.0.1/tcp/43797", send_back_addr: "/ip4/127.0.0.1/tcp/51178" }, info: PeerId("12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox") }; Total (peer): 1.    
Jul 30 16:13:42.595 TRACE bgtask{node="b"}: ipfs::p2p::swarm: inject_connected 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox Listener { local_addr: "/ip4/127.0.0.1/tcp/43797", send_back_addr: "/ip4/127.0.0.1/tcp/51178" }
Jul 30 16:13:42.595 DEBUG bgtask{node="b"}: ipfs::subscription: Finishing the subscription to Connect to /ip4/127.0.0.1/tcp/51178
Jul 30 16:13:42.595 DEBUG bgtask{node="b"}: bitswap::behaviour: bitswap: inject_connected 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox
Jul 30 16:13:42.595 TRACE bgtask{node="b"}: ipfs: ConnectionEstablished { peer_id: PeerId("12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox"), endpoint: Listener { local_addr: "/ip4/127.0.0.1/tcp/43797", send_back_addr: "/ip4/127.0.0.1/tcp/51178" }, num_established: 1 }
Jul 30 16:13:42.595 DEBUG bgtask{node="a"}: libp2p_swarm: Connection established: Connected { endpoint: Dialer { address: "/ip4/127.0.0.1/tcp/43797" }, info: PeerId("12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc") }; Total (peer): 1.    
Jul 30 16:13:42.595 TRACE bgtask{node="b"}: ipfs::p2p::behaviour: kad: peer 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox is unroutable
Jul 30 16:13:42.595 TRACE bgtask{node="a"}: ipfs::p2p::swarm: inject_connected 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc Dialer { address: "/ip4/127.0.0.1/tcp/43797" }
Jul 30 16:13:42.596 DEBUG bgtask{node="a"}: ipfs::subscription: Finishing the subscription to Connect to /ip4/127.0.0.1/tcp/43797
Jul 30 16:13:42.596 TRACE ipfs::subscription: Dropping subscription 0 to Connect to /ip4/127.0.0.1/tcp/43797
Jul 30 16:13:42.596 DEBUG bgtask{node="a"}: bitswap::behaviour: bitswap: inject_connected 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc
Jul 30 16:13:42.596 TRACE facade{node="a"}: ipfs::repo::mem: new block
Jul 30 16:13:42.596 TRACE bgtask{node="a"}: ipfs: ConnectionEstablished { peer_id: PeerId("12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc"), endpoint: Dialer { address: "/ip4/127.0.0.1/tcp/43797" }, num_established: 1 }
Jul 30 16:13:42.596 DEBUG facade{node="a"}: ipfs::subscription: Finishing the subscription to Obtain block bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
Jul 30 16:13:42.596 DEBUG facade{node="b"}: ipfs::subscription: Creating subscription 1 to Obtain block bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
Jul 30 16:13:42.596 TRACE bgtask{node="a"}: ipfs::p2p::behaviour: kad: routing updated; 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc: ["/ip4/127.0.0.1/tcp/43797"]
Jul 30 16:13:42.597 TRACE bgtask{node="b"}: libp2p_kad::behaviour: Query QueryId(0) finished.    
Jul 30 16:13:42.597 DEBUG bgtask{node="b"}: ipfs::subscription: Finishing the subscription to Kad request QueryId(0)
Jul 30 16:13:42.597  WARN bgtask{node="b"}: ipfs::p2p::behaviour: kad: could not find a provider for bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
Jul 30 16:13:42.600 TRACE bgtask{node="a"}: ipfs::p2p::behaviour: ping: pong from 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc
Jul 30 16:13:42.601 TRACE bgtask{node="b"}: ipfs::p2p::behaviour: ping: pong from 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox
Jul 30 16:13:42.602 DEBUG bitswap::protocol: upgrade_outbound: /ipfs/bitswap/1.1.0
Jul 30 16:13:42.602 DEBUG bgtask{node="a"}: bitswap::behaviour: bitswap: inject_event from 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc: (empty message)
Jul 30 16:13:42.603 TRACE bgtask{node="a"}: ipfs::p2p::behaviour: ping: rtt to 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc is 4 ms
Jul 30 16:13:42.603 DEBUG bgtask{node="b"}: bitswap::behaviour: bitswap: inject_event from 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox: cancel: bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
Jul 30 16:13:42.604 TRACE bgtask{node="b"}: ipfs::p2p::behaviour: ping: rtt to 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox is 3 ms
Jul 30 16:13:42.604 TRACE bgtask{node="a"}: libp2p_kad::behaviour: Request to PeerId("12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc") in query QueryId(0) succeeded.    
Jul 30 16:13:42.604 TRACE bgtask{node="a"}: libp2p_kad::behaviour: Query QueryId(0) finished.    
Jul 30 16:13:42.604 TRACE bgtask{node="a"}: libp2p_kad::behaviour: Query QueryId(0) finished.    
Jul 30 16:13:42.604 DEBUG bgtask{node="a"}: ipfs::subscription: Finishing the subscription to Kad request QueryId(0)
Jul 30 16:13:42.604  INFO bgtask{node="a"}: ipfs::p2p::behaviour: kad: providing bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
Jul 30 16:13:42.605 TRACE libp2p_kad::handler: Inbound substream: EOF    
Jul 30 16:13:42.605 DEBUG bitswap::protocol: upgrade_outbound: /ipfs/bitswap/1.1.0
Jul 30 16:13:42.605 DEBUG bgtask{node="b"}: bitswap::behaviour: bitswap: inject_event from 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox: (empty message)
Jul 30 16:13:42.606 DEBUG bgtask{node="a"}: bitswap::behaviour: bitswap: inject_event from 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc: want: bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i 1
Jul 30 16:13:42.606  INFO bgtask{node="a"}: ipfs::p2p::behaviour: Peer 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc wants block bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i with priority 1
Jul 30 16:13:42.607 TRACE bgtask{node="a"}: bitswap::behaviour: queueing block to be sent to 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc: bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
Jul 30 16:13:42.608 DEBUG bitswap::protocol: upgrade_outbound: /ipfs/bitswap/1.1.0
Jul 30 16:13:42.609 DEBUG bgtask{node="a"}: bitswap::behaviour: bitswap: inject_event from 12D3KooWMYo2VuqaAE4pajBEs6mrPYND6WQrCkTF7NP1JoeQvwpc: (empty message)
Jul 30 16:13:42.609 DEBUG bgtask{node="b"}: bitswap::behaviour: bitswap: inject_event from 12D3KooWKnZGUipX95ZGzqpQhPQ637euKNJ6b57H99mQcTt1hvox: block: bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
Jul 30 16:13:42.610 TRACE ipfs::repo::mem: new block
Jul 30 16:13:42.610 DEBUG ipfs::subscription: Finishing the subscription to Obtain block bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
Jul 30 16:13:42.610 TRACE facade{node="b"}: ipfs::subscription: Dropping subscription 1 to Obtain block bafkreidisjp6jmjonhw67p4j2cwwr2lohkce3lqrkjwcngr6lqgsjb6g2i
test exchange_block ... ok
```