### PR TITLE
add a DHT mode param

### DIFF
--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU16;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-use ipfs::{Ipfs, IpfsOptions, IpfsTypes, UninitializedIpfs};
+use ipfs::{DhtMode, Ipfs, IpfsOptions, IpfsTypes, UninitializedIpfs};
 use ipfs_http::{config, v0};
 
 #[derive(Debug, StructOpt)]
@@ -134,8 +134,14 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
-        let opts: IpfsOptions =
-            IpfsOptions::new(home.clone().into(), keypair, Vec::new(), false, None);
+        let opts: IpfsOptions = IpfsOptions::new(
+            home.clone().into(),
+            keypair,
+            Vec::new(),
+            false,
+            None,
+            DhtMode::Client,
+        );
 
         let (ipfs, task): (Ipfs<ipfs::TestTypes>, _) = UninitializedIpfs::new(opts, None)
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ pub struct IpfsOptions {
     /// The path of the ipfs repo.
     pub ipfs_path: PathBuf,
     /// The keypair used with libp2p.
-    pub keypair: Keypair,
+    pub keypair: DebuggableKeypair<Keypair>,
     /// Nodes dialed during startup.
     pub bootstrap: Vec<(Multiaddr, PeerId)>,
     /// Enables mdns for peer discovery when true.
@@ -109,7 +109,7 @@ impl fmt::Debug for IpfsOptions {
         fmt.debug_struct("IpfsOptions")
             .field("ipfs_path", &self.ipfs_path)
             .field("bootstrap", &self.bootstrap)
-            .field("keypair", &DebuggableKeypair(&self.keypair))
+            .field("keypair", &self.keypair)
             .field("mdns", &self.mdns)
             .field("kad_protocol", &self.kad_protocol)
             .finish()
@@ -121,7 +121,7 @@ impl IpfsOptions {
     pub fn inmemory_with_generated_keys() -> Self {
         Self {
             ipfs_path: std::env::temp_dir().into(),
-            keypair: Keypair::generate_ed25519(),
+            keypair: DebuggableKeypair(Keypair::generate_ed25519()),
             mdns: Default::default(),
             bootstrap: Default::default(),
             kad_protocol: Default::default(),
@@ -133,7 +133,7 @@ impl IpfsOptions {
 /// Workaround for libp2p::identity::Keypair missing a Debug impl, works with references and owned
 /// keypairs.
 #[derive(Clone)]
-struct DebuggableKeypair<I: Borrow<Keypair>>(I);
+pub struct DebuggableKeypair<I: Borrow<Keypair>>(I);
 
 impl<I: Borrow<Keypair>> fmt::Debug for DebuggableKeypair<I> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -164,7 +164,7 @@ impl IpfsOptions {
     ) -> Self {
         Self {
             ipfs_path,
-            keypair,
+            keypair: DebuggableKeypair(keypair),
             bootstrap,
             mdns,
             kad_protocol,
@@ -209,7 +209,7 @@ impl Default for IpfsOptions {
             .join("rust-ipfs")
             .join("config.json");
         let config = ConfigFile::new(config_path).unwrap();
-        let keypair = config.secio_key_pair();
+        let keypair = DebuggableKeypair(config.secio_key_pair());
         let bootstrap = config.bootstrap();
 
         IpfsOptions {
@@ -239,7 +239,6 @@ pub struct IpfsInner<Types: IpfsTypes> {
     pub span: Span,
     options: IpfsOptions,
     repo: Repo<Types>,
-    keys: DebuggableKeypair<Keypair>,
     to_task: Sender<IpfsEvent>,
 }
 
@@ -284,7 +283,6 @@ enum IpfsEvent {
 pub struct UninitializedIpfs<Types: IpfsTypes> {
     repo: Repo<Types>,
     span: Span,
-    keys: Keypair,
     options: IpfsOptions,
     repo_events: Receiver<RepoEvent>,
 }
@@ -299,13 +297,11 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
     pub async fn new(options: IpfsOptions, span: Option<Span>) -> Self {
         let repo_options = RepoOptions::from(&options);
         let (repo, repo_events) = create_repo(repo_options);
-        let keys = options.keypair.clone();
         let span = span.unwrap_or_else(|| tracing::trace_span!("ipfs"));
 
         UninitializedIpfs {
             repo,
             span,
-            keys,
             options,
             repo_events,
         }
@@ -323,7 +319,6 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
         let UninitializedIpfs {
             repo,
             span,
-            keys,
             repo_events,
             options,
         } = self;
@@ -336,7 +331,6 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             options: options.clone(),
             span,
             repo,
-            keys: DebuggableKeypair(keys),
             to_task,
         }));
 
@@ -554,7 +548,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
                     .send(IpfsEvent::GetAddresses(tx))
                     .await?;
                 let addresses = rx.await?;
-                Ok((self.keys.get_ref().public(), addresses))
+                Ok((self.options.keypair.get_ref().public(), addresses))
             })
             .await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ use self::dag::IpldDag;
 pub use self::error::Error;
 use self::ipns::Ipns;
 pub use self::p2p::pubsub::{PubsubMessage, SubscriptionStream};
-use self::p2p::{create_swarm, SwarmOptions, TSwarm};
+use self::p2p::{create_swarm, TSwarm};
 pub use self::p2p::{Connection, ConnectionTarget};
 pub use self::path::IpfsPath;
 pub use self::repo::RepoTypes;
@@ -340,8 +340,7 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
             to_task,
         }));
 
-        let swarm_options = SwarmOptions::from(options);
-        let swarm = create_swarm(swarm_options, ipfs.clone()).await;
+        let swarm = create_swarm(ipfs.clone()).await;
 
         let fut = IpfsFuture {
             repo_events: repo_events.fuse(),

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -336,7 +336,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<IdentifyEvent> for Behaviour
 impl<Types: IpfsTypes> Behaviour<Types> {
     /// Create a Kademlia behaviour with the IPFS bootstrap nodes.
     pub async fn new(ipfs: Ipfs<Types>) -> Self {
-        let peer_id = ipfs.options.keypair.public().into_peer_id();
+        let peer_id = ipfs.options.keypair.get_ref().public().into_peer_id();
         info!("net: starting with peer id {}", peer_id);
 
         let mdns = if ipfs.options.mdns {
@@ -365,7 +365,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         let identify = Identify::new(
             "/ipfs/0.1.0".into(),
             "rust-ipfs".into(),
-            ipfs.options.keypair.public(),
+            ipfs.options.keypair.get_ref().public(),
         );
         let pubsub = Pubsub::new(peer_id);
         let swarm = SwarmApi::default();

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -22,13 +22,17 @@ pub struct SwarmOptions {
     pub kad_protocol: Option<String>,
 }
 
-impl From<&IpfsOptions> for SwarmOptions {
-    fn from(options: &IpfsOptions) -> Self {
-        let keypair = options.keypair.clone();
+impl From<IpfsOptions> for SwarmOptions {
+    fn from(options: IpfsOptions) -> Self {
+        let IpfsOptions {
+            keypair,
+            bootstrap,
+            mdns,
+            kad_protocol,
+            ..
+        } = options;
+
         let peer_id = keypair.public().into_peer_id();
-        let bootstrap = options.bootstrap.clone();
-        let mdns = options.mdns;
-        let kad_protocol = options.kad_protocol.clone();
 
         SwarmOptions {
             keypair,

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -14,10 +14,10 @@ pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 
 /// Creates a new IPFS swarm.
 pub async fn create_swarm<TIpfsTypes: IpfsTypes>(ipfs: Ipfs<TIpfsTypes>) -> TSwarm<TIpfsTypes> {
-    let peer_id = ipfs.options.keypair.public().into_peer_id();
+    let peer_id = ipfs.options.keypair.get_ref().public().into_peer_id();
 
     // Set up an encrypted TCP transport over the Mplex protocol.
-    let transport = transport::build_transport(ipfs.options.keypair.clone());
+    let transport = transport::build_transport(ipfs.options.keypair.get_ref().clone());
 
     let swarm_span = ipfs.0.span.clone();
 


### PR DESCRIPTION
Currently defaults to `Client` and can't be adjusted manually. Also removes `SwarmOptions` and `IpfsInner.keys` due to retaining all the `IpfsOptions` inside `IpfsInner`.