### PR TITLE
Put "Rust-IPFS contributors" as package authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["David Craven <david@craven.ch>"]
+authors = ["Rust-IPFS contributors"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 name = "ipfs"

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["David Craven <david@craven.ch>"]
+authors = ["Rust-IPFS contributors"]
 edition = "2018"
 name = "bitswap"
 version = "0.1.0"

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Joonas Koivunen <joonas@equilibrium.co>"]
+authors = ["Rust-IPFS contributors"]
 build = "build.rs"
 edition = "2018"
 name = "ipfs-http"

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Joonas Koivunen <joonas@equilibrium.co>"]
+authors = ["Rust-IPFS contributors"]
 description = "UnixFs tree support"
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
The usual convention for Rust crates that are a collaborative, open source effort is to put `<project> contributors` under the `[package] authors` in the `toml`.