### PR TITLE
Some Kademlia debugging

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1002,11 +1002,11 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                 match evt {
                     RepoEvent::WantBlock(cid) => self.swarm.want_block(cid),
                     RepoEvent::UnwantBlock(cid) => self.swarm.bitswap().cancel_block(&cid),
-                    RepoEvent::ProvideBlock(cid) => {
+                    RepoEvent::ProvideBlock(cid, ret) => {
                         // TODO: consider if cancel is applicable in cases where we provide the
                         // associated Block ourselves
                         self.swarm.bitswap().cancel_block(&cid);
-                        self.swarm.provide_block(cid)
+                        let _ = ret.send(self.swarm.provide_block(cid));
                     }
                     RepoEvent::UnprovideBlock(cid) => self.swarm.stop_providing_block(&cid),
                 }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -433,13 +433,19 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         &mut self,
         cid: Cid,
     ) -> Result<SubscriptionFuture<(), String>, anyhow::Error> {
-        let key = cid.to_bytes();
-        match self.kademlia.start_providing(key.into()) {
-            // Kademlia queries are marked with QueryIds, which are most fitting to
-            // be used as kad Subscription keys - they are small and require no
-            // conversion for the applicable finish_subscription calls
-            Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
-            Err(e) => Err(anyhow!("kad: can't provide block {}: {:?}", cid, e)),
+        // currently disabled; see https://github.com/rs-ipfs/rust-ipfs/pull/281#discussion_r465583345
+        // for details regarding the concerns about enabling this functionality as-is
+        if false {
+            let key = cid.to_bytes();
+            match self.kademlia.start_providing(key.into()) {
+                // Kademlia queries are marked with QueryIds, which are most fitting to
+                // be used as kad Subscription keys - they are small and require no
+                // conversion for the applicable finish_subscription calls
+                Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
+                Err(e) => Err(anyhow!("kad: can't provide block {}: {:?}", cid, e)),
+            }
+        } else {
+            Err(anyhow!("providing blocks is currently unsupported"))
         }
     }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -427,20 +427,14 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         self.bitswap.want_block(cid, 1);
     }
 
-    // FIXME: it would probably be best if this could return a SubscriptionFuture, so
-    // that the put_block operation truly finishes only when the block is already being
-    // provided; it is, however, pretty tricky in terms of internal communication between
-    // Ipfs and IpfsFuture objects - it would currently require some extra back-and-forth
-    pub fn provide_block(&mut self, cid: Cid) {
+    pub fn provide_block(
+        &mut self,
+        cid: Cid,
+    ) -> Result<SubscriptionFuture<Result<(), String>>, anyhow::Error> {
         let key = cid.to_bytes();
         match self.kademlia.start_providing(key.into()) {
-            Ok(_id) => {
-                // Ok(self.kad_subscriptions.create_subscription(id.into(), None))
-            }
-            Err(e) => {
-                error!("kad: can't provide block {}: {:?}", cid, e);
-                // Err(anyhow!("kad: can't provide block {}", key))
-            }
+            Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
+            Err(e) => Err(anyhow!("kad: can't provide block {}: {:?}", cid, e)),
         }
     }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -369,7 +369,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
             options.keypair.public(),
         );
         let pubsub = Pubsub::new(options.peer_id);
-        let swarm = SwarmApi::new();
+        let swarm = SwarmApi::default();
 
         Behaviour {
             ipfs,

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -84,7 +84,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                     }
                     GetClosestPeers(Ok(GetClosestPeersOk { key: _, peers })) => {
                         for peer in peers {
-                            info!("kad: peer {} is close", peer);
+                            debug!("kad: peer {} is close", peer);
                         }
                     }
                     GetClosestPeers(Err(GetClosestPeersError::Timeout { key: _, peers })) => {
@@ -92,7 +92,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                             "kad: timed out trying to find all closest peers; got the following:"
                         );
                         for peer in peers {
-                            info!("kad: peer {} is close", peer);
+                            debug!("kad: peer {} is close", peer);
                         }
                     }
                     GetProviders(Ok(GetProvidersOk {
@@ -105,7 +105,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                             warn!("kad: could not find a provider for {}", key);
                         } else {
                             for peer in closest_peers.into_iter().chain(providers.into_iter()) {
-                                info!("kad: {} is provided by {}", key, peer);
+                                debug!("kad: {} is provided by {}", key, peer);
                                 self.bitswap.connect(peer);
                             }
                         }
@@ -116,7 +116,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                     }
                     StartProviding(Ok(AddProviderOk { key })) => {
                         let key = multibase::encode(Base::Base32Lower, key);
-                        info!("kad: providing {}", key);
+                        debug!("kad: providing {}", key);
                     }
                     StartProviding(Err(AddProviderError::Timeout { key })) => {
                         let key = multibase::encode(Base::Base32Lower, key);
@@ -124,7 +124,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                     }
                     RepublishProvider(Ok(AddProviderOk { key })) => {
                         let key = multibase::encode(Base::Base32Lower, key);
-                        info!("kad: republished provider {}", key);
+                        debug!("kad: republished provider {}", key);
                     }
                     RepublishProvider(Err(AddProviderError::Timeout { key })) => {
                         let key = multibase::encode(Base::Base32Lower, key);
@@ -133,7 +133,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                     GetRecord(Ok(GetRecordOk { records })) => {
                         for record in records {
                             let key = multibase::encode(Base::Base32Lower, record.record.key);
-                            info!("kad: got record {}:{:?}", key, record.record.value);
+                            debug!("kad: got record {}:{:?}", key, record.record.value);
                         }
                     }
                     GetRecord(Err(GetRecordError::NotFound {
@@ -156,7 +156,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                         );
                         for record in records {
                             let key = multibase::encode(Base::Base32Lower, record.record.key);
-                            info!("kad: got record {}:{:?}", key, record.record.value);
+                            debug!("kad: got record {}:{:?}", key, record.record.value);
                         }
                     }
                     GetRecord(Err(GetRecordError::Timeout {
@@ -172,13 +172,13 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                         );
                         for record in records {
                             let key = multibase::encode(Base::Base32Lower, record.record.key);
-                            info!("kad: got record {}:{:?}", key, record.record.value);
+                            debug!("kad: got record {}:{:?}", key, record.record.value);
                         }
                     }
                     PutRecord(Ok(PutRecordOk { key }))
                     | RepublishRecord(Ok(PutRecordOk { key })) => {
                         let key = multibase::encode(Base::Base32Lower, key);
-                        info!("kad: successfully put record {}", key);
+                        debug!("kad: successfully put record {}", key);
                     }
                     PutRecord(Err(PutRecordError::QuorumFailed {
                         key,
@@ -191,7 +191,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                         quorum,
                     })) => {
                         let key = multibase::encode(Base::Base32Lower, key);
-                        info!(
+                        warn!(
                             "kad: quorum failed ({}) trying to put record {}",
                             quorum, key
                         );
@@ -207,7 +207,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                         quorum: _,
                     })) => {
                         let key = multibase::encode(Base::Base32Lower, key);
-                        info!("kad: timed out trying to put record {}", key);
+                        warn!("kad: timed out trying to put record {}", key);
                     }
                 }
             }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -84,10 +84,12 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                     }
                     GetClosestPeers(Ok(GetClosestPeersOk { key: _, peers })) => {
                         for peer in peers {
+                            // don't mention the key here, as this is just the id of our node
                             debug!("kad: peer {} is close", peer);
                         }
                     }
                     GetClosestPeers(Err(GetClosestPeersError::Timeout { key: _, peers })) => {
+                        // don't mention the key here, as this is just the id of our node
                         warn!(
                             "kad: timed out trying to find all closest peers; got the following:"
                         );

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -433,6 +433,9 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     ) -> Result<SubscriptionFuture<(), String>, anyhow::Error> {
         let key = cid.to_bytes();
         match self.kademlia.start_providing(key.into()) {
+            // Kademlia queries are marked with QueryIds, which are most fitting to
+            // be used as kad Subscription keys - they are small and require no
+            // conversion for the applicable finish_subscription calls
             Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
             Err(e) => Err(anyhow!("kad: can't provide block {}: {:?}", cid, e)),
         }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -28,7 +28,7 @@ pub struct Behaviour<Types: IpfsTypes> {
     mdns: Toggle<Mdns>,
     kademlia: Kademlia<MemoryStore>,
     #[behaviour(ignore)]
-    kad_subscriptions: SubscriptionRegistry<Result<(), String>>,
+    kad_subscriptions: SubscriptionRegistry<(), String>,
     bitswap: Bitswap,
     ping: Ping,
     identify: Identify,
@@ -411,7 +411,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         self.swarm.connections()
     }
 
-    pub fn connect(&mut self, target: ConnectionTarget) -> SubscriptionFuture<Result<(), String>> {
+    pub fn connect(&mut self, target: ConnectionTarget) -> SubscriptionFuture<(), String> {
         self.swarm.connect(target)
     }
 
@@ -430,7 +430,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     pub fn provide_block(
         &mut self,
         cid: Cid,
-    ) -> Result<SubscriptionFuture<Result<(), String>>, anyhow::Error> {
+    ) -> Result<SubscriptionFuture<(), String>, anyhow::Error> {
         let key = cid.to_bytes();
         match self.kademlia.start_providing(key.into()) {
             Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
@@ -452,7 +452,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         &mut self.bitswap
     }
 
-    pub fn bootstrap(&mut self) -> Result<SubscriptionFuture<Result<(), String>>, anyhow::Error> {
+    pub fn bootstrap(&mut self) -> Result<SubscriptionFuture<(), String>, anyhow::Error> {
         match self.kademlia.bootstrap() {
             Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
             Err(e) => {
@@ -462,7 +462,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         }
     }
 
-    pub fn get_closest_peers(&mut self, id: PeerId) -> SubscriptionFuture<Result<(), String>> {
+    pub fn get_closest_peers(&mut self, id: PeerId) -> SubscriptionFuture<(), String> {
         let id = id.to_base58();
 
         self.kad_subscriptions

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -207,7 +207,6 @@ impl NetworkBehaviour for SwarmApi {
             self.connected_peers.remove(peer_id);
         }
         self.connections.remove(closed_addr);
-        // FIXME: should be an error
         self.connect_registry.finish_subscription(
             closed_addr.clone().into(),
             Err("Connection reset by peer".to_owned()),

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -216,7 +216,9 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
                 .await
                 .ok();
 
-            rx.await??.await?;
+            if let Ok(kad_subscription) = rx.await? {
+                kad_subscription.await?;
+            }
         }
 
         Ok((cid, res))

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -417,8 +417,9 @@ impl<T: Debug + PartialEq, E: Debug> fmt::Debug for SubscriptionFuture<T, E> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         write!(
             fmt,
-            "SubscriptionFuture<Output = Result<{}, Cancelled>>",
-            std::any::type_name::<T>()
+            "SubscriptionFuture<Output = Result<{}, {}>>",
+            std::any::type_name::<T>(),
+            std::any::type_name::<E>(),
         )
     }
 }


### PR DESCRIPTION
These changes were sparked by the following 2 observations:
- the logs sometimes indicate that a Kademlia query was executed twice
- `finish_subscription` didn't always result in futures being awoken

While the former remains a mystery (its occurrence is not correlated with subscriptions, meaning it's either some polling issue that eludes me or a bug in `libp2p`), investigating the `kad`<>`Subscription` route yielded a few improvements, namely:
- tweaked `kad` log levels
- proper `SubscriptionFuture` handling in `put_block`
- improved `SubscriptionRegistry` logs and a small fix
- simpler `SubscriptionFuture` type handling (it always returned a `Result`, so now it's a default)
- a `debug_assert` checking that we don't trigger zero-wake cases in `finish_subscription` during tests
- improved `swarm_api` test (that sometimes caused issues with the new `debug_assert`, but could be improved regardless)