### PR TITLE
Ipfs object tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,17 +79,15 @@ _Note: binaries available via `cargo install` is coming soon._
 ```rust,no_run
 use async_std::task;
 use futures::join;
-use ipfs::{IpfsOptions, IpfsPath, Ipld, Types, UninitializedIpfs};
+use ipfs::{Ipfs, IpfsOptions, IpfsPath, Ipld, Types, UninitializedIpfs};
 use libipld::ipld;
 
 fn main() {
     tracing_subscriber::fmt::init();
 
-    let options = IpfsOptions::<Types>::default();
-
     task::block_on(async move {
         // Start daemon and initialize repo
-        let (ipfs, fut) = UninitializedIpfs::new(options, None).await.start().await.unwrap();
+        let (ipfs, fut): (Ipfs<Types>, _) = UninitializedIpfs::default().await.start().await.unwrap();
         task::spawn(fut);
 
         // Create a DAG

--- a/examples/client1.rs
+++ b/examples/client1.rs
@@ -1,19 +1,14 @@
 use async_std::task;
 use futures::join;
-use ipfs::{IpfsOptions, Types, UninitializedIpfs};
+use ipfs::{Ipfs, TestTypes, UninitializedIpfs};
 use libipld::ipld;
 
 fn main() {
     tracing_subscriber::fmt::init();
 
-    let options = IpfsOptions::<Types>::default();
-
     task::block_on(async move {
-        let (ipfs, fut) = UninitializedIpfs::new(options, None)
-            .await
-            .start()
-            .await
-            .unwrap();
+        let (ipfs, fut): (Ipfs<TestTypes>, _) =
+            UninitializedIpfs::default().await.start().await.unwrap();
         task::spawn(fut);
 
         let f1 = ipfs.put_dag(ipld!("block1"));

--- a/examples/client2.rs
+++ b/examples/client2.rs
@@ -1,21 +1,17 @@
 use async_std::task;
 use futures::join;
-use ipfs::{IpfsOptions, IpfsPath, TestTypes, UninitializedIpfs};
+use ipfs::{Ipfs, IpfsPath, TestTypes, UninitializedIpfs};
 use std::str::FromStr;
 
 fn main() {
     tracing_subscriber::fmt::init();
 
-    let options = IpfsOptions::<TestTypes>::default();
     let path =
         IpfsPath::from_str("/ipfs/zdpuB1caPcm4QNXeegatVfLQ839Lmprd5zosXGwRUBJHwj66X").unwrap();
 
     task::block_on(async move {
-        let (ipfs, fut) = UninitializedIpfs::new(options, None)
-            .await
-            .start()
-            .await
-            .unwrap();
+        let (ipfs, fut): (Ipfs<TestTypes>, _) =
+            UninitializedIpfs::default().await.start().await.unwrap();
         task::spawn(fut);
 
         let f1 = ipfs.get_dag(path.sub_path("0").unwrap());

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -4,15 +4,13 @@ use cid::Cid;
 use futures::io::AsyncWriteExt;
 use futures::pin_mut;
 use futures::stream::StreamExt; // needed for StreamExt::next
-use ipfs::{IpfsOptions, TestTypes, UninitializedIpfs};
+use ipfs::{Ipfs, TestTypes, UninitializedIpfs};
 use std::convert::TryFrom;
 use std::env;
 use std::process::exit;
 
 fn main() {
     tracing_subscriber::fmt::init();
-
-    let options = IpfsOptions::<TestTypes>::default();
 
     // this example will wait forever attempting to fetch a CID provided at command line. It is
     // expected to be used by connecting another ipfs peer to it and providing the blocks from that
@@ -40,11 +38,8 @@ fn main() {
 
     async_std::task::block_on(async move {
         // Start daemon and initialize repo
-        let (ipfs, fut) = UninitializedIpfs::new(options, None)
-            .await
-            .start()
-            .await
-            .unwrap();
+        let (ipfs, fut): (Ipfs<TestTypes>, _) =
+            UninitializedIpfs::default().await.start().await.unwrap();
         async_std::task::spawn(fut);
 
         let (public_key, addresses) = ipfs.identity().await.unwrap();

--- a/examples/ipfs_bitswap_test.rs
+++ b/examples/ipfs_bitswap_test.rs
@@ -2,13 +2,11 @@
 
 use async_std::task;
 use cid::{Cid, Codec};
-use ipfs::{Block, IpfsOptions, TestTypes, UninitializedIpfs};
+use ipfs::{Block, Ipfs, TestTypes, UninitializedIpfs};
 use multihash::Sha2_256;
 
 fn main() {
     tracing_subscriber::fmt::init();
-
-    let options = IpfsOptions::<TestTypes>::default();
 
     // this example demonstrates
     //  - block building
@@ -16,11 +14,8 @@ fn main() {
 
     task::block_on(async move {
         // Start daemon and initialize repo
-        let (ipfs, fut) = UninitializedIpfs::new(options, None)
-            .await
-            .start()
-            .await
-            .unwrap();
+        let (ipfs, fut): (Ipfs<TestTypes>, _) =
+            UninitializedIpfs::default().await.start().await.unwrap();
         task::spawn(fut);
 
         let data = b"block-want\n".to_vec().into_boxed_slice();

--- a/examples/ipfs_ipns_test.rs
+++ b/examples/ipfs_ipns_test.rs
@@ -1,19 +1,14 @@
 use async_std::task;
-use ipfs::{IpfsOptions, IpfsPath, PeerId, TestTypes, UninitializedIpfs};
+use ipfs::{Ipfs, IpfsPath, PeerId, TestTypes, UninitializedIpfs};
 use std::str::FromStr;
 
 fn main() {
     tracing_subscriber::fmt::init();
 
-    let options = IpfsOptions::<TestTypes>::default();
-
     task::block_on(async move {
         // Start daemon and initialize repo
-        let (ipfs, fut) = UninitializedIpfs::new(options, None)
-            .await
-            .start()
-            .await
-            .unwrap();
+        let (ipfs, fut): (Ipfs<TestTypes>, _) =
+            UninitializedIpfs::default().await.start().await.unwrap();
         task::spawn(fut);
 
         // Create a Block

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -134,10 +134,10 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
-        let opts: IpfsOptions<ipfs::TestTypes> =
+        let opts: IpfsOptions =
             IpfsOptions::new(home.clone().into(), keypair, Vec::new(), false, None);
 
-        let (ipfs, task) = UninitializedIpfs::new(opts, None)
+        let (ipfs, task): (Ipfs<ipfs::TestTypes>, _) = UninitializedIpfs::new(opts, None)
             .await
             .start()
             .await

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -156,6 +156,7 @@ async fn not_implemented() -> Result<(impl warp::Reply,), std::convert::Infallib
 
 #[cfg(test)]
 mod tests {
+    use ipfs::{Ipfs, TestTypes};
     /// Creates routes for tests, the ipfs will not work as no background task is being spawned.
     async fn testing_routes(
     ) -> impl warp::Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
@@ -163,7 +164,7 @@ mod tests {
         use ipfs::{IpfsOptions, UninitializedIpfs};
 
         let options = IpfsOptions::inmemory_with_generated_keys();
-        let (ipfs, _) = UninitializedIpfs::new(options, None)
+        let (ipfs, _): (Ipfs<TestTypes>, _) = UninitializedIpfs::new(options, None)
             .await
             .start()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub use self::error::Error;
 use self::ipns::Ipns;
 pub use self::p2p::pubsub::{PubsubMessage, SubscriptionStream};
 use self::p2p::{create_swarm, SwarmOptions, TSwarm};
-pub use self::p2p::{Connection, ConnectionTarget, SwarmTypes};
+pub use self::p2p::{Connection, ConnectionTarget};
 pub use self::path::IpfsPath;
 pub use self::repo::RepoTypes;
 use self::repo::{create_repo, Repo, RepoEvent, RepoOptions};
@@ -55,9 +55,8 @@ use self::unixfs::File;
 
 /// All types can be changed at compile time by implementing
 /// `IpfsTypes`.
-pub trait IpfsTypes: SwarmTypes + RepoTypes {}
-impl<T: RepoTypes> SwarmTypes for T {}
-impl<T: SwarmTypes + RepoTypes> IpfsTypes for T {}
+pub trait IpfsTypes: RepoTypes {}
+impl<T: RepoTypes> IpfsTypes for T {}
 
 /// Default IPFS types.
 #[derive(Debug)]

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -1,6 +1,6 @@
 use super::pubsub::Pubsub;
 use super::swarm::{Connection, ConnectionTarget, Disconnector, SwarmApi};
-use crate::p2p::{SwarmOptions, SwarmTypes};
+use crate::p2p::SwarmOptions;
 use crate::repo::BlockPut;
 use crate::subscription::{SubscriptionFuture, SubscriptionRegistry};
 use crate::{Ipfs, IpfsTypes};
@@ -336,10 +336,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour
 
 impl<Types: IpfsTypes> Behaviour<Types> {
     /// Create a Kademlia behaviour with the IPFS bootstrap nodes.
-    pub async fn new<TSwarmTypes: SwarmTypes>(
-        options: SwarmOptions<TSwarmTypes>,
-        ipfs: Ipfs<Types>,
-    ) -> Self {
+    pub async fn new(options: SwarmOptions<Types>, ipfs: Ipfs<Types>) -> Self {
         info!("net: starting with peer id {}", options.peer_id);
 
         let mdns = if options.mdns {
@@ -482,9 +479,9 @@ impl<Types: IpfsTypes> Behaviour<Types> {
 }
 
 /// Create a IPFS behaviour with the IPFS bootstrap nodes.
-pub async fn build_behaviour<TSwarmTypes: SwarmTypes>(
-    options: SwarmOptions<TSwarmTypes>,
-    ipfs: Ipfs<TSwarmTypes>,
-) -> Behaviour<TSwarmTypes> {
+pub async fn build_behaviour<TIpfsTypes: IpfsTypes>(
+    options: SwarmOptions<TIpfsTypes>,
+    ipfs: Ipfs<TIpfsTypes>,
+) -> Behaviour<TIpfsTypes> {
     Behaviour::new(options, ipfs).await
 }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -336,7 +336,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour
 
 impl<Types: IpfsTypes> Behaviour<Types> {
     /// Create a Kademlia behaviour with the IPFS bootstrap nodes.
-    pub async fn new(options: SwarmOptions<Types>, ipfs: Ipfs<Types>) -> Self {
+    pub async fn new(options: SwarmOptions, ipfs: Ipfs<Types>) -> Self {
         info!("net: starting with peer id {}", options.peer_id);
 
         let mdns = if options.mdns {
@@ -480,7 +480,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
 
 /// Create a IPFS behaviour with the IPFS bootstrap nodes.
 pub async fn build_behaviour<TIpfsTypes: IpfsTypes>(
-    options: SwarmOptions<TIpfsTypes>,
+    options: SwarmOptions,
     ipfs: Ipfs<TIpfsTypes>,
 ) -> Behaviour<TIpfsTypes> {
     Behaviour::new(options, ipfs).await

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,7 +1,5 @@
 //! P2P handling for IPFS nodes.
-use crate::repo::RepoTypes;
-use crate::Ipfs;
-use crate::IpfsOptions;
+use crate::{Ipfs, IpfsOptions, IpfsTypes};
 use core::marker::PhantomData;
 use libp2p::identity::Keypair;
 use libp2p::Swarm;
@@ -17,10 +15,8 @@ pub use swarm::{Connection, ConnectionTarget};
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 
-pub trait SwarmTypes: RepoTypes + Sized {}
-
-pub struct SwarmOptions<TSwarmTypes: SwarmTypes> {
-    _marker: PhantomData<TSwarmTypes>,
+pub struct SwarmOptions<TIpfsTypes: IpfsTypes> {
+    _marker: PhantomData<TIpfsTypes>,
     pub keypair: Keypair,
     pub peer_id: PeerId,
     pub bootstrap: Vec<(Multiaddr, PeerId)>,
@@ -28,8 +24,8 @@ pub struct SwarmOptions<TSwarmTypes: SwarmTypes> {
     pub kad_protocol: Option<String>,
 }
 
-impl<TSwarmTypes: SwarmTypes> From<&IpfsOptions<TSwarmTypes>> for SwarmOptions<TSwarmTypes> {
-    fn from(options: &IpfsOptions<TSwarmTypes>) -> Self {
+impl<TIpfsTypes: IpfsTypes> From<&IpfsOptions<TIpfsTypes>> for SwarmOptions<TIpfsTypes> {
+    fn from(options: &IpfsOptions<TIpfsTypes>) -> Self {
         let keypair = options.keypair.clone();
         let peer_id = keypair.public().into_peer_id();
         let bootstrap = options.bootstrap.clone();
@@ -48,10 +44,10 @@ impl<TSwarmTypes: SwarmTypes> From<&IpfsOptions<TSwarmTypes>> for SwarmOptions<T
 }
 
 /// Creates a new IPFS swarm.
-pub async fn create_swarm<TSwarmTypes: SwarmTypes>(
-    options: SwarmOptions<TSwarmTypes>,
-    ipfs: Ipfs<TSwarmTypes>,
-) -> TSwarm<TSwarmTypes> {
+pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
+    options: SwarmOptions<TIpfsTypes>,
+    ipfs: Ipfs<TIpfsTypes>,
+) -> TSwarm<TIpfsTypes> {
     let peer_id = options.peer_id.clone();
 
     // Set up an encrypted TCP transport over the Mplex protocol.

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,6 +1,5 @@
 //! P2P handling for IPFS nodes.
 use crate::{Ipfs, IpfsOptions, IpfsTypes};
-use core::marker::PhantomData;
 use libp2p::identity::Keypair;
 use libp2p::Swarm;
 use libp2p::{Multiaddr, PeerId};
@@ -15,8 +14,7 @@ pub use swarm::{Connection, ConnectionTarget};
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 
-pub struct SwarmOptions<TIpfsTypes: IpfsTypes> {
-    _marker: PhantomData<TIpfsTypes>,
+pub struct SwarmOptions {
     pub keypair: Keypair,
     pub peer_id: PeerId,
     pub bootstrap: Vec<(Multiaddr, PeerId)>,
@@ -24,8 +22,8 @@ pub struct SwarmOptions<TIpfsTypes: IpfsTypes> {
     pub kad_protocol: Option<String>,
 }
 
-impl<TIpfsTypes: IpfsTypes> From<&IpfsOptions<TIpfsTypes>> for SwarmOptions<TIpfsTypes> {
-    fn from(options: &IpfsOptions<TIpfsTypes>) -> Self {
+impl From<&IpfsOptions> for SwarmOptions {
+    fn from(options: &IpfsOptions) -> Self {
         let keypair = options.keypair.clone();
         let peer_id = keypair.public().into_peer_id();
         let bootstrap = options.bootstrap.clone();
@@ -33,7 +31,6 @@ impl<TIpfsTypes: IpfsTypes> From<&IpfsOptions<TIpfsTypes>> for SwarmOptions<TIpf
         let kad_protocol = options.kad_protocol.clone();
 
         SwarmOptions {
-            _marker: PhantomData,
             keypair,
             peer_id,
             bootstrap,
@@ -45,7 +42,7 @@ impl<TIpfsTypes: IpfsTypes> From<&IpfsOptions<TIpfsTypes>> for SwarmOptions<TIpf
 
 /// Creates a new IPFS swarm.
 pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
-    options: SwarmOptions<TIpfsTypes>,
+    options: SwarmOptions,
     ipfs: Ipfs<TIpfsTypes>,
 ) -> TSwarm<TIpfsTypes> {
     let peer_id = options.peer_id.clone();

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -9,7 +9,6 @@ use bitswap::Block;
 use cid::{self, Cid};
 use core::convert::TryFrom;
 use core::fmt::Debug;
-use core::marker::PhantomData;
 use futures::channel::{
     mpsc::{channel, Receiver, Sender},
     oneshot,
@@ -27,22 +26,20 @@ pub trait RepoTypes: Send + Sync + 'static {
 }
 
 #[derive(Clone, Debug)]
-pub struct RepoOptions<TRepoTypes: RepoTypes> {
-    _marker: PhantomData<TRepoTypes>,
+pub struct RepoOptions {
     path: PathBuf,
 }
 
-impl<TRepoTypes: RepoTypes> From<&IpfsOptions<TRepoTypes>> for RepoOptions<TRepoTypes> {
-    fn from(options: &IpfsOptions<TRepoTypes>) -> Self {
+impl From<&IpfsOptions> for RepoOptions {
+    fn from(options: &IpfsOptions) -> Self {
         RepoOptions {
-            _marker: PhantomData,
             path: options.ipfs_path.clone(),
         }
     }
 }
 
 pub fn create_repo<TRepoTypes: RepoTypes>(
-    options: RepoOptions<TRepoTypes>,
+    options: RepoOptions,
 ) -> (Repo<TRepoTypes>, Receiver<RepoEvent>) {
     Repo::new(options)
 }
@@ -151,7 +148,7 @@ impl TryFrom<RequestKind> for RepoEvent {
 }
 
 impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
-    pub fn new(options: RepoOptions<TRepoTypes>) -> (Self, Receiver<RepoEvent>) {
+    pub fn new(options: RepoOptions) -> (Self, Receiver<RepoEvent>) {
         let mut blockstore_path = options.path.clone();
         let mut datastore_path = options.path;
         blockstore_path.push("blockstore");
@@ -369,10 +366,7 @@ pub(crate) mod tests {
     pub fn create_mock_repo() -> (Repo<Types>, Receiver<RepoEvent>) {
         let mut tmp = temp_dir();
         tmp.push("rust-ipfs-repo");
-        let options: RepoOptions<Types> = RepoOptions {
-            _marker: PhantomData,
-            path: tmp.into(),
-        };
+        let options: RepoOptions = RepoOptions { path: tmp.into() };
         Repo::new(options)
     }
 


### PR DESCRIPTION
Removes `SwarmTypes`, drops the generic from `IpfsOptions`, `RepoOptions` and `SwarmOptions` and simplifies the creation of `Ipfs`/`UnitializedIpfs` via more pattern-matching `move`s.

Rationale: since we already need to specify the type in order to create `IpfsOptions`, we might as well do that directly for `Ipfs` instead, without dragging the generic through all the options that don't even use it (they just carry `PhantomData`).