### PR TITLE
Use tokio::test in http instead of its async_std counterpart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,6 @@ dependencies = [
 name = "ipfs-http"
 version = "0.1.0"
 dependencies = [
- "async-std",
  "async-stream",
  "bytes 0.5.6",
  "cid",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -38,7 +38,6 @@ url = { default-features = false, version = "2.1" }
 warp = { default-features = false, version = "0.2" }
 
 [dev-dependencies]
-async-std = { default-features = false, features = ["attributes"], version = "1.6" }
 hex = { default-features = false, version = "0.4" }
 hex-literal = { default-features = false, version = "0.3" }
 tempfile = { default-features = false, version = "3.1" }

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -560,7 +560,7 @@ mod tests {
         })
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn url_hacked_args() {
         let response = request()
             .path("/pubsub/pub?arg=some_channel&arg=foobar")
@@ -570,7 +570,7 @@ mod tests {
         assert_eq!(body, r#"{"message":"foobar","topic":"some_channel"}"#);
     }
 
-    #[async_std::test]
+    #[tokio::test]
     async fn message_in_body() {
         let response = request()
             .path("/pubsub/pub?arg=some_channel")


### PR DESCRIPTION
As `tokio` is the async executor in `http`.