### PR TITLE
fix: update async-stream to 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22068c0c19514942eefcfd4daf8976ef1aad84e61539f95cd200c35202f80af5"
+checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
 dependencies = [
  "async-stream-impl",
  "futures-core",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "async-stream-impl"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25f9db3b38af870bf7e5cc649167533b493928e50744e2c30ae350230b414670"
+checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
 dependencies = [
  "proc-macro2 1.0.19",
  "quote 1.0.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ nightly = []
 [dependencies]
 anyhow = { default-features = false, version = "1.0" }
 async-std = { default-features = false, features = ["attributes", "std"], version = "1.6" }
-async-stream = { default-features = false, version = "0.2" }
+async-stream = { default-features = false, version = "0.3" }
 async-trait = { default-features = false, version = "0.1" }
 bitswap = { path = "bitswap" }
 byteorder =  { default-features = false, version = "1.3" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -10,7 +10,7 @@ prost-build = { default-features = false, version = "0.6" }
 vergen = { default-features = false, version = "3.1" }
 
 [dependencies]
-async-stream = { default-features = false, version = "0.2" }
+async-stream = { default-features = false, version = "0.3" }
 bytes = { default-features = false, version = "0.5" }
 cid = { default-features = false, version = "0.5" }
 futures = { default-features = false, version = "0.3" }
@@ -33,7 +33,7 @@ tar = { default-features = false, version = "0.4" }
 thiserror = { default-features = false, version = "1.0" }
 tokio = { default-features = false, features = ["full"], version = "0.2" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
-tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log"], version = "0.2" }
+tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "env-filter"], version = "0.2" }
 url = { default-features = false, version = "2.1" }
 warp = { default-features = false, version = "0.2" }
 

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,6 +1,3 @@
-// Required by the use of async_stream
-#![recursion_limit = "512"]
-
 #[macro_use]
 extern crate tracing;
 

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -472,7 +472,7 @@ fn iplds_refs<T: IpfsTypes>(
                 }
             };
 
-            let mut ipld = match decode_ipld(&cid, &data) {
+            let ipld = match decode_ipld(&cid, &data) {
                 Ok(ipld) => ipld,
                 Err(e) => {
                     warn!("failed to parse {}, linked from {}: {}", cid, source, e);

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -161,7 +161,7 @@ fn walk<Types: IpfsTypes>(
                 ContinuedWalk::File(segment, item) => {
                     if let Entry::Metadata(MetadataEntry::File(.., p, md, size)) = item.as_entry() {
                         if segment.is_first() {
-                            for mut bytes in tar_helper.apply_file(p, md, size)?.iter_mut() {
+                            for bytes in tar_helper.apply_file(p, md, size)?.iter_mut() {
                                 if let Some(bytes) = bytes.take() {
                                     yield bytes;
                                 }
@@ -194,7 +194,7 @@ fn walk<Types: IpfsTypes>(
                     if let Entry::Metadata(metadata_entry) = item.as_entry() {
                         let metadata = metadata_entry.metadata();
                         let path = metadata_entry.path();
-                        for mut bytes in tar_helper.apply_directory(path, metadata)?.iter_mut() {
+                        for bytes in tar_helper.apply_directory(path, metadata)?.iter_mut() {
                             if let Some(bytes) = bytes.take() {
                                 yield bytes;
                             }
@@ -210,7 +210,7 @@ fn walk<Types: IpfsTypes>(
                         let target = Path::new(target);
                         let metadata = metadata_entry.metadata();
 
-                        for mut bytes in tar_helper.apply_symlink(path, target, metadata)?.iter_mut() {
+                        for bytes in tar_helper.apply_symlink(path, target, metadata)?.iter_mut() {
                             if let Some(bytes) = bytes.take() {
                                 yield bytes;
                             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! IPFS node implementation
 //#![deny(missing_docs)]
-// Recursion limit is required by the use of async_stream
-#![recursion_limit = "512"]
 #![cfg_attr(feature = "nightly", feature(external_doc))]
 #![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 


### PR DESCRIPTION
this uses the rust 1.45 features to remove recursion inside the macro. great for #284 which adds even more complicated async-stream(s).

good to go if CI passes.