### PR TITLE
Add the means to connect by PeerId

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,7 +479,7 @@ version = "2.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -1823,6 +1832,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +2615,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder 1.3.4",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,6 +3362,10 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7b33f8b2ef2ab0c3778c12646d9c42a24f7772bee4cdafc72199644a9f58fdc"
 dependencies = [
+ "ansi_term 0.12.1",
+ "lazy_static",
+ "matchers",
+ "regex",
  "sharded-slab",
  "tracing-core",
  "tracing-log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ prost-build = { default-features = false, version = "0.6" }
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
-tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.2" }
+tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
 
 [workspace]
 members = [ "bitswap", "http", "unixfs" ]

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -1,5 +1,5 @@
 use super::pubsub::Pubsub;
-use super::swarm::{Connection, Disconnector, SwarmApi};
+use super::swarm::{Connection, ConnectionTarget, Disconnector, SwarmApi};
 use crate::p2p::{SwarmOptions, SwarmTypes};
 use crate::repo::BlockPut;
 use crate::subscription::{SubscriptionFuture, SubscriptionRegistry};
@@ -411,8 +411,8 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         self.swarm.connections()
     }
 
-    pub fn connect(&mut self, addr: Multiaddr) -> SubscriptionFuture<Result<(), String>> {
-        self.swarm.connect(addr)
+    pub fn connect(&mut self, target: ConnectionTarget) -> SubscriptionFuture<Result<(), String>> {
+        self.swarm.connect(target)
     }
 
     pub fn disconnect(&mut self, addr: Multiaddr) -> Option<Disconnector> {

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -13,7 +13,7 @@ pub(crate) mod pubsub;
 mod swarm;
 mod transport;
 
-pub use swarm::Connection;
+pub use swarm::{Connection, ConnectionTarget};
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 


### PR DESCRIPTION
I've encountered this while working on improved bitswap <> kademlia interop - we still can't easily connect using `PeerId`. Improve this by introducing an `enum ConnectionTarget` that is either a `Multiaddr` or a `PeerId` and adjusting the `SwarmApi.connect_registry` accordingly. There's also a new related test.

As a drive-by, adjust some `tracing` features that are among the defaults but we'd still enjoy having :smiley:.