### PR TITLE
Allow connecting by peer id + addresses

### DIFF
--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -6,6 +6,7 @@ use libp2p::swarm::protocols_handler::{
 };
 use libp2p::swarm::{self, DialPeerCondition, NetworkBehaviour, PollParameters, Swarm};
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::{Hash, Hasher};
 use std::time::Duration;
 
 /// A description of currently active connection.
@@ -19,10 +20,43 @@ pub struct Connection {
     pub rtt: Option<Duration>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone)]
 pub enum ConnectionTarget {
     Addr(Multiaddr),
     PeerId(PeerId),
+    PeerWithAddrs(PeerId, Vec<Multiaddr>),
+}
+
+impl PartialEq for ConnectionTarget {
+    fn eq(&self, other: &Self) -> bool {
+        match self {
+            Self::Addr(addr) => match other {
+                Self::PeerWithAddrs(_, addrs) => addrs.contains(addr),
+                Self::Addr(peer_addr) => peer_addr == addr,
+                Self::PeerId(_) => false,
+            },
+            Self::PeerId(id) => match other {
+                Self::PeerWithAddrs(peer_id, _) => peer_id == id,
+                Self::PeerId(peer_id) => peer_id == id,
+                Self::Addr(_) => false,
+            },
+            Self::PeerWithAddrs(id, addrs) => match other {
+                Self::PeerId(peer_id) => peer_id == id,
+                Self::Addr(peer_addr) => addrs.contains(peer_addr),
+                Self::PeerWithAddrs(peer_id, _) => peer_id == id,
+            },
+        }
+    }
+}
+impl Eq for ConnectionTarget {}
+
+impl Hash for ConnectionTarget {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Addr(addr) => addr.hash(state),
+            Self::PeerId(id) | Self::PeerWithAddrs(id, _) => id.hash(state),
+        }
+    }
 }
 
 impl From<Multiaddr> for ConnectionTarget {
@@ -34,6 +68,12 @@ impl From<Multiaddr> for ConnectionTarget {
 impl From<PeerId> for ConnectionTarget {
     fn from(peer_id: PeerId) -> Self {
         Self::PeerId(peer_id)
+    }
+}
+
+impl From<(PeerId, Vec<Multiaddr>)> for ConnectionTarget {
+    fn from((peer_id, addrs): (PeerId, Vec<Multiaddr>)) -> Self {
+        Self::PeerWithAddrs(peer_id, addrs)
     }
 }
 
@@ -108,15 +148,26 @@ impl SwarmApi {
     pub fn connect(&mut self, target: ConnectionTarget) -> SubscriptionFuture<Result<(), String>> {
         trace!("Connecting to {:?}", target);
 
-        self.events.push_back(match target {
-            ConnectionTarget::Addr(ref addr) => NetworkBehaviourAction::DialAddress {
-                address: addr.clone(),
-            },
-            ConnectionTarget::PeerId(ref id) => NetworkBehaviourAction::DialPeer {
-                peer_id: id.clone(),
-                condition: DialPeerCondition::Disconnected,
-            },
-        });
+        match target {
+            ConnectionTarget::Addr(ref addr) => {
+                self.events.push_back(NetworkBehaviourAction::DialAddress {
+                    address: addr.clone(),
+                })
+            }
+            ConnectionTarget::PeerId(ref id) => {
+                self.events.push_back(NetworkBehaviourAction::DialPeer {
+                    peer_id: id.clone(),
+                    condition: DialPeerCondition::Disconnected,
+                })
+            }
+            ConnectionTarget::PeerWithAddrs(ref _peer_id, ref addrs) => {
+                for addr in addrs {
+                    self.events.push_back(NetworkBehaviourAction::DialAddress {
+                        address: addr.clone(),
+                    })
+                }
+            }
+        };
 
         self.connect_registry
             .create_subscription(target.into(), None)

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -53,7 +53,11 @@ impl From<PeerId> for RequestKind {
 
 impl From<ConnectionTarget> for RequestKind {
     fn from(target: ConnectionTarget) -> Self {
-        Self::Connect(target)
+        match target {
+            ConnectionTarget::Addr(addr) => addr.into(),
+            ConnectionTarget::PeerId(id) => id.into(),
+            ConnectionTarget::PeerWithAddrs(peer_id, _) => peer_id.into(),
+        }
     }
 }
 

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -1,5 +1,4 @@
 use ipfs::Node;
-use libp2p::PeerId;
 
 // Make sure two instances of ipfs can be connected.
 #[async_std::test]
@@ -29,7 +28,7 @@ async fn connect_two_nodes_by_peer_id() {
     let node_b = Node::new("b").await;
 
     let (b_key, mut b_addrs) = node_b.identity().await.unwrap();
-    let b_id = PeerId::from_public_key(b_key);
+    let b_id = b_key.into_peer_id();
 
     while let Some(addr) = b_addrs.pop() {
         node_a.add_peer(b_id.clone(), addr).await.unwrap();


### PR DESCRIPTION
An extension of https://github.com/rs-ipfs/rust-ipfs/pull/277. I'm not 100% sure how to proceed here, so bear with me.

The main assumption here is that connecting by `PeerId` + `Multiaddr`(s) is the preferable means of connecting to IPFS nodes, though doing that via `libp2p` makes me wonder about the approach - the reason being that `NetworkBehaviourAction`s dial options are **either** by _a_ `Multiaddr` or by a `PeerId`.

The choice I've made here was to attempt multiple connections by `Multiaddr` if the `PeerId`+`Vec<Multiaddr>` combo is provided. The fancy `PartialEq` and `Hash` implementations are needed in order to satisfy the needs of the `SubscriptionRegistry` applicable to connections; the current assumption is that any successful connection that is characterized by the given `PeerId` or any of the `Multiaddr`s (sent with it) fulfills the subscription to that connection request.