### PR TITLE
Enable 2 conformance timeout tests

### DIFF
--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -35,9 +35,6 @@ const factory = createFactory(options)
 tests.miscellaneous(factory, { skip: [
   'dns',
   'resolve',
-  // these cause a hang 20% of time:
-  'should respect timeout option when getting the node id',
-  'should respect timeout option when getting the node version',
   // this hangs on windows, see #251
   'stop'
 ] })


### PR DESCRIPTION
I noticed that we have 2 seemingly simple conformance tests disabled. I wanted to take a stab at fixing them, but try as I may, I can't trigger any hangs, so they might already have been fixed by some of our recent changes; let's see how they fare with the CI.