### PR TITLE
set opt-level = 1 in the dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ license = "MIT OR Apache-2.0"
 name = "ipfs"
 version = "0.1.0"
 
+[profile.dev]
+opt-level = 1
+
 [features]
 default = []
 nightly = []


### PR DESCRIPTION
This should allow https://github.com/rs-ipfs/rust-ipfs/pull/284 to pass the conformance tests without `ipfs-http` triggering a stack overflow.