### PR TITLE
Remove unneccesary Jekyll file

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
This PR removes the _config.yml file, which is not needed since the website content lives in other repos.