### PR TITLE
fix: go back to std::sync::Mutex

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1088,7 +1088,7 @@ mod node {
 
         pub fn get_subscriptions(
             &self,
-        ) -> &futures::lock::Mutex<subscription::Subscriptions<Block, String>> {
+        ) -> &std::sync::Mutex<subscription::Subscriptions<Block, String>> {
             &self.ipfs.repo.subscriptions.subscriptions
         }
 

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -38,7 +38,7 @@ where
 }
 
 async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) {
-    let subs = ipfs.get_subscriptions().lock().await;
+    let subs = ipfs.get_subscriptions().lock().unwrap();
     if expected_count > 0 {
         assert_eq!(subs.len(), 1);
     }

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -38,11 +38,13 @@ where
 }
 
 async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) {
-    let subs = ipfs.get_subscriptions().lock().unwrap();
-    if expected_count > 0 {
-        assert_eq!(subs.len(), 1);
-    }
-    let subscription_count = subs.get(&cid.clone().into()).map(|l| l.len());
+    let subscription_count = {
+        let subs = ipfs.get_subscriptions().lock().unwrap();
+        if expected_count > 0 {
+            assert_eq!(subs.len(), 1);
+        }
+        subs.get(&cid.clone().into()).map(|l| l.len())
+    };
     // treat None as 0
     assert_eq!(subscription_count.unwrap_or(0), expected_count);
 }


### PR DESCRIPTION
Turns out #174 was wrong, as the alternative required sprinkling block_on which made the whole thing worse. We shouldn't risk a deadlock with the mutex as we are not (can not) holding it across awaits.

Unwrap as we are not expecting subscriptions to panic and poison the mutex.