### PR TITLE
Use explicit Multiaddr wrappers

### DIFF
--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -105,3 +105,21 @@ impl fmt::Display for MultiaddrWithPeerId {
         write!(f, "{}/p2p/{}", self.multiaddr.as_ref(), self.peer_id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn connection_targets() {
+        let peer_id = "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ";
+        let multiaddr_wo_peer = "/ip4/104.131.131.82/tcp/4001";
+        let multiaddr_with_peer = format!("{}/p2p/{}", multiaddr_wo_peer, peer_id);
+        let p2p_peer = format!("/p2p/{}", peer_id);
+        // note: /ipfs/peer_id doesn't properly parse as a Multiaddr
+
+        assert!(multiaddr_wo_peer.parse::<MultiaddrWithoutPeerId>().is_ok());
+        assert!(multiaddr_with_peer.parse::<MultiaddrWithPeerId>().is_ok());
+        assert!(p2p_peer.parse::<Multiaddr>().is_ok());
+    }
+}

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -1,0 +1,84 @@
+use anyhow::anyhow;
+use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
+use std::{convert::TryFrom, fmt, str::FromStr};
+
+/// A wrapper for `Multiaddr` that does **not** contain `Protocol::P2p`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MultiaddrWithoutPeerId(Multiaddr);
+
+impl From<Multiaddr> for MultiaddrWithoutPeerId {
+    fn from(addr: Multiaddr) -> Self {
+        Self(
+            addr.into_iter()
+                .filter(|p| !matches!(p, Protocol::P2p(_)))
+                .collect(),
+        )
+    }
+}
+
+impl From<MultiaddrWithoutPeerId> for Multiaddr {
+    fn from(addr: MultiaddrWithoutPeerId) -> Self {
+        let MultiaddrWithoutPeerId(multiaddr) = addr;
+        multiaddr
+    }
+}
+
+impl AsRef<Multiaddr> for MultiaddrWithoutPeerId {
+    fn as_ref(&self) -> &Multiaddr {
+        &self.0
+    }
+}
+
+impl FromStr for MultiaddrWithoutPeerId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let multiaddr = s.parse::<Multiaddr>()?;
+        Ok(multiaddr.into())
+    }
+}
+
+/// A `Multiaddr` paired with a discrete `PeerId`. The `Multiaddr` can contain a
+/// `Protocol::P2p`, but it's not as easy to work with, and some functionalities
+/// don't support it being contained within the `Multiaddr`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MultiaddrWithPeerId {
+    pub multiaddr: MultiaddrWithoutPeerId,
+    pub peer_id: PeerId,
+}
+
+impl From<(MultiaddrWithoutPeerId, PeerId)> for MultiaddrWithPeerId {
+    fn from((multiaddr, peer_id): (MultiaddrWithoutPeerId, PeerId)) -> Self {
+        Self { multiaddr, peer_id }
+    }
+}
+
+impl TryFrom<Multiaddr> for MultiaddrWithPeerId {
+    type Error = anyhow::Error;
+
+    fn try_from(mut multiaddr: Multiaddr) -> Result<Self, Self::Error> {
+        if let Some(Protocol::P2p(hash)) = multiaddr.pop() {
+            let multiaddr = MultiaddrWithoutPeerId(multiaddr);
+            let peer_id = PeerId::from_multihash(hash)
+                .map_err(|_| anyhow!("Invalid Multihash in Protocol::P2p"))?;
+            Ok(Self { multiaddr, peer_id })
+        } else {
+            Err(anyhow!("Missing Protocol::P2p in the Multiaddr"))
+        }
+    }
+}
+
+impl FromStr for MultiaddrWithPeerId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let multiaddr = s.parse::<Multiaddr>()?;
+        Self::try_from(multiaddr)
+    }
+}
+
+impl fmt::Display for MultiaddrWithPeerId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/p2p/{}", self.multiaddr.as_ref(), self.peer_id)
+    }
+}

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -1,6 +1,6 @@
 use super::pubsub::Pubsub;
 use super::swarm::{Connection, Disconnector, SwarmApi};
-use crate::p2p::SwarmOptions;
+use crate::p2p::{MultiaddrWithPeerId, SwarmOptions};
 use crate::repo::BlockPut;
 use crate::subscription::{SubscriptionFuture, SubscriptionRegistry};
 use crate::{Ipfs, IpfsTypes};
@@ -414,11 +414,11 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         self.swarm.connections()
     }
 
-    pub fn connect(&mut self, addr: Multiaddr) -> Option<SubscriptionFuture<(), String>> {
+    pub fn connect(&mut self, addr: MultiaddrWithPeerId) -> Option<SubscriptionFuture<(), String>> {
         self.swarm.connect(addr)
     }
 
-    pub fn disconnect(&mut self, addr: Multiaddr) -> Option<Disconnector> {
+    pub fn disconnect(&mut self, addr: MultiaddrWithPeerId) -> Option<Disconnector> {
         self.swarm.disconnect(addr)
     }
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod pubsub;
 mod swarm;
 mod transport;
 
-pub use swarm::Connection;
+pub use swarm::{Connection, MultiaddrWithPeerId, MultiaddrWoPeerId};
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod pubsub;
 mod swarm;
 mod transport;
 
-pub use swarm::{Connection, MultiaddrWithPeerId, MultiaddrWoPeerId};
+pub use swarm::{Connection, MultiaddrWithPeerId, MultiaddrWithoutPeerId};
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -5,12 +5,14 @@ use libp2p::Swarm;
 use libp2p::{Multiaddr, PeerId};
 use tracing::Span;
 
+mod addr;
 mod behaviour;
 pub(crate) mod pubsub;
 mod swarm;
 mod transport;
 
-pub use swarm::{Connection, MultiaddrWithPeerId, MultiaddrWithoutPeerId};
+pub use addr::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
+pub use swarm::Connection;
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -1,98 +1,13 @@
+use crate::p2p::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
 use crate::subscription::{SubscriptionFuture, SubscriptionRegistry};
-use anyhow::anyhow;
 use core::task::{Context, Poll};
-use libp2p::core::{
-    connection::ConnectionId, multiaddr::Protocol, ConnectedPoint, Multiaddr, PeerId,
-};
+use libp2p::core::{connection::ConnectionId, ConnectedPoint, Multiaddr, PeerId};
 use libp2p::swarm::protocols_handler::{
     DummyProtocolsHandler, IntoProtocolsHandler, ProtocolsHandler,
 };
 use libp2p::swarm::{self, NetworkBehaviour, PollParameters, Swarm};
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::convert::TryFrom;
 use std::time::Duration;
-use std::{fmt, str::FromStr};
-
-/// A wrapper for `Multiaddr` that does **not** contain `Protocol::P2p`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MultiaddrWithoutPeerId(Multiaddr);
-
-impl From<Multiaddr> for MultiaddrWithoutPeerId {
-    fn from(addr: Multiaddr) -> Self {
-        Self(
-            addr.into_iter()
-                .filter(|p| !matches!(p, Protocol::P2p(_)))
-                .collect(),
-        )
-    }
-}
-
-impl From<MultiaddrWithoutPeerId> for Multiaddr {
-    fn from(addr: MultiaddrWithoutPeerId) -> Self {
-        let MultiaddrWithoutPeerId(multiaddr) = addr;
-        multiaddr
-    }
-}
-
-impl AsRef<Multiaddr> for MultiaddrWithoutPeerId {
-    fn as_ref(&self) -> &Multiaddr {
-        &self.0
-    }
-}
-
-impl FromStr for MultiaddrWithoutPeerId {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let multiaddr = s.parse::<Multiaddr>()?;
-        Ok(multiaddr.into())
-    }
-}
-
-/// A `Multiaddr` paired with a discrete `PeerId`. The `Multiaddr` can contain a
-/// `Protocol::P2p`, but it's not as easy to work with, and some functionalities
-/// don't support it being contained within the `Multiaddr`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct MultiaddrWithPeerId {
-    pub multiaddr: MultiaddrWithoutPeerId,
-    pub peer_id: PeerId,
-}
-
-impl From<(MultiaddrWithoutPeerId, PeerId)> for MultiaddrWithPeerId {
-    fn from((multiaddr, peer_id): (MultiaddrWithoutPeerId, PeerId)) -> Self {
-        Self { multiaddr, peer_id }
-    }
-}
-
-impl TryFrom<Multiaddr> for MultiaddrWithPeerId {
-    type Error = anyhow::Error;
-
-    fn try_from(mut multiaddr: Multiaddr) -> Result<Self, Self::Error> {
-        if let Some(Protocol::P2p(hash)) = multiaddr.pop() {
-            let multiaddr = MultiaddrWithoutPeerId(multiaddr);
-            let peer_id = PeerId::from_multihash(hash)
-                .map_err(|_| anyhow!("Invalid Multihash in Protocol::P2p"))?;
-            Ok(Self { multiaddr, peer_id })
-        } else {
-            Err(anyhow!("Missing Protocol::P2p in the Multiaddr"))
-        }
-    }
-}
-
-impl FromStr for MultiaddrWithPeerId {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let multiaddr = s.parse::<Multiaddr>()?;
-        Self::try_from(multiaddr)
-    }
-}
-
-impl fmt::Display for MultiaddrWithPeerId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}/p2p/{}", self.multiaddr.as_ref(), self.peer_id)
-    }
-}
 
 /// A description of currently active connection.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -256,7 +256,8 @@ mod tests {
     use super::*;
     use crate::p2p::transport::{build_transport, TTransport};
     use libp2p::identity::Keypair;
-    use libp2p::{multihash::Multihash, swarm::Swarm};
+    use libp2p::{multiaddr::Protocol, multihash::Multihash, swarm::Swarm};
+    use std::convert::TryInto;
 
     #[test]
     fn connection_targets() {
@@ -286,7 +287,7 @@ mod tests {
             addr.push(Protocol::P2p(
                 Multihash::from_bytes(peer1_id.clone().into_bytes()).unwrap(),
             ));
-            if let Some(fut) = swarm2.connect(MultiaddrWithPeerId::try_from(addr).unwrap()) {
+            if let Some(fut) = swarm2.connect(addr.try_into().unwrap()) {
                 fut.await.unwrap();
             }
         }

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -259,19 +259,6 @@ mod tests {
     use libp2p::{multiaddr::Protocol, multihash::Multihash, swarm::Swarm};
     use std::convert::TryInto;
 
-    #[test]
-    fn connection_targets() {
-        let peer_id = "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ";
-        let multiaddr_wo_peer = "/ip4/104.131.131.82/tcp/4001";
-        let multiaddr_with_peer = format!("{}/p2p/{}", multiaddr_wo_peer, peer_id);
-        let p2p_peer = format!("/p2p/{}", peer_id);
-        // note: /ipfs/peer_id doesn't properly parse as a Multiaddr
-
-        assert!(multiaddr_wo_peer.parse::<MultiaddrWithoutPeerId>().is_ok());
-        assert!(multiaddr_with_peer.parse::<MultiaddrWithPeerId>().is_ok());
-        assert!(p2p_peer.parse::<Multiaddr>().is_ok());
-    }
-
     #[tokio::test(max_threads = 1)]
     async fn swarm_api() {
         let (peer1_id, trans) = mk_transport();

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -3,14 +3,14 @@
 //! that contains them. `SubscriptionFuture` is the `Future` bound to pending `Subscription`s and
 //! sharing the same unique numeric identifier, the `SubscriptionId`.
 
-use crate::RepoEvent;
+use crate::{p2p::MultiaddrWithPeerId, RepoEvent};
 use cid::Cid;
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::pin::Pin;
 use futures::channel::mpsc::Sender;
 use futures::future::Future;
-use libp2p::{kad::QueryId, Multiaddr};
+use libp2p::kad::QueryId;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;
@@ -28,8 +28,8 @@ static GLOBAL_REQ_COUNT: AtomicU64 = AtomicU64::new(0);
 /// The type of a request for subscription.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum RequestKind {
-    /// A request to connect to the given `Multiaddr` or `PeerId`.
-    Connect(Multiaddr),
+    /// A request to connect to the given `Multiaddr`+`PeerId` pair.
+    Connect(MultiaddrWithPeerId),
     /// A request to obtain a `Block` with a specific `Cid`.
     GetBlock(Cid),
     /// A DHT request to Kademlia.
@@ -38,8 +38,8 @@ pub enum RequestKind {
     Num(u32),
 }
 
-impl From<Multiaddr> for RequestKind {
-    fn from(addr: Multiaddr) -> Self {
+impl From<MultiaddrWithPeerId> for RequestKind {
+    fn from(addr: MultiaddrWithPeerId) -> Self {
         Self::Connect(addr)
     }
 }

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -20,6 +20,9 @@ async fn connect_two_nodes_by_addr() {
 
 // Make sure only a `Multiaddr` with `/p2p/` can be used to connect.
 #[tokio::test(max_threads = 1)]
+#[should_panic(
+    expected = "called `Result::unwrap()` on an `Err` value: Missing Protocol::P2p in the Multiaddr"
+)]
 async fn dont_connect_without_p2p() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;
@@ -120,7 +123,7 @@ async fn connect_two_nodes_with_two_connections_doesnt_panic() {
     // peer..
 
     node_a
-        .disconnect(peers.remove(0).address)
+        .disconnect(peers.remove(0).addr)
         .await
         .expect("failed to disconnect peer_b at peer_a");
 

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -20,9 +20,7 @@ async fn connect_two_nodes_by_addr() {
 
 // Make sure only a `Multiaddr` with `/p2p/` can be used to connect.
 #[tokio::test(max_threads = 1)]
-#[should_panic(
-    expected = "called `Result::unwrap()` on an `Err` value: Missing Protocol::P2p in the Multiaddr"
-)]
+#[should_panic(expected = "called `Result::unwrap()` on an `Err` value: MissingProtocolP2p")]
 async fn dont_connect_without_p2p() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;


### PR DESCRIPTION
Whether a `Multiaddr` contains `Protocol::P2p` (i.e. essentially `/p2p/PeerId`) or not has a lot of bearing on conformance tests, the internal object and APIs and error-handling. Since it is easy to introduce related human errors, it would be a good idea to enforce some type safety here by introducing 2 wrapper objects: `MultiaddrWoPeerId` and `MultiaddrWithPeerId`.

The extent to which they should be applied (in lieu of `Multiaddr`) is a matter for discussion - in my initial attempt I decided to apply them quite liberally, as it results in more type safety (there are still a few plain `Multiaddr`s left though).