### PR TITLE
Update filetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -846,9 +846,9 @@ checksum = "36a9cb09840f81cd211e435d00a4e487edd263dc3c8ff815c32dd76ad668ebed"
 
 [[package]]
 name = "filetime"
-version = "0.2.8"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ff6d4dab0aa0c8e6346d46052e93b13a16cf847b54ed357087c35011048cc7d"
+checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1185,9 +1185,9 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hex-literal"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc38ca401ca1b8d89ff1185e39a132e5c4f86d844c0cf6364251576f2d7fa0c1"
+checksum = "5af1f635ef1bc545d78392b136bfe1c9809e029023c84a3638a864a10b8819c8"
 
 [[package]]
 name = "hmac"
@@ -3406,9 +3406,9 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "173cd16430c206dc1a430af8a89a0e9c076cf15cb42b4aedb10e8cc8fee73681"
+checksum = "429ffcad8c8c15f874578c7337d156a3727eb4a1c2374c0ae937ad9a9b748c80"
 dependencies = [
  "byteorder 1.3.4",
  "crunchy",

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -14,7 +14,7 @@ default = ["filetime"]
 [dependencies]
 cid = { default-features = false, version = "0.5" }
 either = { default-features = false, version = "1.5" }
-filetime = { optional = true, version = "=0.2.8" }
+filetime = { optional = true, version = "0.2.12" }
 multihash = { default-features = false, version = "0.11" }
 quick-protobuf = { default-features = false, features = ["std"], version = "0.7" }
 sha2 = { default-features = false, version = "0.9" }


### PR DESCRIPTION
Sets `0.2.12` as the minimum required version because of https://github.com/alexcrichton/filetime/issues/62