### PR TITLE
impl<T: Clone, E: Clone> Clone for Subscription<T, E>

### DIFF
--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -231,6 +231,22 @@ pub enum Subscription<T, E> {
     Cancelled,
 }
 
+impl<T: Clone, E: Clone> Clone for Subscription<T, E> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Ready(res) => Self::Ready(res.clone()),
+            Self::Pending {
+                waker,
+                cancel_notifier,
+            } => Self::Pending {
+                waker: waker.clone(),
+                cancel_notifier: cancel_notifier.clone(),
+            },
+            Self::Cancelled => Self::Cancelled,
+        }
+    }
+}
+
 impl<T, E> fmt::Debug for Subscription<T, E> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         use Subscription::*;


### PR DESCRIPTION
My suspects are either the enabled `tracing_subscriber` or the lock over `SubscriptionRegistry` taken in `get_subscriptions`; I've adjusted those and tightened the test's deadlines and wasn't able to trigger the issue while stress-testing. It might not suffice yet, but those changes won't hurt.