### PR TITLE
Conformance test suite updates

### DIFF
--- a/conformance/package-lock.json
+++ b/conformance/package-lock.json
@@ -2161,6 +2161,70 @@
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-0.5.0.tgz",
       "integrity": "sha512-oZLYFEAzUKyi3SKnXvj32ZCEGH6RDnao7COuCVhDydMS9NrCSVXhM79VaKyP5+Zc33m0QXEd2DN3UkU7OsHcfw=="
     },
+    "@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
+      "dev": true
+    },
+    "@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true
+    },
+    "@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true
+    },
+    "@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
+      "dev": true
+    },
+    "@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
+      "dev": true
+    },
+    "@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
+      "dev": true
+    },
+    "@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
+      "dev": true
+    },
+    "@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
+      "dev": true
+    },
+    "@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
+      "dev": true
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -2175,9 +2239,9 @@
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ=="
     },
     "@sinonjs/commons": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.2.tgz",
-      "integrity": "sha512-+DUO6pnp3udV/v2VfUWgaY5BIE1IfT7lLfeDzPVeMT1XKkaAp9LgSI9x5RtrFQoZ9Oi0PgXQQHPaoKu7dCjVxw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
+      "integrity": "sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==",
       "dev": true,
       "requires": {
         "type-detect": "4.0.8"
@@ -2203,9 +2267,9 @@
       }
     },
     "@sinonjs/samsam": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.3.tgz",
-      "integrity": "sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
+      "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.6.0",
@@ -2237,6 +2301,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
+    },
+    "@types/bl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/bl/-/bl-2.1.0.tgz",
+      "integrity": "sha512-1TdA9IXOy4sdqn8vgieQ6GZAiHiPNrOiO1s2GJjuYPw4QVY7gYoVjkW049avj33Ez7IcIvu43hQsMsoUFbCn2g==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/bn.js": {
       "version": "4.11.6",
@@ -2273,6 +2346,12 @@
         "@types/node": "*"
       }
     },
+    "@types/long": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -2297,6 +2376,24 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "@types/pbkdf2": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
+      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/secp256k1": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.1.tgz",
+      "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/unist": {
       "version": "2.0.3",
@@ -3310,6 +3407,16 @@
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
     },
+    "bcrypto": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.1.0.tgz",
+      "integrity": "sha512-WEs5g7WHdEdLLcsvhE7Z1AXv0G+hb+bJhSUYM7samFNrH051XhcFVWxAbAZDmIU1HWjpjhmQ+HqBar7UC/qrzQ==",
+      "dev": true,
+      "requires": {
+        "bufio": "~1.0.6",
+        "loady": "~0.0.1"
+      }
+    },
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -3359,12 +3466,6 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
       "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
-    },
-    "binary-querystring": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/binary-querystring/-/binary-querystring-0.1.2.tgz",
-      "integrity": "sha512-mrot/6OS3YIUSWMyv/9uyMbCDYQWxl+fVDsrJFjPFGcVT0xDCdEg/gbN6eguaCr0UqsuXdtJ3DQ3i2z2alnulg==",
-      "dev": true
     },
     "bindings": {
       "version": "1.5.0",
@@ -3425,9 +3526,9 @@
       "dev": true
     },
     "bitcoinjs-lib": {
-      "version": "5.1.7",
-      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.7.tgz",
-      "integrity": "sha512-sNlTQuvhaoIjOdIdyENsX74Dlikv7l6AzO0/uZQscuvfBID6aMANoCz1rooCTH5upTV5rKCj4z3BXBmXJxq23g==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/bitcoinjs-lib/-/bitcoinjs-lib-5.1.10.tgz",
+      "integrity": "sha512-CesUqtBtnYc+SOMsYN9jWQWhdohW1MpklUkF7Ukn4HiAyN6yxykG+cIJogfRt6x5xcgH87K1Q+Mnoe/B+du1Iw==",
       "dev": true,
       "requires": {
         "bech32": "^1.1.2",
@@ -3478,6 +3579,14 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
       "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
+    },
+    "blob-to-it": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/blob-to-it/-/blob-to-it-0.0.1.tgz",
+      "integrity": "sha512-gvOVIs0YUpKHAwvhoJcRs81LJrOb+kwOol0/NnF/JgD0a5i9SJ/Es/njJo3NgFzb+x/FDPh4cD4D1KnrBeUWuw==",
+      "requires": {
+        "browser-readablestream-to-it": "^0.0.1"
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -3726,6 +3835,11 @@
         "iltorb": "^2.4.3"
       }
     },
+    "browser-readablestream-to-it": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/browser-readablestream-to-it/-/browser-readablestream-to-it-0.0.1.tgz",
+      "integrity": "sha512-leRiI4bLRr7K8znNmQZ3frgL8A7aX4LI4g7444YEtT3alaxqem+XPGsJmOlFRRdRqjFpvf2wW4dXKcgBLxypVg=="
+    },
     "browser-resolve": {
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
@@ -3906,6 +4020,12 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "dev": true
+    },
+    "bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==",
       "dev": true
     },
     "builtin-status-codes": {
@@ -4338,9 +4458,9 @@
           }
         },
         "split2": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-          "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.1.tgz",
+          "integrity": "sha512-wmX3JdfKWWghQSjezpJyMxlFodG/vNbV/Y9scsCqYSDWo0nCdteOdzqh8z1NDxpcIZB6BhkqWo6642VI/HA3oA==",
           "dev": true,
           "requires": {
             "readable-stream": "^3.0.0"
@@ -5576,13 +5696,13 @@
       "integrity": "sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk="
     },
     "dag-cbor-links": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-1.3.4.tgz",
-      "integrity": "sha512-+4yAa3YQo4hucbdT+zsb/8nj5ZXsb4iIm/LzeUdUBv4zwfhR7Z5DJ1WNZTJvNh4XUO1fLOBRxCrlwnn5BqoNqg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/dag-cbor-links/-/dag-cbor-links-1.3.5.tgz",
+      "integrity": "sha512-yvNocHk61MIio/JpDta6/DUS7rxa7N4+uezf2u20hmLaMNA8meExbc8MvpJDEHYE9grbj+hkZnYOjNoaSXFX8A==",
       "dev": true,
       "requires": {
         "cids": "^0.8.0",
-        "ipld-dag-cbor": "^0.15.2"
+        "ipld-dag-cbor": "^0.16.0"
       }
     },
     "dargs": {
@@ -5610,22 +5730,6 @@
             "ms": "^2.1.1"
           }
         },
-        "interface-datastore": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
-          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.0",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -5635,129 +5739,47 @@
       }
     },
     "datastore-fs": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-0.9.1.tgz",
-      "integrity": "sha512-clhkqbYzpe/L0mKVBjXB7hxBpzDbYkMOG2aBH5jepSpmKmouJhp01yzUrqB6zRz01hEN0u2r4kosTVKJ3K4sUA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-fs/-/datastore-fs-1.1.0.tgz",
+      "integrity": "sha512-z/lsSMxi7omrPwCgGjZ1OrPN0cq35sFMWhTHnnF1ekvD3fxntB1gNqEi9ioMMJNX8OQap7JvYT40LdtZZx7mTg==",
       "dev": true,
       "requires": {
-        "datastore-core": "~0.7.0",
-        "fast-write-atomic": "~0.2.0",
+        "datastore-core": "^1.1.0",
+        "fast-write-atomic": "^0.2.0",
         "glob": "^7.1.3",
-        "interface-datastore": "~0.7.0",
-        "mkdirp": "~0.5.1"
+        "interface-datastore": "^1.0.2",
+        "mkdirp": "^1.0.4"
       },
       "dependencies": {
-        "datastore-core": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "interface-datastore": "~0.7.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-          "dev": true
-        },
-        "interface-datastore": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-          "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-          "dev": true,
-          "requires": {
-            "class-is": "^1.1.0",
-            "err-code": "^1.1.2",
-            "uuid": "^3.2.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         }
       }
     },
     "datastore-level": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.14.1.tgz",
-      "integrity": "sha512-gAXD11GfxMfUWkhFr3GebZjGxnHabnz6pOgxFw/6MddAE3pOfHCbPPssYdGGSDv+nl0jwhNrsncGdlQ/FvPpcg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-1.1.0.tgz",
+      "integrity": "sha512-XEuXC3mq2BTUdhOvx7vwD93GN1O8SJf1HL/EOlmVcxLt3EHtDpX5pqZmiDdrXIAfe4uiEuSfFu2tKycuz1PMZA==",
       "dev": true,
       "requires": {
-        "datastore-core": "~0.7.0",
-        "interface-datastore": "^0.8.0",
+        "datastore-core": "^1.1.0",
+        "interface-datastore": "^1.0.2",
         "level": "^5.0.1"
-      },
-      "dependencies": {
-        "datastore-core": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "interface-datastore": "~0.7.0"
-          },
-          "dependencies": {
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "dev": true,
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "datastore-pubsub": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.3.2.tgz",
-      "integrity": "sha512-NEBtuwLToPdzHEBQ+Gb+IBAFV+1Rm6CyFK323987+cNG001tFe5Qnly8MhlG/qOKX4/CdoKGw0bP/DIv4m0/ig==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/datastore-pubsub/-/datastore-pubsub-0.3.3.tgz",
+      "integrity": "sha512-QMGKZpOnwMO4UK14aU1GfsiyXv77F//7jj8mjTmbdma+iVBSLW1aNq6koZtw46DM7K9LfhlfLHyvyAl4JJp7fA==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
         "debug": "^4.1.1",
-        "err-code": "^2.0.0",
-        "interface-datastore": "^1.0.2",
+        "err-code": "^2.0.3",
+        "interface-datastore": "^1.0.4",
         "multibase": "^0.7.0"
       },
       "dependencies": {
@@ -5770,21 +5792,11 @@
             "ms": "^2.1.1"
           }
         },
-        "interface-datastore": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.2.tgz",
-          "integrity": "sha512-6pgs0z8VLTxcyRsT2O0nT87s7VOPs7MAzAqNhYsgpR+DPokyU5BCGD4DDEQmqORewMb4eV4HmwopW5UlkvYk9w==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "err-code": "^2.0.0",
-            "ipfs-utils": "^2.2.2",
-            "iso-random-stream": "^1.1.1",
-            "it-all": "^1.0.2",
-            "it-drain": "^1.0.1",
-            "nanoid": "^3.0.2"
-          }
+        "err-code": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+          "dev": true
         },
         "ms": {
           "version": "2.1.2",
@@ -5985,9 +5997,9 @@
       "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
     },
     "delay": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-4.3.0.tgz",
-      "integrity": "sha512-Lwaf3zVFDMBop1yDuFZ19F9WyGcZcGacsbdlZtWjQmM50tOcMntm1njF/Nb/Vjij3KaSvCF+sEYGKrrjObu2NA=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
+      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA=="
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -6207,9 +6219,9 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-match-patch": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
-      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+      "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
       "dev": true
     },
     "diffie-hellman": {
@@ -6515,17 +6527,6 @@
       "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
       "requires": {
         "is-obj": "^1.0.0"
-      }
-    },
-    "drbg.js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
-      "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
-      "dev": true,
-      "requires": {
-        "browserify-aes": "^1.0.6",
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4"
       }
     },
     "duplexer": {
@@ -7245,6 +7246,29 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "ethereum-cryptography": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
+      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "dev": true,
+      "requires": {
+        "@types/pbkdf2": "^3.0.0",
+        "@types/secp256k1": "^4.0.1",
+        "blakejs": "^1.1.0",
+        "browserify-aes": "^1.2.0",
+        "bs58check": "^2.1.2",
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "hash.js": "^1.1.7",
+        "keccak": "^3.0.0",
+        "pbkdf2": "^3.0.17",
+        "randombytes": "^2.1.0",
+        "safe-buffer": "^5.1.2",
+        "scrypt-js": "^3.0.0",
+        "secp256k1": "^4.0.1",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "ethereumjs-account": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ethereumjs-account/-/ethereumjs-account-3.0.0.tgz",
@@ -7279,9 +7303,9 @@
           }
         },
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         },
         "deferred-leveldown": {
@@ -7294,18 +7318,18 @@
           }
         },
         "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
             "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
+            "safe-buffer": "^5.1.1"
           }
         },
         "isarray": {
@@ -7313,18 +7337,6 @@
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
           "dev": true
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
-          }
         },
         "level-codec": {
           "version": "7.0.1",
@@ -7406,22 +7418,6 @@
             }
           }
         },
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
-        },
         "semver": {
           "version": "5.4.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
@@ -7437,9 +7433,9 @@
       }
     },
     "ethereumjs-common": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.1.tgz",
-      "integrity": "sha512-aVUPRLgmXORGXXEVkFYgPhr9TGtpBY2tGhZ9Uh0A3lIUzUDr1x6kQx33SbjPUkLkX3eniPQnIL/2psjkjrOfcQ==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.5.2.tgz",
+      "integrity": "sha512-hTfZjwGX52GS2jcVO6E2sx4YuFnf0Fhp5ylo4pEPhEffNln7vS59Hr5sLnp3/QCazFLluuBZ+FZ6J5HTp0EqCA==",
       "dev": true
     },
     "ethereumjs-tx": {
@@ -7453,41 +7449,25 @@
       }
     },
     "ethereumjs-util": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.0.tgz",
-      "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dev": true,
       "requires": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
+        "elliptic": "^6.5.2",
+        "ethereum-cryptography": "^0.1.3",
         "ethjs-util": "0.1.6",
-        "keccak": "^2.0.0",
-        "rlp": "^2.2.3",
-        "secp256k1": "^3.0.1"
+        "rlp": "^2.2.3"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
-        },
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
-          }
         }
       }
     },
@@ -7502,9 +7482,9 @@
       }
     },
     "event-iterator": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-1.2.0.tgz",
-      "integrity": "sha512-Daq7YUl0Mv1i4QEgzGQlz0jrx7hUFNyLGbiF+Ap7NCMCjDLCCnolyj6s0TAc6HmrBziO5rNVHsPwGMp7KdRPvw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/event-iterator/-/event-iterator-2.0.0.tgz",
+      "integrity": "sha512-KGft0ldl31BZVV//jj+IAIGCxkvvUkkON+ScH6zfoX+l+omX6001ggyRSpI0Io2Hlro0ThXotswCtfzS8UkIiQ==",
       "dev": true
     },
     "event-target-shim": {
@@ -7986,13 +7966,13 @@
       }
     },
     "file-type": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.3.0.tgz",
-      "integrity": "sha512-s71v6jMkbfwVdj87csLeNpL5K93mv4lN+lzgzifoICtPHhnXokDwBa3jrzfg+z6FK872iYJ0vS0i74v8XmoFDA==",
+      "version": "14.7.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-14.7.1.tgz",
+      "integrity": "sha512-sXAMgFk67fQLcetXustxfKX+PZgHIUFn96Xld9uH8aXPdX3xOp0/jg9OdouVTvQrf7mrn+wAa4jN/y9fUOOiRA==",
       "dev": true,
       "requires": {
         "readable-web-to-node-stream": "^2.0.0",
-        "strtok3": "^6.0.0",
+        "strtok3": "^6.0.3",
         "token-types": "^2.0.0",
         "typedarray-to-buffer": "^3.1.5"
       }
@@ -10458,90 +10438,48 @@
       }
     },
     "interface-datastore": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.8.3.tgz",
-      "integrity": "sha512-0boeaQbqRUV+7edgdkDDNl8/m0bzFbBEfM3tC0Prro2ZE7N9dtcIDh/cW812P/22Gjhlj1J7KIn0mPzbO4HjPQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-1.0.4.tgz",
+      "integrity": "sha512-nIOP/mVwDUc7OenayUyFQB3D6c3SxDG5opTPeSrhA0jS5q0XWkf8Nz2GtNBm3wkeSKUM6iXt6LwIOCH/+jFXIQ==",
       "dev": true,
       "requires": {
         "buffer": "^5.5.0",
         "class-is": "^1.1.0",
-        "err-code": "^2.0.0",
-        "ipfs-utils": "^1.2.3",
+        "err-code": "^2.0.1",
+        "ipfs-utils": "^2.2.2",
         "iso-random-stream": "^1.1.1",
+        "it-all": "^1.0.2",
+        "it-drain": "^1.0.1",
         "nanoid": "^3.0.2"
       },
       "dependencies": {
-        "ipfs-utils": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-1.2.4.tgz",
-          "integrity": "sha512-xUP7SmOAb50OHL8D2KasRHRBOtRdyHHerfCEJBmS9+qpe6wzpbhftdsZJ2UD2v7HXgi7IH9eTps5uPXKUd2aVg==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^5.4.2",
-            "err-code": "^2.0.0",
-            "fs-extra": "^9.0.0",
-            "is-electron": "^2.2.0",
-            "iso-url": "^0.4.7",
-            "it-glob": "0.0.7",
-            "merge-options": "^2.0.0",
-            "nanoid": "^2.1.11",
-            "node-fetch": "^2.6.0",
-            "stream-to-it": "^0.2.0"
-          },
-          "dependencies": {
-            "nanoid": {
-              "version": "2.1.11",
-              "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-              "integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
-              "dev": true
-            }
-          }
-        },
-        "it-glob": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.7.tgz",
-          "integrity": "sha512-XfbziJs4fi0MfdEGTLkZXeqo2EorF2baFXxFn1E2dGbgYMhFTZlZ2Yn/mx5CkpuLWVJvO1DwtTOVW2mzRyVK8w==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^8.1.0",
-            "minimatch": "^3.0.4"
-          },
-          "dependencies": {
-            "fs-extra": {
-              "version": "8.1.0",
-              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-              "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-              "dev": true,
-              "requires": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-              }
-            }
-          }
+        "err-code": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+          "dev": true
         }
       }
     },
     "interface-ipfs-core": {
-      "version": "0.137.0",
-      "resolved": "https://registry.npmjs.org/interface-ipfs-core/-/interface-ipfs-core-0.137.0.tgz",
-      "integrity": "sha512-//opRMeMUVnkxgkUa+ssZQh2XjhOw2stGxJsGI+ZN0d0TPsWRL3uk069eHWsQGODWo95B4663z4Y0dzxgTQQfQ==",
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/interface-ipfs-core/-/interface-ipfs-core-0.139.0.tgz",
+      "integrity": "sha512-CB/iX5Pc7yJeF0v88NRctIMlIjmYJzqS+xHWqvkAw1id9ZIuNNh/4zbwSlFsGEH7oZ12IYGJIJzdNcbj15sWXQ==",
       "requires": {
         "abort-controller": "^3.0.0",
         "buffer": "^5.6.0",
         "chai": "^4.2.0",
         "chai-as-promised": "^7.1.1",
         "chai-subset": "^1.6.0",
-        "cids": "^0.8.0",
+        "cids": "^0.8.3",
         "delay": "^4.3.0",
         "dirty-chai": "^2.0.1",
         "ipfs-unixfs": "^1.0.3",
         "ipfs-unixfs-importer": "^2.0.2",
         "ipfs-utils": "^2.2.2",
-        "ipld-block": "^0.9.1",
-        "ipld-dag-cbor": "^0.15.2",
-        "ipld-dag-pb": "^0.18.5",
+        "ipld-block": "^0.9.2",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
         "is-ipfs": "^1.0.3",
         "iso-random-stream": "^1.1.1",
         "it-all": "^1.0.1",
@@ -10549,15 +10487,28 @@
         "it-drain": "^1.0.1",
         "it-last": "^1.0.1",
         "it-pushable": "^1.3.1",
+        "libp2p-crypto": "^0.17.9",
         "multiaddr": "^7.4.3",
-        "multibase": "^0.7.0",
-        "multihashing-async": "^0.8.0",
+        "multibase": "^1.0.1",
+        "multihashing-async": "^1.0.0",
         "nanoid": "^3.0.2",
         "peer-id": "^0.13.12",
         "readable-stream": "^3.4.0",
         "temp-write": "^4.0.0"
       },
       "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
         "ipfs-unixfs": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.3.tgz",
@@ -10585,6 +10536,183 @@
             "merge-options": "^2.0.0",
             "multihashing-async": "^0.8.0",
             "rabin-wasm": "^0.1.1"
+          },
+          "dependencies": {
+            "ipld-dag-pb": {
+              "version": "0.18.5",
+              "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
+              "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "cids": "~0.8.0",
+                "class-is": "^1.1.0",
+                "multicodec": "^1.0.1",
+                "multihashing-async": "~0.8.1",
+                "protons": "^1.0.2",
+                "stable": "^0.1.8"
+              }
+            },
+            "multihashing-async": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+              "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "^0.8.0",
+                "multihashes": "^1.0.1",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            }
+          }
+        },
+        "ipld-dag-cbor": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
+          "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
+          "requires": {
+            "borc": "^2.1.2",
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "is-circular": "^1.0.2",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0"
+          },
+          "dependencies": {
+            "multicodec": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
+          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0",
+            "protons": "^1.2.1",
+            "stable": "^0.1.8"
+          },
+          "dependencies": {
+            "multicodec": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
+              }
+            },
+            "protons": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+              "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+              "requires": {
+                "buffer": "^5.5.0",
+                "protocol-buffers-schema": "^3.3.1",
+                "signed-varint": "^2.0.1",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.2.1",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.0.0",
+            "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "multicodec": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
+              }
+            },
+            "multihashing-async": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+              "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "^0.8.0",
+                "multihashes": "^1.0.1",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            },
+            "protons": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+              "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+              "requires": {
+                "buffer": "^5.5.0",
+                "protocol-buffers-schema": "^3.3.1",
+                "signed-varint": "^2.0.1",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         },
         "readable-stream": {
@@ -10666,9 +10794,9 @@
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "ipfs": {
-      "version": "0.43.3",
-      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.43.3.tgz",
-      "integrity": "sha512-uNd9KReDFRHJ73tCR77y+AkiknroMBZA/LoN+wZ26Z8m7NRyEhXRxVIoeIB2EfIdOdYuwfkz2HB8ihWki0COVA==",
+      "version": "0.49.0",
+      "resolved": "https://registry.npmjs.org/ipfs/-/ipfs-0.49.0.tgz",
+      "integrity": "sha512-v1NpOoHDWmsRFaic2oYWAT/m7QnoF9GaPFT07u47g6rnYujp2IW5U8pQKVVAMgdyGsWpWALHuMJ13WBUZMfYYg==",
       "dev": true,
       "requires": {
         "@hapi/ammo": "^3.1.2",
@@ -10680,100 +10808,100 @@
         "any-signal": "^1.1.0",
         "array-shuffle": "^1.0.1",
         "bignumber.js": "^9.0.0",
-        "binary-querystring": "^0.1.2",
-        "bl": "^4.0.0",
+        "bl": "^4.0.2",
         "bs58": "^4.0.1",
+        "buffer": "^5.6.0",
         "byteman": "^1.3.5",
         "cid-tool": "^0.4.0",
-        "cids": "^0.8.0",
+        "cids": "^0.8.3",
         "class-is": "^1.1.0",
-        "dag-cbor-links": "^1.3.2",
-        "datastore-core": "^1.0.0",
-        "datastore-level": "^0.14.1",
-        "datastore-pubsub": "^0.3.0",
+        "dag-cbor-links": "^1.3.3",
+        "datastore-core": "^1.1.0",
+        "datastore-pubsub": "^0.3.2",
         "debug": "^4.1.0",
         "dlv": "^1.1.3",
         "err-code": "^2.0.0",
+        "execa": "^4.0.0",
         "file-type": "^14.1.4",
         "fnv1a": "^1.0.1",
         "get-folder-size": "^2.0.0",
         "hamt-sharding": "^1.0.0",
         "hapi-pino": "^6.1.0",
         "hashlru": "^2.3.0",
-        "interface-datastore": "^0.8.0",
-        "ipfs-bitswap": "0.27.1",
-        "ipfs-block": "^0.8.1",
-        "ipfs-block-service": "^0.16.0",
-        "ipfs-core-utils": "^0.2.2",
-        "ipfs-http-client": "^44.0.3",
+        "interface-datastore": "^1.0.2",
+        "ipfs-bitswap": "^2.0.1",
+        "ipfs-block-service": "^0.17.1",
+        "ipfs-core-utils": "^0.3.1",
+        "ipfs-http-client": "^46.0.0",
         "ipfs-http-response": "^0.5.0",
-        "ipfs-repo": "^1.0.1",
-        "ipfs-unixfs": "^1.0.1",
-        "ipfs-unixfs-exporter": "^2.0.0",
-        "ipfs-unixfs-importer": "^2.0.0",
+        "ipfs-repo": "^4.0.0",
+        "ipfs-unixfs": "^1.0.3",
+        "ipfs-unixfs-exporter": "^2.0.2",
+        "ipfs-unixfs-importer": "^2.0.2",
         "ipfs-utils": "^2.2.2",
-        "ipld": "^0.25.0",
+        "ipld": "^0.26.2",
         "ipld-bitcoin": "^0.3.0",
-        "ipld-dag-cbor": "^0.15.1",
-        "ipld-dag-pb": "^0.18.3",
+        "ipld-block": "^0.9.2",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
         "ipld-ethereum": "^4.0.0",
         "ipld-git": "^0.5.0",
-        "ipld-raw": "^4.0.1",
+        "ipld-raw": "^5.0.0",
         "ipld-zcash": "^0.4.0",
-        "ipns": "^0.7.0",
+        "ipns": "^0.7.1",
         "is-domain-name": "^1.0.1",
-        "is-ipfs": "^1.0.0",
+        "is-ipfs": "^1.0.3",
+        "iso-url": "^0.4.7",
         "it-all": "^1.0.1",
         "it-concat": "^1.0.0",
-        "it-drain": "^1.0.0",
-        "it-glob": "0.0.7",
+        "it-drain": "^1.0.1",
+        "it-first": "^1.0.1",
+        "it-glob": "0.0.8",
         "it-last": "^1.0.1",
         "it-map": "^1.0.0",
         "it-multipart": "^1.0.1",
         "it-pipe": "^1.1.0",
-        "it-tar": "^1.2.1",
+        "it-tar": "^1.2.2",
         "it-to-stream": "^0.1.1",
         "iterable-ndjson": "^1.1.0",
         "jsondiffpatch": "^0.4.1",
         "just-safe-set": "^2.1.0",
-        "libp2p": "^0.27.2",
-        "libp2p-bootstrap": "^0.10.3",
-        "libp2p-crypto": "^0.17.1",
-        "libp2p-delegated-content-routing": "^0.4.4",
-        "libp2p-delegated-peer-routing": "^0.4.2",
-        "libp2p-floodsub": "^0.20.0",
-        "libp2p-gossipsub": "^0.2.3",
-        "libp2p-kad-dht": "^0.18.3",
-        "libp2p-keychain": "^0.6.0",
-        "libp2p-mdns": "^0.13.1",
-        "libp2p-mplex": "^0.9.3",
-        "libp2p-record": "^0.7.0",
-        "libp2p-secio": "^0.12.2",
-        "libp2p-tcp": "^0.14.3",
-        "libp2p-webrtc-star": "^0.17.9",
+        "libp2p": "^0.28.10",
+        "libp2p-bootstrap": "^0.11.0",
+        "libp2p-crypto": "^0.17.9",
+        "libp2p-delegated-content-routing": "^0.5.0",
+        "libp2p-delegated-peer-routing": "^0.5.0",
+        "libp2p-floodsub": "^0.21.0",
+        "libp2p-gossipsub": "^0.4.0",
+        "libp2p-kad-dht": "^0.19.9",
+        "libp2p-mdns": "^0.14.1",
+        "libp2p-mplex": "^0.9.5",
+        "libp2p-noise": "^1.1.1",
+        "libp2p-record": "^0.7.3",
+        "libp2p-secio": "^0.12.6",
+        "libp2p-tcp": "^0.14.5",
+        "libp2p-webrtc-star": "^0.18.0",
         "libp2p-websockets": "^0.13.3",
         "mafmt": "^7.0.0",
         "merge-options": "^2.0.0",
         "mortice": "^2.0.0",
-        "multiaddr": "^7.2.1",
+        "multiaddr": "^7.4.3",
         "multiaddr-to-uri": "^5.1.0",
-        "multibase": "^0.7.0",
+        "multibase": "^1.0.1",
         "multicodec": "^1.0.0",
-        "multihashes": "^0.4.14",
-        "multihashing-async": "^0.8.0",
+        "multihashing-async": "^1.0.0",
         "p-defer": "^3.0.0",
         "p-queue": "^6.1.0",
-        "parse-duration": "^0.1.2",
-        "peer-id": "^0.13.5",
-        "peer-info": "^0.17.0",
+        "parse-duration": "^0.4.4",
+        "peer-id": "^0.13.12",
         "pretty-bytes": "^5.3.0",
         "progress": "^2.0.1",
         "prom-client": "^12.0.0",
         "prometheus-gc-stats": "^0.6.0",
-        "protons": "^1.0.1",
-        "semver": "^7.1.2",
-        "stream-to-it": "^0.2.0",
-        "streaming-iterables": "^4.1.1",
+        "protons": "^1.2.1",
+        "semver": "^7.3.2",
+        "stream-to-it": "^0.2.1",
+        "streaming-iterables": "^5.0.0",
         "temp": "^0.9.0",
         "timeout-abort-controller": "^1.1.0",
         "update-notifier": "^4.0.0",
@@ -10804,6 +10932,19 @@
             "@hapi/topo": "3.x.x"
           }
         },
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -10813,60 +10954,52 @@
             "ms": "^2.1.1"
           }
         },
-        "fs-extra": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-          "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
-          }
-        },
-        "ipfs-http-client": {
-          "version": "44.0.3",
-          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-44.0.3.tgz",
-          "integrity": "sha512-uO/UkMryuKMqIzNkyWv056RpGZZX7UPGwIE49Y0ZAAqAmm08pxIiC1B93NP4jBefW/aNFjazcyhAewMqg1YeNw==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "bignumber.js": "^9.0.0",
-            "bs58": "^4.0.1",
-            "buffer": "^5.4.2",
-            "cids": "^0.8.0",
-            "debug": "^4.1.0",
-            "form-data": "^3.0.0",
-            "ipfs-block": "^0.8.1",
-            "ipfs-core-utils": "^0.2.2",
-            "ipfs-utils": "^2.2.2",
-            "ipld-dag-cbor": "^0.15.1",
-            "ipld-dag-pb": "^0.18.3",
-            "ipld-raw": "^4.0.1",
-            "iso-url": "^0.4.7",
-            "it-tar": "^1.2.1",
-            "it-to-buffer": "^1.0.0",
-            "it-to-stream": "^0.1.1",
-            "merge-options": "^2.0.0",
-            "multiaddr": "^7.2.1",
-            "multiaddr-to-uri": "^5.1.0",
-            "multibase": "^0.7.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "^0.4.14",
-            "nanoid": "^3.0.2",
-            "node-fetch": "^2.6.0",
-            "parse-duration": "^0.1.2",
-            "stream-to-it": "^0.2.0"
-          }
-        },
-        "it-glob": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/it-glob/-/it-glob-0.0.7.tgz",
-          "integrity": "sha512-XfbziJs4fi0MfdEGTLkZXeqo2EorF2baFXxFn1E2dGbgYMhFTZlZ2Yn/mx5CkpuLWVJvO1DwtTOVW2mzRyVK8w==",
-          "dev": true,
-          "requires": {
-            "fs-extra": "^8.1.0",
-            "minimatch": "^3.0.4"
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.2.1",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.0.0",
+            "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "multicodec": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
+              }
+            },
+            "multihashing-async": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+              "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+              "dev": true,
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "^0.8.0",
+                "multihashes": "^1.0.1",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            }
           }
         },
         "ms": {
@@ -10874,47 +11007,106 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
         },
         "p-defer": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
           "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
           "dev": true
+        },
+        "protons": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+          "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "stream-to-it": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.2.tgz",
+          "integrity": "sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==",
+          "dev": true,
+          "requires": {
+            "get-iterator": "^1.0.2"
+          }
         }
       }
     },
     "ipfs-bitswap": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-0.27.1.tgz",
-      "integrity": "sha512-s0RGRVOq9zyBwzz93y7VSkYL6YbjJPNnkZy4ibPS8N7lRgJgIoO2JLrVgeBLJjlecqVesHMIlgvfIIkjvKRYBA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-bitswap/-/ipfs-bitswap-2.0.1.tgz",
+      "integrity": "sha512-kZauF0XwatrMe0SfdKs4abrarcVNRzdfWFaz+kodGl1Uq7aryf/DZmSutw3NFkJDVnYWAQ7l55VsDRxC4kD6dg==",
       "dev": true,
       "requires": {
+        "abort-controller": "^3.0.0",
+        "any-signal": "^1.1.0",
         "bignumber.js": "^9.0.0",
-        "cids": "~0.7.0",
+        "cids": "^0.8.3",
         "debug": "^4.1.0",
-        "ipfs-block": "~0.8.0",
+        "ipld-block": "^0.9.1",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.1.0",
         "just-debounce-it": "^1.1.0",
+        "libp2p-interfaces": "^0.3.0",
         "moving-average": "^1.0.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "^0.8.0",
+        "multicodec": "^1.0.3",
+        "multihashing-async": "^1.0.0",
         "protons": "^1.0.1",
-        "streaming-iterables": "^4.1.1",
-        "varint-decoder": "~0.1.1"
+        "streaming-iterables": "^5.0.2",
+        "varint-decoder": "^0.4.0"
       },
       "dependencies": {
         "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
+            "buffer": "^5.6.0",
             "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
           }
         },
         "debug": {
@@ -10933,106 +11125,170 @@
           "dev": true
         },
         "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
           "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
-          }
-        }
-      }
-    },
-    "ipfs-block": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/ipfs-block/-/ipfs-block-0.8.1.tgz",
-      "integrity": "sha512-0FaCpmij+jZBoUYhjoB5ptjdl9QzvrdRIoBmUU5JiBnK2GA+4YM/ifklaB8ePRhA/rRzhd+KYBjvMFMAL4NrVQ==",
-      "dev": true,
-      "requires": {
-        "cids": "~0.7.0",
-        "class-is": "^1.1.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
           }
         },
-        "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
           "dev": true,
           "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
     },
     "ipfs-block-service": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.16.0.tgz",
-      "integrity": "sha512-cSITuhI8Bizrmks8rC6SmFcSbtUf9bIUPbpHetwb7T3raSseODx80Wy51JKXFkMyLAuWYHOfDie0J/kf5csGKw==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/ipfs-block-service/-/ipfs-block-service-0.17.1.tgz",
+      "integrity": "sha512-I12f6nXCJfkv9IoxZTRbHcIAa/bptSGAMDawAm2GUqD8lNPs3w2KuLpxBX6doZomhJ07C5VtaiW0pmWY5L52WA==",
       "dev": true,
       "requires": {
+        "err-code": "^2.0.0",
         "streaming-iterables": "^4.1.0"
+      },
+      "dependencies": {
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
+        }
       }
     },
     "ipfs-core-utils": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.2.2.tgz",
-      "integrity": "sha512-JBE1yx9OEjj463ymR01qoky/DTX3KOocL+8BhlUJaWAFHyh4HEmJXVdjITp60jiq+VRTVmASIFA85Gtoosx9UA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.3.1.tgz",
+      "integrity": "sha512-FFvGyw4etKamNHnwQdfq//PYW0h1GvbMu3cikNUgSwA2gTEj8B3rq2ypxb0sOw+wszlCjF/aWfZ4+UEK+sjakw==",
       "dev": true,
       "requires": {
-        "buffer": "^5.4.2",
+        "blob-to-it": "0.0.1",
+        "browser-readablestream-to-it": "0.0.1",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "err-code": "^2.0.0",
-        "ipfs-utils": "^2.2.2"
+        "ipfs-utils": "^2.2.2",
+        "it-all": "^1.0.1",
+        "it-map": "^1.0.0",
+        "it-peekable": "0.0.1"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "ipfs-http-client": {
-      "version": "44.3.0",
-      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-44.3.0.tgz",
-      "integrity": "sha512-oGlD2GkyisCrRPgJYrpo6TYA5VZneCoazEaaKxc1fyGd9TG0Fvc/nBuwW6jB6I5CR78z1JwKr/71QlvZL4jDNg==",
+      "version": "46.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-46.0.0.tgz",
+      "integrity": "sha512-7aSluSl4BzZXHhS60OgUxr3HYjIfszWxzYNevF9008c0/nfqHDRKm9Q4J+zd+S1tJS0JNTRuCOfGVE35g+jtTw==",
       "requires": {
         "abort-controller": "^3.0.0",
         "any-signal": "^1.1.0",
         "bignumber.js": "^9.0.0",
         "buffer": "^5.6.0",
-        "cids": "^0.8.0",
+        "cids": "^0.8.3",
         "debug": "^4.1.0",
         "form-data": "^3.0.0",
-        "ipfs-core-utils": "^0.2.4",
+        "ipfs-core-utils": "^0.3.1",
         "ipfs-utils": "^2.2.2",
-        "ipld-block": "^0.9.1",
-        "ipld-dag-cbor": "^0.15.2",
-        "ipld-dag-pb": "^0.18.5",
+        "ipld-block": "^0.9.2",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
         "ipld-raw": "^5.0.0",
         "iso-url": "^0.4.7",
+        "it-last": "^1.0.1",
         "it-tar": "^1.2.2",
         "it-to-buffer": "^1.0.0",
         "it-to-stream": "^0.1.1",
         "merge-options": "^2.0.0",
         "multiaddr": "^7.4.3",
         "multiaddr-to-uri": "^5.1.0",
-        "multibase": "^0.7.0",
+        "multibase": "^1.0.1",
         "multicodec": "^1.0.0",
         "multihashes": "^1.0.1",
         "nanoid": "^3.0.2",
         "node-fetch": "^2.6.0",
-        "parse-duration": "^0.1.2",
-        "stream-to-it": "^0.2.0"
+        "parse-duration": "^0.4.4",
+        "stream-to-it": "^0.2.1"
       },
       "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -11042,13 +11298,68 @@
           }
         },
         "ipfs-core-utils": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.2.4.tgz",
-          "integrity": "sha512-Spj5xtmdKMAOsPSUEmiKxj5Oa6FLP5QJgdA5w2WGpaUKw9fTU0he+mtb5Fs/PZusbU9GWxYELVZ1f1TnemeVsA==",
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/ipfs-core-utils/-/ipfs-core-utils-0.3.1.tgz",
+          "integrity": "sha512-FFvGyw4etKamNHnwQdfq//PYW0h1GvbMu3cikNUgSwA2gTEj8B3rq2ypxb0sOw+wszlCjF/aWfZ4+UEK+sjakw==",
+          "requires": {
+            "blob-to-it": "0.0.1",
+            "browser-readablestream-to-it": "0.0.1",
+            "buffer": "^5.6.0",
+            "cids": "^0.8.3",
+            "err-code": "^2.0.0",
+            "ipfs-utils": "^2.2.2",
+            "it-all": "^1.0.1",
+            "it-map": "^1.0.0",
+            "it-peekable": "0.0.1"
+          }
+        },
+        "ipld-dag-cbor": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
+          "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
+          "requires": {
+            "borc": "^2.1.2",
+            "buffer": "^5.6.0",
+            "cids": "~0.8.3",
+            "is-circular": "^1.0.2",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0"
+          },
+          "dependencies": {
+            "multicodec": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.19.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
+          "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
           "requires": {
             "buffer": "^5.6.0",
-            "err-code": "^2.0.0",
-            "ipfs-utils": "^2.2.2"
+            "cids": "~0.8.3",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.3",
+            "multihashing-async": "^1.0.0",
+            "protons": "^1.2.1",
+            "stable": "^0.1.8"
+          },
+          "dependencies": {
+            "multicodec": {
+              "version": "1.0.4",
+              "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+              "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+              "requires": {
+                "buffer": "^5.6.0",
+                "varint": "^5.0.0"
+              }
+            }
           }
         },
         "ipld-raw": {
@@ -11059,12 +11370,36 @@
             "cids": "~0.8.0",
             "multicodec": "^1.0.1",
             "multihashing-async": "~0.8.1"
+          },
+          "dependencies": {
+            "multihashing-async": {
+              "version": "0.8.2",
+              "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+              "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+              "requires": {
+                "blakejs": "^1.1.0",
+                "buffer": "^5.4.3",
+                "err-code": "^2.0.0",
+                "js-sha3": "^0.8.0",
+                "multihashes": "^1.0.1",
+                "murmurhash3js-revisited": "^3.0.0"
+              }
+            }
           }
         },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
         },
         "multihashes": {
           "version": "1.0.1",
@@ -11074,28 +11409,54 @@
             "buffer": "^5.6.0",
             "multibase": "^1.0.1",
             "varint": "^5.0.0"
-          },
-          "dependencies": {
-            "multibase": {
-              "version": "1.0.1",
-              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
-              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
-              "requires": {
-                "base-x": "^3.0.8",
-                "buffer": "^5.5.0"
-              }
-            }
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "parse-duration": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.4.4.tgz",
+          "integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg=="
+        },
+        "protons": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+          "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "stream-to-it": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.2.tgz",
+          "integrity": "sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==",
+          "requires": {
+            "get-iterator": "^1.0.2"
           }
         }
       }
     },
     "ipfs-http-response": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.5.0.tgz",
-      "integrity": "sha512-+z0HxqD6rxEPQCINgTvvMVsdr48pS1P9jzgz1hRjbufVugcpf5r2FGGjwXKCYGjKrWUT83CjpN0PWFI/dSQBmQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/ipfs-http-response/-/ipfs-http-response-0.5.1.tgz",
+      "integrity": "sha512-Mu7LWkCCE2C8H0he2jJKY7KtmmjuSaft+wSzAZedT1WRvsgv/05JI4XXlGc2Z37eB9q0nQPFKIE83I7gJRNEaw==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.1",
+        "cids": "~0.8.1",
         "debug": "^4.1.1",
         "file-type": "^8.0.0",
         "filesize": "^3.6.1",
@@ -11103,22 +11464,35 @@
         "it-concat": "^1.0.0",
         "it-reader": "^2.1.0",
         "it-to-stream": "^0.1.1",
-        "mime-types": "^2.1.21",
-        "multihashes": "~0.4.14",
+        "mime-types": "^2.1.27",
+        "multihashes": "~0.4.19",
         "p-try-each": "^1.0.1"
       },
       "dependencies": {
         "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
+            "buffer": "^5.6.0",
             "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          },
+          "dependencies": {
+            "multihashes": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+              "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.6.0",
+                "multibase": "^1.0.1",
+                "varint": "^5.0.0"
+              }
+            }
           }
         },
         "debug": {
@@ -11143,9 +11517,9 @@
           "dev": true
         },
         "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
           "dev": true,
           "requires": {
             "base-x": "^3.0.8",
@@ -11155,60 +11529,34 @@
       }
     },
     "ipfs-repo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-1.1.0.tgz",
-      "integrity": "sha512-7I/5NOiitacpHyU8bTw258dAApJsb3ssfZT+ZHzGd7aIrUmU7qh1v6F5tYVoVMYuPL2yMlX8ciOcPNBTCh6OMQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-repo/-/ipfs-repo-4.0.0.tgz",
+      "integrity": "sha512-rhmRjO3ekS4/RzgNB1EQOudKCCYK23Lb2/E6eD3So5r0bX1PvDdybbzfpDj05HBoNmvDy9pYDJzdtdH7a4gP3w==",
       "dev": true,
       "requires": {
-        "base32.js": "~0.1.0",
         "bignumber.js": "^9.0.0",
+        "buffer": "^5.6.0",
         "bytes": "^3.1.0",
         "cids": "^0.8.0",
-        "datastore-core": "~0.7.0",
-        "datastore-fs": "~0.9.0",
-        "datastore-level": "~0.14.0",
+        "datastore-core": "^1.1.0",
+        "datastore-fs": "^1.1.0",
+        "datastore-level": "^1.1.0",
         "debug": "^4.1.0",
         "err-code": "^2.0.0",
-        "interface-datastore": "^0.8.0",
-        "ipfs-block": "~0.8.1",
-        "ipfs-repo-migrations": "~0.1.0",
+        "interface-datastore": "^1.0.2",
+        "ipfs-repo-migrations": "^1.0.0",
+        "ipfs-utils": "^2.2.0",
+        "ipld-block": "^0.9.1",
+        "it-map": "^1.0.2",
+        "it-pushable": "^1.4.0",
         "just-safe-get": "^2.0.0",
         "just-safe-set": "^2.1.0",
-        "lodash.has": "^4.5.2",
+        "multibase": "^1.0.1",
         "p-queue": "^6.0.0",
         "proper-lockfile": "^4.0.0",
         "sort-keys": "^4.0.0"
       },
       "dependencies": {
-        "datastore-core": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "interface-datastore": "~0.7.0"
-          },
-          "dependencies": {
-            "err-code": {
-              "version": "1.1.2",
-              "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-              "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-              "dev": true
-            },
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "dev": true,
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
-            }
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -11230,6 +11578,16 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
         "sort-keys": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-4.0.0.tgz",
@@ -11242,100 +11600,33 @@
       }
     },
     "ipfs-repo-migrations": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-0.1.1.tgz",
-      "integrity": "sha512-Id8K32l7bEqMt0YxfDUAAiMFkfFr9pslOT0xg3EqTrPc0AeXQ5sZu6y69p5TI7N+A28PhrGgMU40R7IQ8Mb7sg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ipfs-repo-migrations/-/ipfs-repo-migrations-1.0.1.tgz",
+      "integrity": "sha512-yPVm9hyhZxc3ZB7+5YJ1W1MOzXN+9Oyp/4xdmNyjsI9lTtf5s0PP2NqXcpxgDP09epNlMMt3LJEt4QP3qHrL/A==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
-        "datastore-fs": "~0.9.1",
-        "datastore-level": "~0.12.1",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
+        "datastore-core": "^1.1.0",
+        "datastore-fs": "^1.0.0",
+        "datastore-level": "^1.1.0",
         "debug": "^4.1.0",
-        "interface-datastore": "~0.8.0",
-        "proper-lockfile": "^4.1.1",
-        "yargs": "^14.2.0",
-        "yargs-promise": "^1.1.0"
+        "interface-datastore": "^1.0.2",
+        "multibase": "^1.0.1",
+        "proper-lockfile": "^4.1.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "datastore-core": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/datastore-core/-/datastore-core-0.7.0.tgz",
-          "integrity": "sha512-hj7YQCDW+N22k7PRQ1XIwFWv78cJ311OGKzqFlJb5Afe1ARx9T1lyDkzr19a6ejDpK+f5EcSumra0MwJ/Ee7mw==",
-          "dev": true,
-          "requires": {
-            "debug": "^4.1.1",
-            "interface-datastore": "~0.7.0"
-          },
-          "dependencies": {
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "dev": true,
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
-            }
-          }
-        },
-        "datastore-level": {
-          "version": "0.12.1",
-          "resolved": "https://registry.npmjs.org/datastore-level/-/datastore-level-0.12.1.tgz",
-          "integrity": "sha512-PxUIrH/0ijuaJLypOx1XjOIvsZCZcN1qZ3HKyqXFhU8Wpkn01/Q/9nL/MM1tKK1EwOTFmgXKUtFbO27gf6LpcQ==",
-          "dev": true,
-          "requires": {
-            "datastore-core": "~0.7.0",
-            "interface-datastore": "~0.7.0",
-            "level": "^5.0.1"
-          },
-          "dependencies": {
-            "interface-datastore": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-0.7.0.tgz",
-              "integrity": "sha512-TfwzBe7iInnakxjWDQn8GQHRDSgmVXRylBo9Z6ONjtaIXB1aJFYpvW1mt+Kbnql/xpTxD2LsQKRBS9+EiTVmhA==",
-              "dev": true,
-              "requires": {
-                "class-is": "^1.1.0",
-                "err-code": "^1.1.2",
-                "uuid": "^3.2.2"
-              }
-            }
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
           }
         },
         "debug": {
@@ -11347,151 +11638,39 @@
             "ms": "^2.1.1"
           }
         },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "err-code": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
-          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=",
-          "dev": true
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
           }
         },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "yargs": {
-          "version": "14.2.3",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
-          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^15.0.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "15.0.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
-          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
           }
         }
       }
     },
     "ipfs-unixfs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.2.tgz",
-      "integrity": "sha512-+TucOvxUjSiNSn0eh7aiRaP+KkZC7IM8BnmVammbsUczKbzsWhxQfdgYRQk/btct/KvJeJkF0SVlKLd3MwJ/UQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs/-/ipfs-unixfs-1.0.3.tgz",
+      "integrity": "sha512-fCwC0vIuQrPSNDWzVKwf31T1tA3vLwlPTC5UgAD8ZrrDgOdeJlhyeqEsMX0fxtuxR3SAKscZr43Lgjrbd5qh0Q==",
       "dev": true,
       "requires": {
         "err-code": "^2.0.0",
@@ -11499,31 +11678,31 @@
       }
     },
     "ipfs-unixfs-exporter": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-2.0.1.tgz",
-      "integrity": "sha512-DyXM/D7I/dquiXP9HS1MsPwJZYht1KjJkRncgzHstQ6fepKPlC28n1cbPr43/JfYG0GfI5sjhvSI7w3XEou+PQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-exporter/-/ipfs-unixfs-exporter-2.0.2.tgz",
+      "integrity": "sha512-O4PknoOXzQKyAPFSZ+DCaPcSMmUnjPn2kxzhMGlWbXlUXkgGSs1cf3vcy16c/czF7DzVbQruhwURiR1IpUcYQA==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
         "cids": "^0.8.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^1.0.2",
+        "ipfs-unixfs": "^1.0.3",
         "it-last": "^1.0.1",
         "multihashing-async": "^0.8.0"
       }
     },
     "ipfs-unixfs-importer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-2.0.1.tgz",
-      "integrity": "sha512-N3PRdmreRz4WqaVPmgMSgvL8+mh4Xb7T0c/2kmsdJJem8Dorn0eYe5wJ7pk227uDqq/R6XxAN0dWZt5+hsnwFw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ipfs-unixfs-importer/-/ipfs-unixfs-importer-2.0.2.tgz",
+      "integrity": "sha512-VPi3zfNtTZZ22xECD2eY9c90tvzsan21z+8p+mG5U4inzUm+yBeWU8QCk9gzkHfrxAXaJO3VS8KOriFK+o0RGQ==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
         "buffer": "^5.6.0",
         "err-code": "^2.0.0",
         "hamt-sharding": "^1.0.0",
-        "ipfs-unixfs": "^1.0.2",
+        "ipfs-unixfs": "^1.0.3",
         "ipld-dag-pb": "^0.18.5",
         "it-all": "^1.0.1",
         "it-batch": "^1.0.3",
@@ -11532,6 +11711,23 @@
         "merge-options": "^2.0.0",
         "multihashing-async": "^0.8.0",
         "rabin-wasm": "^0.1.1"
+      },
+      "dependencies": {
+        "ipld-dag-pb": {
+          "version": "0.18.5",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
+          "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "multicodec": "^1.0.1",
+            "multihashing-async": "~0.8.1",
+            "protons": "^1.0.2",
+            "stable": "^0.1.8"
+          }
+        }
       }
     },
     "ipfs-utils": {
@@ -11650,55 +11846,118 @@
       }
     },
     "ipld": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.25.5.tgz",
-      "integrity": "sha512-9t5qh/ROQyj2Denl4KbOd3SmNLTGvh33ZYbt5P8Jury8EdDoZhBvknFq4maK6GZMjEeAiXphMGg/YaKTrim5Ew==",
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/ipld/-/ipld-0.26.4.tgz",
+      "integrity": "sha512-beRa9tayJDbzlqA7UEnUXQq654dAgnsrTSIJIe/vOBJToH8lDc/pLuIOmPYrDCVlv6XtJuZ7qgk3bIPppb21dA==",
       "dev": true,
       "requires": {
-        "cids": "~0.8.0",
-        "ipfs-block": "~0.8.1",
-        "ipld-dag-cbor": "~0.15.0",
-        "ipld-dag-pb": "~0.18.1",
-        "ipld-raw": "^4.0.0",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
+        "ipld-block": "^0.9.1",
+        "ipld-dag-cbor": "^0.16.0",
+        "ipld-dag-pb": "^0.19.0",
+        "ipld-raw": "^5.0.0",
         "merge-options": "^2.0.0",
         "multicodec": "^1.0.0",
         "typical": "^6.0.0"
-      }
-    },
-    "ipld-bitcoin": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.3.1.tgz",
-      "integrity": "sha512-0ysHoWyT+xXNyDafZrlH6YHGXWKkZ392eOardFTl2c9EUXDOt2W8VNaWol8ZyYSlD1nELwNLjC4e7p8aBY/OEg==",
-      "dev": true,
-      "requires": {
-        "bitcoinjs-lib": "^5.0.0",
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.8.0"
       },
       "dependencies": {
         "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
+            "buffer": "^5.6.0",
             "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
           }
         },
         "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
           "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        }
+      }
+    },
+    "ipld-bitcoin": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/ipld-bitcoin/-/ipld-bitcoin-0.3.2.tgz",
+      "integrity": "sha512-cglP2KmfpQK6UWR6Yu4+F2Aj8z5m3z/ng4Bq2FV9rxASGSQn1nmVRFQu39j2lYcEUrvPPc+HRsDz1Ppvd6xODQ==",
+      "dev": true,
+      "requires": {
+        "bitcoinjs-lib": "^5.0.0",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
+        "multicodec": "^1.0.0",
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
@@ -11714,200 +11973,396 @@
       }
     },
     "ipld-dag-cbor": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.15.2.tgz",
-      "integrity": "sha512-Ioni4s959P/CtkWQOt1TXrj4zqc3MoPxvHrEmybCn5JFdG3dpBNJR1oBVvP6uUrmF5bBtUGKNbX1pSI5SEOaHg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-cbor/-/ipld-dag-cbor-0.16.0.tgz",
+      "integrity": "sha512-dnmR8Pgt1gGmEXWSf/V3dKDPveGnHsovvAAN7m/WHW5mXsBqYYOStt98K1RhCifbB7vY+IHmpdRhVka0g9DWFQ==",
+      "dev": true,
       "requires": {
         "borc": "^2.1.2",
-        "buffer": "^5.5.0",
-        "cids": "~0.8.0",
+        "buffer": "^5.6.0",
+        "cids": "~0.8.3",
         "is-circular": "^1.0.2",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
+        "multicodec": "^1.0.3",
+        "multihashing-async": "^1.0.0"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        }
       }
     },
     "ipld-dag-pb": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.18.5.tgz",
-      "integrity": "sha512-8IAPZrkRjgTpkxV9JOwXSBe0GXNxd4B2lubPgbifTGL92rZOEKWutpijsWsWvjXOltDFHKMQIIIhkgLC5RPqbA==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.19.0.tgz",
+      "integrity": "sha512-qwuJM2Ev74HLKxgfmH7Qw/ob/Iwo4Te6ADZas8OqV2FCY+I4H+KJujLvaBs+By2g3h0aagv0ei3aUgqE8XzDfw==",
+      "dev": true,
       "requires": {
         "buffer": "^5.6.0",
-        "cids": "~0.8.0",
+        "cids": "~0.8.3",
         "class-is": "^1.1.0",
-        "multicodec": "^1.0.1",
-        "multihashing-async": "~0.8.1",
-        "protons": "^1.0.2",
+        "multicodec": "^1.0.3",
+        "multihashing-async": "^1.0.0",
+        "protons": "^1.2.1",
         "stable": "^0.1.8"
+      },
+      "dependencies": {
+        "cids": {
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "class-is": "^1.1.0",
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
+          }
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
+        "protons": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+          "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "protocol-buffers-schema": "^3.3.1",
+            "signed-varint": "^2.0.1",
+            "varint": "^5.0.0"
+          }
+        }
       }
     },
     "ipld-ethereum": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-4.0.1.tgz",
-      "integrity": "sha512-okaDApIYUpuSE/eJuYAhZsXzGJZrgY4nUPeESBWz/jNlhIAj2ZjDLjRcqL0mobsFPOww9+ml1Y96V8VsXOoXqg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ipld-ethereum/-/ipld-ethereum-4.0.2.tgz",
+      "integrity": "sha512-0uShqn7PcCgWca7lkn8WE8sS8GVDxoi7+juiSLw2MApx+r11hPBjiMDKy0SFZoyXMRYPZA6Xh1WTqzH8UM2eHA==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.0",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "ethereumjs-account": "^3.0.0",
         "ethereumjs-block": "^2.2.1",
         "ethereumjs-tx": "^2.1.1",
         "merkle-patricia-tree": "^3.0.0",
         "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15",
-        "multihashing-async": "~0.8.0",
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0",
         "rlp": "^2.2.4"
       },
       "dependencies": {
         "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
+            "buffer": "^5.6.0",
             "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
           }
         },
         "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
           "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
     },
     "ipld-git": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.5.1.tgz",
-      "integrity": "sha512-041Hq9hEjgzGue46lkPoBD6rEO+YCj04JFXVRGxd7AdacGrx3rV62uz/zUXfkncNZ/mjpovycZ+MC4skbO/43w==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/ipld-git/-/ipld-git-0.5.3.tgz",
+      "integrity": "sha512-ffJgkGFb7VnTh8AOZNu19de1pXecbInJ62iEfL1ydn330tgwWtSMI2ny2EXGuOg1LvR9DF87Shz92CdtW4zYTw==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashes": "~0.4.14",
-        "multihashing-async": "~0.8.0",
-        "smart-buffer": "^4.0.2",
-        "strftime": "~0.10.0"
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
+        "multicodec": "^1.0.2",
+        "multihashing-async": "^1.0.0",
+        "smart-buffer": "^4.1.0",
+        "strftime": "^0.10.0"
       },
       "dependencies": {
         "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
+            "buffer": "^5.6.0",
             "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
           }
         },
         "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
           "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
+          }
+        },
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
     },
     "ipld-raw": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-4.0.1.tgz",
-      "integrity": "sha512-WjIdtZ06jJEar8zh+BHB84tE6ZdbS/XNa7+XCArOYfmeJ/c01T9VQpeMwdJQYn5c3s5UvvCu7y4VIi3vk2g1bA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ipld-raw/-/ipld-raw-5.0.0.tgz",
+      "integrity": "sha512-z1Fie224lTtQZbFg+wC5WDY692G3SIpO8vT86yCU83vqpIvasVuV3SzDSv7G36kRxP03PPZOkvKAOFrcjb7gpw==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.0",
-        "multicodec": "^1.0.0",
-        "multihashing-async": "~0.8.0"
-      },
-      "dependencies": {
-        "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
-          }
-        },
-        "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
-          "dev": true,
-          "requires": {
-            "base-x": "^3.0.8",
-            "buffer": "^5.5.0"
-          }
-        }
+        "cids": "~0.8.0",
+        "multicodec": "^1.0.1",
+        "multihashing-async": "~0.8.1"
       }
     },
     "ipld-zcash": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.4.1.tgz",
-      "integrity": "sha512-1JNnY0HuLeJDzlRJSKxs8laZ+TKPr8zui7GNiJMHgMIjH7KOiVjAQfO7Rt7KzDucMLYPokarfIPaK3qeffwI2A==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/ipld-zcash/-/ipld-zcash-0.4.3.tgz",
+      "integrity": "sha512-HBczqYbhRWOGmq4kcLnD9W8sM5BBJPGTH/hHia4b97BpF1JYDCu+vDv8xrJUAj6l+o+VX4xs+S50tMMEDEhXXA==",
       "dev": true,
       "requires": {
-        "cids": "~0.7.1",
+        "buffer": "^5.6.0",
+        "cids": "^0.8.3",
         "multicodec": "^1.0.0",
-        "multihashes": "~0.4.15",
-        "multihashing-async": "~0.8.0",
+        "multihashes": "^1.0.1",
+        "multihashing-async": "^1.0.0",
         "zcash-block": "^2.0.0"
       },
       "dependencies": {
         "cids": {
-          "version": "0.7.5",
-          "resolved": "https://registry.npmjs.org/cids/-/cids-0.7.5.tgz",
-          "integrity": "sha512-zT7mPeghoWAu+ppn8+BS1tQ5qGmbMfB4AregnQjA/qHY3GC1m1ptI9GkWNlgeu38r7CuRdXB47uY2XgAYt6QVA==",
+          "version": "0.8.3",
+          "resolved": "https://registry.npmjs.org/cids/-/cids-0.8.3.tgz",
+          "integrity": "sha512-yoXTbV3llpm+EBGWKeL9xKtksPE/s6DPoDSY4fn8I8TEW1zehWXPSB0pwAXVDlLaOlrw+sNynj995uD9abmPhA==",
           "dev": true,
           "requires": {
-            "buffer": "^5.5.0",
+            "buffer": "^5.6.0",
             "class-is": "^1.1.0",
-            "multibase": "~0.6.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "~0.4.15"
+            "multibase": "^1.0.0",
+            "multicodec": "^1.0.1",
+            "multihashes": "^1.0.1"
           }
         },
         "multibase": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.1.tgz",
-          "integrity": "sha512-pFfAwyTjbbQgNc3G7D48JkJxWtoJoBMaR4xQUOuB8RnCgRqaYmWNFeJTTvrJ2w51bjLq2zTby6Rqj9TQ9elSUw==",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
           "dev": true,
           "requires": {
             "base-x": "^3.0.8",
             "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-1.0.0.tgz",
+          "integrity": "sha512-gRtHjJuULvo2dd9ybIsF+aUEamraAwet/ib3YapWdaP7QWkI8JtN/6EZBhdoqlzSVU7POrC3/rp13Or7zY7x1A==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
           }
         }
       }
     },
     "ipns": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.7.1.tgz",
-      "integrity": "sha512-2kKXu+AXlDXOxxjawey5H81al3xray/pUSHGpx6K7+VKgzCQr5A3PSuDRMFFiEst0nJ5lBvgMLpA+r3HBfUvlQ==",
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/ipns/-/ipns-0.7.4.tgz",
+      "integrity": "sha512-M1yX3oU5NSTC1fRb7GFs3RZk9b7bKxtPfDLRO5ezOVaqviTWNsZerMi/AueD9HuwTMVRhFQODRXnsOWntU0oBg==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "interface-datastore": "^0.8.0",
+        "interface-datastore": "^1.0.2",
         "libp2p-crypto": "^0.17.1",
-        "multibase": "^0.7.0",
-        "multihashes": "~0.4.14",
+        "multibase": "^3.0.0",
+        "multihashes": "^3.0.1",
         "peer-id": "^0.13.6",
         "protons": "^1.0.1",
         "timestamp-nano": "^1.0.0"
@@ -11927,6 +12382,27 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multibase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+          "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "web-encoding": "^1.0.2"
+          }
+        },
+        "multihashes": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-3.0.1.tgz",
+          "integrity": "sha512-fFY67WOtb0359IjDZxaCU3gJILlkwkFbxbwrK9Bej5+NqNaYztzLOj8/NgMNMg/InxmhK+Uu8S/U4EcqsHzB7Q==",
+          "dev": true,
+          "requires": {
+            "multibase": "^3.0.0",
+            "uint8arrays": "^1.0.0",
+            "varint": "^5.0.0"
+          }
         }
       }
     },
@@ -12670,15 +13146,18 @@
       }
     },
     "it-goodbye": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/it-goodbye/-/it-goodbye-2.0.1.tgz",
-      "integrity": "sha512-6Ou0kMEqybqcEirCZH/3WuPwna+jvwyrpbwCADTZyrVSKNHwh56x4lMRwLwkGR+mvp4EihPEVW0qZni06rL56g==",
-      "dev": true
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/it-goodbye/-/it-goodbye-2.0.2.tgz",
+      "integrity": "sha512-k56lqArpxkIU0yyhnPhvnyOBpzRQn+4VEyd+dUBWhN5kvCgPBeC0XMuHiA71iU98sDpCrJrT/X+81ajT0AOQtQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.6.0"
+      }
     },
     "it-handshake": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-1.0.1.tgz",
-      "integrity": "sha512-ZDN6HfaS9ZMOohEUr5j0TYI8nCtiSJsucXHwoeiH9IHal3sLDYcSpYWQe+CsUHHK5rMnPHwDiiPptP/Yioc0kg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/it-handshake/-/it-handshake-1.0.2.tgz",
+      "integrity": "sha512-uutOim5xF1eyDQD3u8qd3TxbWKwxqGMlbvacZsRsPdjO1BD9lnPTVci0jSMGsvMOu+5Y3W/QQ4hPQb87qPmPVQ==",
       "dev": true,
       "requires": {
         "it-pushable": "^1.4.0",
@@ -12700,11 +13179,12 @@
       "integrity": "sha512-zjWiVvkDXKxGA+u2ZNzq321RWnj52RLucsIX0Bve3NUX3X/b1RjtUufvUdjtkFtQLKG1yCf5+hxbdeIYiRT1rQ=="
     },
     "it-length-prefixed": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-3.0.1.tgz",
-      "integrity": "sha512-QnfnFkpklDhWpyPQ2al6pdqmsQbwZAUpa7066e8S9RQxXo0s4o21ceqCG0n/0wdmvgfRSYsW5g2dYgchqtLZYw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-3.1.0.tgz",
+      "integrity": "sha512-E5GwT6qfZEwh3/XThyYwgjKJ4/hxvTC9kdbj3gxXDeUDKtC7+K2T647sPeX7xDEWqunsnoQyvOrjoHPegaT3uw==",
       "dev": true,
       "requires": {
+        "@types/bl": "^2.1.0",
         "bl": "^4.0.2",
         "buffer": "^5.5.0",
         "varint": "^5.0.0"
@@ -12713,8 +13193,7 @@
     "it-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/it-map/-/it-map-1.0.2.tgz",
-      "integrity": "sha512-WTy7ZK4MDo5B9JgcGz2VLwDxqItUHzv8Mg0YzVM7jhcqY8EdjUuMoAcL7PqzJed+TMy/AYorw47Muc87sdD4sA==",
-      "dev": true
+      "integrity": "sha512-WTy7ZK4MDo5B9JgcGz2VLwDxqItUHzv8Mg0YzVM7jhcqY8EdjUuMoAcL7PqzJed+TMy/AYorw47Muc87sdD4sA=="
     },
     "it-multipart": {
       "version": "1.0.3",
@@ -12762,6 +13241,11 @@
           "dev": true
         }
       }
+    },
+    "it-peekable": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/it-peekable/-/it-peekable-0.0.1.tgz",
+      "integrity": "sha512-fd0JzbNldseeq+FFWthbqYB991UpKNyjPG6LqFhIOmJviCxSompMyoopKIXvLPLY+fBhhv2CT5PT31O/lEnTHw=="
     },
     "it-pipe": {
       "version": "1.1.0",
@@ -12854,21 +13338,21 @@
       }
     },
     "it-ws": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-3.0.0.tgz",
-      "integrity": "sha512-9qPAgBPA4yyu8XC71ugOhTOrEDpmSqVeEoJeAaNmtQIOu4sByzO8rsLq1GFKChaEhf8nbtK6jxr3e7LmpjMqmQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/it-ws/-/it-ws-3.0.2.tgz",
+      "integrity": "sha512-INZhCXNjd5Xr7mYWtNZQb9y5i6XIsf4CKD4XUXeCD3tbaoIya1bPVtJNP1lN5UVGo6Ql9rAn3WVre/8IKtKShw==",
       "dev": true,
       "requires": {
-        "buffer": "^5.4.3",
-        "event-iterator": "^1.2.0",
+        "buffer": "^5.6.0",
+        "event-iterator": "^2.0.0",
         "relative-url": "^1.0.2",
-        "ws": "^7.2.1"
+        "ws": "^7.3.1"
       },
       "dependencies": {
         "ws": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
           "dev": true
         }
       }
@@ -13405,23 +13889,13 @@
       }
     },
     "keccak": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-2.1.0.tgz",
-      "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+      "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
       "dev": true,
       "requires": {
-        "bindings": "^1.5.0",
-        "inherits": "^2.0.4",
-        "nan": "^2.14.0",
-        "safe-buffer": "^5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        }
+        "node-addon-api": "^2.0.0",
+        "node-gyp-build": "^4.2.0"
       }
     },
     "keypair": {
@@ -13506,10 +13980,13 @@
       }
     },
     "level-codec": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
-      "dev": true
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.2.tgz",
+      "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.6.0"
+      }
     },
     "level-concat-iterator": {
       "version": "2.0.1",
@@ -13792,9 +14269,9 @@
       }
     },
     "libp2p": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.27.8.tgz",
-      "integrity": "sha512-0pJrdJ1byAMzDfq+ZZ1WEJXJTofKDsz9f7ezjMjxZxLUlpvb4ncrE3TaRo5TkH1y+D8doFab9q6c9MjST2UVDA==",
+      "version": "0.28.10",
+      "resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.28.10.tgz",
+      "integrity": "sha512-0WR86vPj3RIEP7jFWBy1J4GBp8wweC1pmzy5nfKZazP22wA/crqqnxcr4xGs/7lzFyfBJuqRIswz3/IrlgO+ag==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -13806,6 +14283,7 @@
         "err-code": "^2.0.0",
         "events": "^3.1.0",
         "hashlru": "^2.3.0",
+        "interface-datastore": "^1.0.4",
         "ipfs-utils": "^2.2.0",
         "it-all": "^1.0.1",
         "it-buffer": "^0.1.2",
@@ -13813,8 +14291,8 @@
         "it-length-prefixed": "^3.0.1",
         "it-pipe": "^1.1.0",
         "it-protocol-buffers": "^0.2.0",
-        "libp2p-crypto": "^0.17.6",
-        "libp2p-interfaces": "^0.2.8",
+        "libp2p-crypto": "^0.17.9",
+        "libp2p-interfaces": "^0.3.1",
         "libp2p-utils": "^0.1.2",
         "mafmt": "^7.0.0",
         "merge-options": "^2.0.0",
@@ -13822,13 +14300,14 @@
         "multiaddr": "^7.4.3",
         "multistream-select": "^0.15.0",
         "mutable-proxy": "^1.0.0",
+        "node-forge": "^0.9.1",
         "p-any": "^3.0.0",
         "p-fifo": "^1.0.0",
         "p-settle": "^4.0.1",
         "peer-id": "^0.13.11",
-        "peer-info": "^0.17.0",
         "protons": "^1.0.1",
         "retimer": "^2.0.0",
+        "sanitize-filename": "^1.6.3",
         "streaming-iterables": "^4.1.0",
         "timeout-abort-controller": "^1.0.0",
         "xsalsa20": "^1.0.2"
@@ -13843,25 +14322,86 @@
             "ms": "^2.1.1"
           }
         },
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.2.1",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.0.0",
+            "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "protons": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+              "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "protocol-buffers-schema": "^3.3.1",
+                "signed-varint": "^2.0.1",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
         }
       }
     },
     "libp2p-bootstrap": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.10.4.tgz",
-      "integrity": "sha512-4FKLZzoXKM342eSPnUu3FcoZCqg8NA3283z92baebOCCjIb6nvM6Jn5LUWyo3dBwr2ntmLGOZvhYsGKII2oEcQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/libp2p-bootstrap/-/libp2p-bootstrap-0.11.0.tgz",
+      "integrity": "sha512-vLMmCJsecnHdR9pPUxvOimtnZdOfGXv4EImNB+Y0DKX3LUSyzb868N5oWCGhKMxDwt2Nm6/7Vl/Vd+eHnsU79g==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "mafmt": "^7.0.0",
         "multiaddr": "^7.2.1",
-        "peer-id": "^0.13.5",
-        "peer-info": "^0.17.0"
+        "peer-id": "^0.13.5"
       },
       "dependencies": {
         "debug": {
@@ -13901,18 +14441,16 @@
       }
     },
     "libp2p-delegated-content-routing": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.4.5.tgz",
-      "integrity": "sha512-2liHjh8lK2S93MaBPTwzoO5vNR+i0MoD5s4iErISGO3uc/Zp2jXkNg5SGT8eD7aFXGaEG6KsF/A7IbHe/QzFew==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-content-routing/-/libp2p-delegated-content-routing-0.5.0.tgz",
+      "integrity": "sha512-ag5gt752n0TynbRsQN1JMF0FzSdMpHOprNdVm6vq/rsz/8wMGh9WxN+a1Zp9VoPp5rGHe7LTom13ziFf1Z/Nyg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "ipfs-http-client": "^44.0.0",
         "it-all": "^1.0.0",
         "multiaddr": "^7.4.3",
         "p-defer": "^3.0.0",
-        "p-queue": "^6.3.0",
-        "peer-info": "^0.17.5"
+        "p-queue": "^6.2.1"
       },
       "dependencies": {
         "debug": {
@@ -13922,41 +14460,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "ipfs-http-client": {
-          "version": "44.0.3",
-          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-44.0.3.tgz",
-          "integrity": "sha512-uO/UkMryuKMqIzNkyWv056RpGZZX7UPGwIE49Y0ZAAqAmm08pxIiC1B93NP4jBefW/aNFjazcyhAewMqg1YeNw==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "bignumber.js": "^9.0.0",
-            "bs58": "^4.0.1",
-            "buffer": "^5.4.2",
-            "cids": "^0.8.0",
-            "debug": "^4.1.0",
-            "form-data": "^3.0.0",
-            "ipfs-block": "^0.8.1",
-            "ipfs-core-utils": "^0.2.2",
-            "ipfs-utils": "^2.2.2",
-            "ipld-dag-cbor": "^0.15.1",
-            "ipld-dag-pb": "^0.18.3",
-            "ipld-raw": "^4.0.1",
-            "iso-url": "^0.4.7",
-            "it-tar": "^1.2.1",
-            "it-to-buffer": "^1.0.0",
-            "it-to-stream": "^0.1.1",
-            "merge-options": "^2.0.0",
-            "multiaddr": "^7.2.1",
-            "multiaddr-to-uri": "^5.1.0",
-            "multibase": "^0.7.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "^0.4.14",
-            "nanoid": "^3.0.2",
-            "node-fetch": "^2.6.0",
-            "parse-duration": "^0.1.2",
-            "stream-to-it": "^0.2.0"
           }
         },
         "ms": {
@@ -13974,16 +14477,14 @@
       }
     },
     "libp2p-delegated-peer-routing": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.4.3.tgz",
-      "integrity": "sha512-UlRBaw6pddd5MmzzrxiEUexXNy0PmKphnZnpuIEMzNLY3QERoRMq8RgRtVUZdPBRM+zS5a+nMI7dlEbvr84QUw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/libp2p-delegated-peer-routing/-/libp2p-delegated-peer-routing-0.5.0.tgz",
+      "integrity": "sha512-crnVXH56bTj0hqqsEb4xmfrZrdIxOBqnFp2D19inxTVwZtpg/Je1XJZDGSG2JJ2EnXxFGTNPFHcB5AIm8avDEg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "ipfs-http-client": "^44.0.0",
         "p-queue": "^6.3.0",
-        "peer-id": "^0.13.11",
-        "peer-info": "^0.17.5"
+        "peer-id": "^0.13.11"
       },
       "dependencies": {
         "debug": {
@@ -13993,41 +14494,6 @@
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
-          }
-        },
-        "ipfs-http-client": {
-          "version": "44.0.3",
-          "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-44.0.3.tgz",
-          "integrity": "sha512-uO/UkMryuKMqIzNkyWv056RpGZZX7UPGwIE49Y0ZAAqAmm08pxIiC1B93NP4jBefW/aNFjazcyhAewMqg1YeNw==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "bignumber.js": "^9.0.0",
-            "bs58": "^4.0.1",
-            "buffer": "^5.4.2",
-            "cids": "^0.8.0",
-            "debug": "^4.1.0",
-            "form-data": "^3.0.0",
-            "ipfs-block": "^0.8.1",
-            "ipfs-core-utils": "^0.2.2",
-            "ipfs-utils": "^2.2.2",
-            "ipld-dag-cbor": "^0.15.1",
-            "ipld-dag-pb": "^0.18.3",
-            "ipld-raw": "^4.0.1",
-            "iso-url": "^0.4.7",
-            "it-tar": "^1.2.1",
-            "it-to-buffer": "^1.0.0",
-            "it-to-stream": "^0.1.1",
-            "merge-options": "^2.0.0",
-            "multiaddr": "^7.2.1",
-            "multiaddr-to-uri": "^5.1.0",
-            "multibase": "^0.7.0",
-            "multicodec": "^1.0.0",
-            "multihashes": "^0.4.14",
-            "nanoid": "^3.0.2",
-            "node-fetch": "^2.6.0",
-            "parse-duration": "^0.1.2",
-            "stream-to-it": "^0.2.0"
           }
         },
         "ms": {
@@ -14039,9 +14505,9 @@
       }
     },
     "libp2p-floodsub": {
-      "version": "0.20.3",
-      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.20.3.tgz",
-      "integrity": "sha512-R/uMu25eLB/tPfkXlV07VOYDV0NRq1gw2WUzl3mh6wqvFPyH7M23U37Gcj39opNobRLPi+fGig8tv8gCVfJjkw==",
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/libp2p-floodsub/-/libp2p-floodsub-0.21.3.tgz",
+      "integrity": "sha512-TTehsDd5kZos27qmugmviF9GvzfyH8Tq2/YNBpp7Ku1KoSZugcdQAhz8hmStMtMGDkW5ysoKSBG739IhHUtgdg==",
       "dev": true,
       "requires": {
         "async.nexttick": "^0.5.2",
@@ -14049,8 +14515,9 @@
         "debug": "^4.1.1",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.0.1",
-        "libp2p-pubsub": "~0.4.0",
-        "p-map": "^3.0.0",
+        "libp2p-pubsub": "~0.5.2",
+        "p-map": "^4.0.0",
+        "peer-id": "~0.13.3",
         "protons": "^1.0.1",
         "time-cache": "^0.3.0"
       },
@@ -14069,32 +14536,23 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
         }
       }
     },
     "libp2p-gossipsub": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.2.6.tgz",
-      "integrity": "sha512-S+Kpf1GQk3PqFxtXgWECSgCZI8EZW8eo00Pi6N9wVqEnqD83Qsrt2ICEjVf+uIGZ5fxxjwdphxIMBPUIUiMUpg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/libp2p-gossipsub/-/libp2p-gossipsub-0.4.6.tgz",
+      "integrity": "sha512-ViGAeWwQWmXCQxg7ya5PmtLexDVpzrFjIETFhFceMGHAUI/vv8kXhLmze7SNpIhKnWx33VfxUJfQmsiKVYWjbw==",
       "dev": true,
       "requires": {
+        "buffer": "^5.6.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.0.1",
-        "libp2p-pubsub": "~0.4.1",
-        "p-map": "^3.0.0",
-        "peer-id": "~0.13.3",
-        "peer-info": "~0.17.0",
+        "libp2p-pubsub": "~0.5.2",
+        "p-map": "^4.0.0",
+        "peer-id": "~0.13.12",
         "protons": "^1.0.1",
         "time-cache": "^0.3.0"
       },
@@ -14113,22 +14571,13 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
-        },
-        "p-map": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-          "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-          "dev": true,
-          "requires": {
-            "aggregate-error": "^3.0.0"
-          }
         }
       }
     },
     "libp2p-interfaces": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.2.8.tgz",
-      "integrity": "sha512-Uzjlzbjk7Bx9giSU2z3qbQv/N8iV9ARL7GV5g9UNCXEYV+lPx0CUX8egnUlxf7/EMjUTz1PsSsf8C7nOZDbVJQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.3.2.tgz",
+      "integrity": "sha512-EZviUYO5d4T/mYwDFMC/tVvLiS95+Ui8agn/DovsnUhlYPojLJJNapEJYFqFbgKqP+dxpMVMZ5CyJXD334qsuA==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -14137,22 +14586,122 @@
         "chai": "^4.2.0",
         "chai-checkmark": "^1.0.1",
         "class-is": "^1.1.0",
+        "delay": "^4.3.0",
         "detect-node": "^2.0.4",
         "dirty-chai": "^2.0.1",
         "err-code": "^2.0.0",
         "it-goodbye": "^2.0.1",
         "it-pair": "^1.0.0",
-        "it-pipe": "^1.0.1",
-        "libp2p-tcp": "^0.14.1",
-        "multiaddr": "^7.4.3",
+        "it-pipe": "^1.1.0",
+        "libp2p-tcp": "^0.14.5",
+        "multiaddr": "^7.5.0",
+        "p-defer": "^3.0.0",
         "p-limit": "^2.3.0",
         "p-wait-for": "^3.1.0",
-        "peer-id": "^0.13.11",
-        "peer-info": "^0.17.0",
+        "peer-id": "^0.13.13",
         "sinon": "^9.0.2",
-        "streaming-iterables": "^4.1.0"
+        "streaming-iterables": "^5.0.2"
       },
       "dependencies": {
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.2.1",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.0.0",
+            "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "protons": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+              "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "protocol-buffers-schema": "^3.3.1",
+                "signed-varint": "^2.0.1",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "p-defer": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
+          "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
+          "dev": true
+        },
         "p-limit": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -14167,13 +14716,28 @@
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
+        },
+        "peer-id": {
+          "version": "0.13.13",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.13.tgz",
+          "integrity": "sha512-5FpBXN6PDTcHs51gkHWPf0OIQZAO3Z10i6lWc+GaoxTU4bQHtsoKFnhxoXo5Ze04JblpzIrtowkluLSCLP1WYg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "^0.8.0",
+            "class-is": "^1.1.0",
+            "libp2p-crypto": "^0.17.7",
+            "minimist": "^1.2.5",
+            "multihashes": "^1.0.1",
+            "protons": "^1.0.2"
+          }
         }
       }
     },
     "libp2p-kad-dht": {
-      "version": "0.18.7",
-      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.18.7.tgz",
-      "integrity": "sha512-qaePQ+hS/1mFsot9HquGETvHhSmiyznyV+UOlHsTdhfUTu5bZEeTefoQDqJZBeZCi1IaEJi1e3Ep+IFJsJFpbg==",
+      "version": "0.19.9",
+      "resolved": "https://registry.npmjs.org/libp2p-kad-dht/-/libp2p-kad-dht-0.19.9.tgz",
+      "integrity": "sha512-nbXkusPRpWoLc89/6eGV+IrE105kcWUE/cUAJtaAPUFpuSonKk+TPYfsAJnYhX93y7JA8XGXZfuPDJbHIo7Qnw==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -14185,22 +14749,21 @@
         "err-code": "^2.0.0",
         "hashlru": "^2.3.0",
         "heap": "~0.2.6",
-        "interface-datastore": "~0.8.0",
+        "interface-datastore": "^1.0.2",
         "it-length-prefixed": "^3.0.0",
         "it-pipe": "^1.1.0",
         "k-bucket": "^5.0.0",
         "libp2p-crypto": "~0.17.1",
-        "libp2p-interfaces": "^0.2.8",
+        "libp2p-interfaces": "^0.3.0",
         "libp2p-record": "~0.7.0",
-        "multihashes": "~0.4.15",
-        "multihashing-async": "~0.8.0",
+        "multiaddr": "^7.4.3",
+        "multihashing-async": "^0.8.2",
         "p-filter": "^2.1.0",
         "p-map": "^4.0.0",
         "p-queue": "^6.2.1",
         "p-timeout": "^3.2.0",
-        "p-times": "^2.1.0",
+        "p-times": "^3.0.0",
         "peer-id": "~0.13.5",
-        "peer-info": "~0.17.0",
         "promise-to-callback": "^1.0.0",
         "protons": "^1.0.1",
         "streaming-iterables": "^4.1.1",
@@ -14223,6 +14786,41 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         },
+        "multibase": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+          "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+          "dev": true,
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.5.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashing-async": {
+          "version": "0.8.2",
+          "resolved": "https://registry.npmjs.org/multihashing-async/-/multihashing-async-0.8.2.tgz",
+          "integrity": "sha512-2lKa1autuCy8x7KIEj9aVNbAb3aIMRFYIwN7mq/zD4pxgNIVgGlm+f6GKY4880EOF2Y3GktHYssRy7TAJQ2DyQ==",
+          "dev": true,
+          "requires": {
+            "blakejs": "^1.1.0",
+            "buffer": "^5.4.3",
+            "err-code": "^2.0.0",
+            "js-sha3": "^0.8.0",
+            "multihashes": "^1.0.1",
+            "murmurhash3js-revisited": "^3.0.0"
+          }
+        },
         "p-timeout": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -14231,34 +14829,25 @@
           "requires": {
             "p-finally": "^1.0.0"
           }
+        },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
         }
       }
     },
-    "libp2p-keychain": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/libp2p-keychain/-/libp2p-keychain-0.6.0.tgz",
-      "integrity": "sha512-r0EmaRvEwOImiYxrhTAjxzFf+JHxk66ooMezHF/LkXIdncc/eGt32k80UvnJ/xgoCzDHl4IlzXu1j8VKxy/80g==",
-      "dev": true,
-      "requires": {
-        "err-code": "^2.0.0",
-        "interface-datastore": "^0.8.0",
-        "libp2p-crypto": "^0.17.1",
-        "merge-options": "^2.0.0",
-        "node-forge": "^0.9.1",
-        "sanitize-filename": "^1.6.1"
-      }
-    },
     "libp2p-mdns": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.13.3.tgz",
-      "integrity": "sha512-OheK4CF+76jAK4Ls9a/luix3Lb9TM0ETn6llkTCfJ444dymtqKdetqYGNmn6k0eZndU4D5xeEMAKS+OjlztBiw==",
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/libp2p-mdns/-/libp2p-mdns-0.14.3.tgz",
+      "integrity": "sha512-NxGFh469olcTr/AJ43BSmcAa5tvM6bXLXS54dq3Lw5IEeqr2JrTbxkcl+evFu3caKe/p+bN4c5kH7hGDZX6+yQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
-        "multiaddr": "^7.1.0",
+        "multiaddr": "^7.5.0",
         "multicast-dns": "^7.2.0",
-        "peer-id": "~0.13.3",
-        "peer-info": "~0.17.0"
+        "peer-id": "^0.13.13"
       },
       "dependencies": {
         "debug": {
@@ -14270,11 +14859,119 @@
             "ms": "^2.1.1"
           }
         },
+        "libp2p-crypto": {
+          "version": "0.17.9",
+          "resolved": "https://registry.npmjs.org/libp2p-crypto/-/libp2p-crypto-0.17.9.tgz",
+          "integrity": "sha512-nH3vTfQ4UqhZ1SORTP7HOsmFdJBs604Qy0Xi3IFFtU6ofYt+rFAZ2QNgo4MH1ZTT38/LEM374N9K7yzj1IQm0g==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "err-code": "^2.0.0",
+            "is-typedarray": "^1.0.0",
+            "iso-random-stream": "^1.1.0",
+            "keypair": "^1.0.1",
+            "multibase": "^1.0.1",
+            "multicodec": "^1.0.4",
+            "multihashing-async": "^0.8.1",
+            "node-forge": "^0.9.1",
+            "pem-jwk": "^2.0.0",
+            "protons": "^1.2.1",
+            "secp256k1": "^4.0.0",
+            "uint8arrays": "^1.0.0",
+            "ursa-optional": "^0.10.1"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            },
+            "protons": {
+              "version": "1.2.1",
+              "resolved": "https://registry.npmjs.org/protons/-/protons-1.2.1.tgz",
+              "integrity": "sha512-2oqDyc/SN+tNcJf8XxrXhYL7sQn2/OMl8mSdD7NVGsWjMEmAbks4eDVnCyf0vAoRbBWyWTEXWk4D8XfuKVl3zg==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.5.0",
+                "protocol-buffers-schema": "^3.3.1",
+                "signed-varint": "^2.0.1",
+                "varint": "^5.0.0"
+              }
+            }
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multicodec": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/multicodec/-/multicodec-1.0.4.tgz",
+          "integrity": "sha512-NDd7FeS3QamVtbgfvu5h7fd1IlbaC4EQ0/pgU4zqE2vdHCmBGsUa0TiM8/TdSeG6BMPC92OOCf8F1ocE/Wkrrg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "multihashes": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/multihashes/-/multihashes-1.0.1.tgz",
+          "integrity": "sha512-S27Tepg4i8atNiFaU5ZOm3+gl3KQlUanLs/jWcBxQHFttgq+5x1OgbQmf2d8axJ/48zYGBd/wT9d723USMFduw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "multibase": "^1.0.1",
+            "varint": "^5.0.0"
+          },
+          "dependencies": {
+            "multibase": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/multibase/-/multibase-1.0.1.tgz",
+              "integrity": "sha512-KcCxpBVY8fdVKu4dJMAahq4F/2Z/9xqEjIiR7PiMe7LRGeorFn2NLmicN6nLBCqQvft6MG2Lc9X5P0IdyvnxEw==",
+              "dev": true,
+              "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.5.0"
+              }
+            }
+          }
+        },
+        "peer-id": {
+          "version": "0.13.13",
+          "resolved": "https://registry.npmjs.org/peer-id/-/peer-id-0.13.13.tgz",
+          "integrity": "sha512-5FpBXN6PDTcHs51gkHWPf0OIQZAO3Z10i6lWc+GaoxTU4bQHtsoKFnhxoXo5Ze04JblpzIrtowkluLSCLP1WYg==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "^0.8.0",
+            "class-is": "^1.1.0",
+            "libp2p-crypto": "^0.17.7",
+            "minimist": "^1.2.5",
+            "multihashes": "^1.0.1",
+            "protons": "^1.0.2"
+          }
         }
       }
     },
@@ -14311,10 +15008,46 @@
         }
       }
     },
+    "libp2p-noise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/libp2p-noise/-/libp2p-noise-1.1.2.tgz",
+      "integrity": "sha512-iKXdzGnPsz3slh6Gm9oNj0h0X37f/YFuSkg7MikQgrx5l5XRaFRxVDoqbsTlQ5nIS02tGuLJvmbqpLOZ+aWVow==",
+      "dev": true,
+      "requires": {
+        "bcrypto": "5.1.0",
+        "buffer": "^5.4.3",
+        "debug": "^4.1.1",
+        "it-buffer": "^0.1.1",
+        "it-length-prefixed": "^3.0.0",
+        "it-pair": "^1.0.0",
+        "it-pb-rpc": "^0.1.8",
+        "it-pipe": "^1.1.0",
+        "libp2p-crypto": "^0.17.6",
+        "peer-id": "^0.13.5",
+        "protobufjs": "6.8.8"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "libp2p-pubsub": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.4.4.tgz",
-      "integrity": "sha512-/nFEWjaeKhDLDgXpoqZa1HivvHAQH6RCX9T+VTzQO2aUVoHWOFnrXqBeu5ffjD2DSyyaKtRs1qsLjPVsk3p2zw==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/libp2p-pubsub/-/libp2p-pubsub-0.5.6.tgz",
+      "integrity": "sha512-1nQ709amKckPOcK7nZZom66PZytn8VIdR9BxpxhXxwmMmeuCIUKB+65UK7tI07M4LrcWsWPwZH6PbQBKiQ+Fzw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -14323,8 +15056,9 @@
         "it-pipe": "^1.0.1",
         "it-pushable": "^1.3.2",
         "libp2p-crypto": "~0.17.0",
-        "libp2p-interfaces": "^0.2.3",
+        "libp2p-interfaces": "^0.3.0",
         "multibase": "^0.7.0",
+        "peer-id": "~0.13.3",
         "protons": "^1.0.1"
       },
       "dependencies": {
@@ -14359,9 +15093,9 @@
       }
     },
     "libp2p-secio": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.12.5.tgz",
-      "integrity": "sha512-S4/i7Bye/utt7FBmJS97XNLALAzvKmKLuqnwpUn3lWI1ns+Hx+tWu5lMFIobJu1BNvxapzCHkkq8H5jqqdzlRQ==",
+      "version": "0.12.6",
+      "resolved": "https://registry.npmjs.org/libp2p-secio/-/libp2p-secio-0.12.6.tgz",
+      "integrity": "sha512-SPuXcQsXXix7Lkmx5fv+woKay+DWycFxv7xkWi+8CD5oa15/4U1E8qqqnE7Lwjj2Ub1i0DuE74GRRzap46sxTQ==",
       "dev": true,
       "requires": {
         "bl": "^4.0.0",
@@ -14387,28 +15121,77 @@
             "ms": "^2.1.1"
           }
         },
+        "libp2p-interfaces": {
+          "version": "0.2.8",
+          "resolved": "https://registry.npmjs.org/libp2p-interfaces/-/libp2p-interfaces-0.2.8.tgz",
+          "integrity": "sha512-Uzjlzbjk7Bx9giSU2z3qbQv/N8iV9ARL7GV5g9UNCXEYV+lPx0CUX8egnUlxf7/EMjUTz1PsSsf8C7nOZDbVJQ==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "abortable-iterator": "^3.0.0",
+            "buffer": "^5.6.0",
+            "chai": "^4.2.0",
+            "chai-checkmark": "^1.0.1",
+            "class-is": "^1.1.0",
+            "detect-node": "^2.0.4",
+            "dirty-chai": "^2.0.1",
+            "err-code": "^2.0.0",
+            "it-goodbye": "^2.0.1",
+            "it-pair": "^1.0.0",
+            "it-pipe": "^1.0.1",
+            "libp2p-tcp": "^0.14.1",
+            "multiaddr": "^7.4.3",
+            "p-limit": "^2.3.0",
+            "p-wait-for": "^3.1.0",
+            "peer-id": "^0.13.11",
+            "peer-info": "^0.17.0",
+            "sinon": "^9.0.2",
+            "streaming-iterables": "^4.1.0"
+          }
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "p-limit": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
         }
       }
     },
     "libp2p-tcp": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.5.tgz",
-      "integrity": "sha512-BLTtCe7jMYCfzrY1j4KAa3iByMZD5fgkH1bQ0WNCn/ye3w5mDemEgOT6+4p8/wuv2e0QXldGRB/DHUqB8lyNFw==",
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/libp2p-tcp/-/libp2p-tcp-0.14.6.tgz",
+      "integrity": "sha512-DeOdaH5QGVMKZflJmZq3dSWROxzD/YU1MFDxfi+DT4JVMcxfVMd+SpVEPMyk2wyA28H4AdGIRsH78yPjlFIyZQ==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
-        "libp2p-utils": "~0.1.0",
-        "mafmt": "^7.0.0",
-        "multiaddr": "^7.2.1",
-        "stream-to-it": "^0.2.0"
+        "libp2p-utils": "^0.1.2",
+        "mafmt": "^7.1.0",
+        "multiaddr": "^7.5.0",
+        "stream-to-it": "^0.2.2"
       },
       "dependencies": {
         "debug": {
@@ -14425,20 +15208,43 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        },
+        "stream-to-it": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/stream-to-it/-/stream-to-it-0.2.2.tgz",
+          "integrity": "sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==",
+          "dev": true,
+          "requires": {
+            "get-iterator": "^1.0.2"
+          }
         }
       }
     },
     "libp2p-utils": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.1.2.tgz",
-      "integrity": "sha512-c/LG4tWRmKo7vwu03j9Og3hFki91JfXEyqpgJJUXKh/fPQDXwixVFc4CjZ83UtAU4IZt/U8HXWeLlXUtt1PsJg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/libp2p-utils/-/libp2p-utils-0.1.3.tgz",
+      "integrity": "sha512-ApiQu45O+wTArSuAA8I0FR+CRf9lqoVTR1iGqSPx57x3iCzAtf3uKEOFxUDkgdWCnhpo04VKr2TLzxEYvkxd/w==",
       "dev": true,
       "requires": {
         "abortable-iterator": "^3.0.0",
         "debug": "^4.1.1",
-        "err-code": "^2.0.0",
+        "err-code": "^2.0.3",
         "ip-address": "^6.1.0",
-        "multiaddr": "^7.3.0"
+        "multiaddr": "^7.5.0"
       },
       "dependencies": {
         "debug": {
@@ -14450,18 +15256,86 @@
             "ms": "^2.1.1"
           }
         },
+        "err-code": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+          "dev": true
+        },
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
+        },
+        "multiaddr": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/multiaddr/-/multiaddr-7.5.0.tgz",
+          "integrity": "sha512-GvhHsIGDULh06jyb6ev+VfREH9evJCFIRnh3jUt9iEZ6XDbyoisZRFEI9bMvK/AiR6y66y6P+eoBw9mBYMhMvw==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.5.0",
+            "cids": "~0.8.0",
+            "class-is": "^1.1.0",
+            "is-ip": "^3.1.0",
+            "multibase": "^0.7.0",
+            "varint": "^5.0.0"
+          }
+        }
+      }
+    },
+    "libp2p-webrtc-peer": {
+      "version": "9.7.2",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-peer/-/libp2p-webrtc-peer-9.7.2.tgz",
+      "integrity": "sha512-r/JzhV9EDYRU2bWHHUT5XsvmVaKb3wCESUbf8TyFBZ3iC11/43tYlK1gNyHvLpmsDLUC2XMRpHCsfxexnHUo0g==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.0.1",
+        "err-code": "^2.0.3",
+        "get-browser-rtc": "^1.0.0",
+        "queue-microtask": "^1.1.0",
+        "randombytes": "^2.0.3",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "err-code": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+          "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         }
       }
     },
     "libp2p-webrtc-star": {
-      "version": "0.17.10",
-      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.17.10.tgz",
-      "integrity": "sha512-9kJhfeu8t33V8dqsNCV5JkUPUMaUV4mw0rhSLeq5aXLAQ0nyxyGua6XdCNxW4Pz1tDMF0H24AAiH/0bnhmvHkQ==",
+      "version": "0.18.6",
+      "resolved": "https://registry.npmjs.org/libp2p-webrtc-star/-/libp2p-webrtc-star-0.18.6.tgz",
+      "integrity": "sha512-rrA0hQ7RwIW8rvwd2R9BnkmVVnH9jG98XaNykmlJ3At5jQOHcVYY13sqfEz8y0I5+5zbSd3xfvV9etBqyT8dRQ==",
       "dev": true,
       "requires": {
         "@hapi/hapi": "^18.4.0",
@@ -14471,22 +15345,21 @@
         "class-is": "^1.1.0",
         "debug": "^4.1.1",
         "err-code": "^2.0.0",
+        "ipfs-utils": "^2.3.0",
         "it-pipe": "^1.0.1",
         "libp2p-utils": "^0.1.0",
+        "libp2p-webrtc-peer": "^9.7.2",
         "mafmt": "^7.0.1",
         "menoetius": "0.0.2",
         "minimist": "^1.2.0",
         "multiaddr": "^7.1.0",
         "p-defer": "^3.0.0",
-        "peer-id": "~0.13.2",
-        "peer-info": "~0.17.0",
+        "peer-id": "~0.13.12",
         "prom-client": "^12.0.0",
-        "simple-peer": "^9.6.0",
         "socket.io": "^2.3.0",
         "socket.io-client": "^2.3.0",
         "stream-to-it": "^0.2.0",
-        "streaming-iterables": "^4.1.0",
-        "webrtcsupport": "github:ipfs/webrtcsupport"
+        "streaming-iterables": "^4.1.0"
       },
       "dependencies": {
         "base64id": {
@@ -14511,9 +15384,9 @@
           }
         },
         "engine.io": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.1.tgz",
-          "integrity": "sha512-8MfIfF1/IIfxuc2gv5K+XlFZczw/BpTvqBdl0E2fBLkYQp4miv4LuDTVtYt4yMyaIFLEr4vtaSgV4mjvll8Crw==",
+          "version": "3.4.2",
+          "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.4.2.tgz",
+          "integrity": "sha512-b4Q85dFkGw+TqgytGPrGgACRUhsdKc9S9ErRAXpPGy/CXKs4tYoHDkvIRdsseAF7NjfVwjRFIn6KTnbw7LwJZg==",
           "dev": true,
           "requires": {
             "accepts": "~1.3.4",
@@ -14525,12 +15398,12 @@
           }
         },
         "engine.io-client": {
-          "version": "3.4.1",
-          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.1.tgz",
-          "integrity": "sha512-RJNmA+A9Js+8Aoq815xpGAsgWH1VoSYM//2VgIiu9lNOaHFfLpTjH4tOzktBpjIs5lvOfiNY1dwf+NuU6D38Mw==",
+          "version": "3.4.3",
+          "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
+          "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
           "dev": true,
           "requires": {
-            "component-emitter": "1.2.1",
+            "component-emitter": "~1.3.0",
             "component-inherit": "0.0.3",
             "debug": "~4.1.0",
             "engine.io-parser": "~2.2.0",
@@ -14543,6 +15416,12 @@
             "yeast": "0.1.2"
           },
           "dependencies": {
+            "component-emitter": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+              "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+              "dev": true
+            },
             "ws": {
               "version": "6.1.4",
               "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
@@ -14567,11 +15446,68 @@
             "has-binary2": "~1.0.2"
           }
         },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "ipfs-utils": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/ipfs-utils/-/ipfs-utils-2.4.0.tgz",
+          "integrity": "sha512-0RH8rMIEhrXyrbh87V8SQC6E6/5EJs+YionqZGAXnVoTzkpFhxC3x3FlsxwZ9s72yaieGP1Mx1tRYgfCFM/mJg==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "any-signal": "^1.1.0",
+            "buffer": "^5.6.0",
+            "err-code": "^2.0.0",
+            "fs-extra": "^9.0.1",
+            "is-electron": "^2.2.0",
+            "iso-url": "^0.4.7",
+            "it-glob": "0.0.8",
+            "it-to-stream": "^0.1.2",
+            "merge-options": "^2.0.0",
+            "nanoid": "^3.1.3",
+            "node-fetch": "^2.6.0",
+            "stream-to-it": "^0.2.0"
+          }
+        },
         "isarray": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
           "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
           "dev": true
+        },
+        "it-to-stream": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/it-to-stream/-/it-to-stream-0.1.2.tgz",
+          "integrity": "sha512-DTB5TJRZG3untmZehcaFN0kGWl2bNv7tnJRgQHAO9QEt8jfvVRrebZtnD5NZd4SCj4WVPjl0LSrugNWE/UaZRQ==",
+          "dev": true,
+          "requires": {
+            "buffer": "^5.6.0",
+            "fast-fifo": "^1.0.0",
+            "get-iterator": "^1.0.2",
+            "p-defer": "^3.0.0",
+            "p-fifo": "^1.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
         },
         "ms": {
           "version": "2.1.2",
@@ -14584,6 +15520,17 @@
           "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-3.0.0.tgz",
           "integrity": "sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==",
           "dev": true
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
         },
         "socket.io": {
           "version": "2.3.0",
@@ -14652,9 +15599,9 @@
           }
         },
         "socket.io-parser": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.0.tgz",
-          "integrity": "sha512-/G/VOI+3DBp0+DJKW4KesGnQkQPFmUCbA/oO2QGT6CWxU7hLGWqU3tyuzeSK/dqcyeHsQg1vTe9jiZI8GU9SCQ==",
+          "version": "3.4.1",
+          "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.4.1.tgz",
+          "integrity": "sha512-11hMgzL+WCLWf1uFtHSNvliI++tcRUWdoeYuwIl+Axvwy9z2gQM+7nJyN3STj1tLj5JyIUH8/gpDGxzAlDdi0A==",
           "dev": true,
           "requires": {
             "component-emitter": "1.2.1",
@@ -14662,10 +15609,22 @@
             "isarray": "2.0.1"
           }
         },
+        "streaming-iterables": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
+          "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
+        },
         "ws": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
-          "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
           "dev": true
         }
       }
@@ -14932,6 +15891,12 @@
         }
       }
     },
+    "loady": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==",
+      "dev": true
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -14966,12 +15931,6 @@
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
-    },
-    "lodash.has": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
       "dev": true
     },
     "lodash.ismatch": {
@@ -15154,6 +16113,12 @@
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         }
       }
+    },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "dev": true
     },
     "longest-streak": {
       "version": "2.0.4",
@@ -15617,36 +16582,24 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         },
         "ethereumjs-util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
-          "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+          "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
           "dev": true,
           "requires": {
             "bn.js": "^4.11.0",
             "create-hash": "^1.1.2",
+            "elliptic": "^6.5.2",
+            "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "^0.1.3",
-            "keccak": "^1.0.2",
             "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
-          }
-        },
-        "keccak": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
-          "integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.2.1",
-            "inherits": "^2.0.3",
-            "nan": "^2.2.1",
-            "safe-buffer": "^5.1.0"
+            "safe-buffer": "^5.1.1"
           }
         },
         "level-ws": {
@@ -15686,22 +16639,6 @@
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
-          }
-        },
-        "secp256k1": {
-          "version": "3.8.0",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.8.0.tgz",
-          "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
-          "dev": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "bip66": "^1.1.5",
-            "bn.js": "^4.11.8",
-            "create-hash": "^1.2.0",
-            "drbg.js": "^1.0.1",
-            "elliptic": "^6.5.2",
-            "nan": "^2.14.0",
-            "safe-buffer": "^5.1.2"
           }
         }
       }
@@ -16561,9 +17498,9 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
     },
     "nise": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.3.tgz",
-      "integrity": "sha512-EGlhjm7/4KvmmE6B/UFsKh7eHykRl9VH+au8dduHLCyWUO/hr7+N+WtTvDUwc9zHuM1IaIJs/0lQ6Ag1jDkQSg==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.4.tgz",
+      "integrity": "sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.0",
@@ -17141,9 +18078,9 @@
       }
     },
     "opencollective-postinstall": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz",
-      "integrity": "sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz",
+      "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==",
       "dev": true
     },
     "opener": {
@@ -17385,15 +18322,21 @@
       }
     },
     "p-queue": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.4.0.tgz",
-      "integrity": "sha512-X7ddxxiQ+bLR/CUt3/BVKrGcJDNxBr0pEEFKHHB6vTPWNUhgDv36GpIH18RmGM3YGPpBT+JWGjDDqsVGuF0ERw==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.1.tgz",
+      "integrity": "sha512-miQiSxLYPYBxGkrldecZC18OTLjdUqnlRebGzPRiVxB8mco7usCmm7hFuxiTvp93K18JnLtE4KMMycjAu/cQQg==",
       "dev": true,
       "requires": {
-        "eventemitter3": "^4.0.0",
+        "eventemitter3": "^4.0.4",
         "p-timeout": "^3.1.0"
       },
       "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+          "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
+          "dev": true
+        },
         "p-timeout": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
@@ -17412,9 +18355,9 @@
       "dev": true
     },
     "p-settle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.0.1.tgz",
-      "integrity": "sha512-/9fOVH7ipE/TSaxHLZ95XklVLaX2rlOcocE17N/YARHaFbdKwf0jDnIVW22MVQ8sn3AjuJ0XIwylg6GZ3Lhg6Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/p-settle/-/p-settle-4.1.1.tgz",
+      "integrity": "sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==",
       "dev": true,
       "requires": {
         "p-limit": "^2.2.2",
@@ -17465,20 +18408,12 @@
       }
     },
     "p-times": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-times/-/p-times-2.1.0.tgz",
-      "integrity": "sha512-y23lF7HegeUyBTAxHNl6qYvwTy6S4d+BQcs+4CwgxXzc1v1Hsf7pyAqbDHMiYnjdL5Vcmr/oHc9l+nAu0Q+Hhg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-times/-/p-times-3.0.0.tgz",
+      "integrity": "sha512-/Z7mcs8Liie8E7IHI9SBtmkHVW/GjLroQ94ALoAMIG20mqFMuh56/3WYhtOTqX9ccRSOxgaCkFC94Bat1Ofskg==",
       "dev": true,
       "requires": {
-        "p-map": "^2.0.0"
-      },
-      "dependencies": {
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-          "dev": true
-        }
+        "p-map": "^4.0.0"
       }
     },
     "p-try": {
@@ -17578,9 +18513,10 @@
       }
     },
     "parse-duration": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.1.3.tgz",
-      "integrity": "sha512-hMOZHfUmjxO5hMKn7Eft+ckP2M4nV4yzauLXiw3PndpkASnx5r8pDAMcOAiqxoemqWjMWmz4fOHQM6n6WwETXw=="
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-0.4.4.tgz",
+      "integrity": "sha512-KbAJuYGUhZkB9gotDiKLnZ7Z3VTacK3fgwmDdB6ZVDtJbMBT6MfLga0WJaYpPDu0mzqT0NgHtHDt5PY4l0nidg==",
+      "dev": true
     },
     "parse-entities": {
       "version": "1.2.2",
@@ -17930,26 +18866,26 @@
           }
         },
         "split2": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-          "integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.1.tgz",
+          "integrity": "sha512-wmX3JdfKWWghQSjezpJyMxlFodG/vNbV/Y9scsCqYSDWo0nCdteOdzqh8z1NDxpcIZB6BhkqWo6642VI/HA3oA==",
           "dev": true,
           "requires": {
             "readable-stream": "^3.0.0"
           }
         },
         "strip-json-comments": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-          "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
       }
     },
     "pino-std-serializers": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-      "integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.5.0.tgz",
+      "integrity": "sha512-wXqbqSrIhE58TdrxxlfLwU9eDhrzppQDvGhBEr1gYbzzM4KKo3Y63gSjiDXRKLVS2UOXdPNR2v+KnQgNrs+xUg==",
       "dev": true
     },
     "pirates": {
@@ -18310,6 +19246,35 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=",
       "optional": true
     },
+    "protobufjs": {
+      "version": "6.8.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
+      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
+      "dev": true,
+      "requires": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.0",
+        "@types/node": "^10.1.0",
+        "long": "^4.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.28",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
+          "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
+          "dev": true
+        }
+      }
+    },
     "protocol-buffers-schema": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.4.0.tgz",
@@ -18459,9 +19424,9 @@
       "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
     },
     "queue-microtask": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.2.tgz",
-      "integrity": "sha512-F9wwNePtXrzZenAB3ax0Y8TSKGvuB7Qw16J30hspEUTbfUM+H827XyN3rlpwhVmtm5wuZtbKIHjOnwDn7MUxWQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.1.4.tgz",
+      "integrity": "sha512-eY/4Obve9cE5FK8YvC1cJsm5cr7XvAurul8UtBDJ2PR1p5NmAwHtvAt5ftcLtwYRCUKNhxCneZZlxmUDFoSeKA==",
       "dev": true
     },
     "quick-format-unescaped": {
@@ -19092,18 +20057,18 @@
       }
     },
     "rlp": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
-      "integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.6.tgz",
+      "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.11.1"
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -19208,6 +20173,12 @@
         "ajv": "^6.12.0",
         "ajv-keywords": "^3.4.1"
       }
+    },
+    "scrypt-js": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+      "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+      "dev": true
     },
     "secp256k1": {
       "version": "4.0.1",
@@ -19489,59 +20460,18 @@
         }
       }
     },
-    "simple-peer": {
-      "version": "9.7.1",
-      "resolved": "https://registry.npmjs.org/simple-peer/-/simple-peer-9.7.1.tgz",
-      "integrity": "sha512-Ja2B8N1/wR83THDCtig4tBmaodGPV0VBOxxfxEABqMVF+JvzMi3vSsRhyYanwSljXTaAjEli4ztqDGbjHWUD8A==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.0.1",
-        "get-browser-rtc": "^1.0.0",
-        "queue-microtask": "^1.1.0",
-        "randombytes": "^2.0.3",
-        "readable-stream": "^3.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
-          }
-        }
-      }
-    },
     "sinon": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.2.tgz",
-      "integrity": "sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
+      "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.7.2",
         "@sinonjs/fake-timers": "^6.0.1",
         "@sinonjs/formatio": "^5.0.1",
-        "@sinonjs/samsam": "^5.0.3",
+        "@sinonjs/samsam": "^5.1.0",
         "diff": "^4.0.2",
-        "nise": "^4.0.1",
+        "nise": "^4.0.4",
         "supports-color": "^7.1.0"
       },
       "dependencies": {
@@ -20120,9 +21050,9 @@
       }
     },
     "streaming-iterables": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-4.1.2.tgz",
-      "integrity": "sha512-IzhmKnQ2thkNMUcaGsjedrxdAoXPhtIFn8hUlmSqSqafa2p0QmZudu6ImG7ckvPNfazpMfr6Ef8cxUWyIyxpxA==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/streaming-iterables/-/streaming-iterables-5.0.2.tgz",
+      "integrity": "sha512-9z5iBWe9WXzdT0X1JT9fVC0mCcVxWt5yzZMBUIgjZnt2k23+UQF8Ac6kiI8DnlYZJn5iysvxKl3uGzlijMQ+/g==",
       "dev": true
     },
     "streamroller": {
@@ -20304,32 +21234,14 @@
       "integrity": "sha1-IrD6OkE4WzO+PzMVUbu4N/oM164="
     },
     "strtok3": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.0.tgz",
-      "integrity": "sha512-ZXlmE22LZnIBvEU3n/kZGdh770fYFie65u5+2hLK9s74DoFtpkQIdBZVeYEzlolpGa+52G5IkzjUWn+iXynOEQ==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.0.4.tgz",
+      "integrity": "sha512-rqWMKwsbN9APU47bQTMEYTPcwdpKDtmf1jVhHzNW2cL1WqAxaM9iBb9t5P2fj+RV2YsErUWgQzHD5JwV0uCTEQ==",
       "dev": true,
       "requires": {
         "@tokenizer/token": "^0.1.1",
         "@types/debug": "^4.1.5",
-        "debug": "^4.1.1",
         "peek-readable": "^3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        }
       }
     },
     "stubs": {
@@ -20743,9 +21655,9 @@
       "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
     },
     "timeout-abort-controller": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.0.tgz",
-      "integrity": "sha512-xLV+Ms6mDc8UKpBAGGwRkZ137VqS63nGYRnzvI2f1bbv5TWqr4S7ST81870ekn+zlODruVsUexU6GCnErkM7Pw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/timeout-abort-controller/-/timeout-abort-controller-1.1.1.tgz",
+      "integrity": "sha512-BsF9i3NAJag6T0ZEjki9j654zoafI2X6ayuNd6Tp8+Ul6Tr5s4jo973qFeiWrRSweqvskC+AHDKUmIW4b7pdhQ==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -20801,9 +21713,9 @@
       }
     },
     "tiny-secp256k1": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.4.tgz",
-      "integrity": "sha512-O7NfGzBdBy/jamehZ1ptutZsh2c+9pq2Pu+KPv75+yzk5/Q/6lppQGMUJucHdRGdkeBcAUeLAOdJInEAZgZ53A==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
+      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
       "dev": true,
       "requires": {
         "bindings": "^1.3.0",
@@ -20814,9 +21726,9 @@
       },
       "dependencies": {
         "bn.js": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-          "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+          "version": "4.11.9",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+          "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
           "dev": true
         }
       }
@@ -21074,9 +21986,9 @@
       "dev": true
     },
     "typical": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-6.0.0.tgz",
-      "integrity": "sha512-bTTHXOq5E2HgNQiWCyE/Qlw3hPZN+mYB0nUfIAKIeH+pYu+j1BLVyARiD2Ezfh62vug4/qDEk89ELbsvqv5L2Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-6.0.1.tgz",
+      "integrity": "sha512-+g3NEp7fJLe9DPa1TArHm9QAA7YciZmWnfAqEaFrBihQ7epOv9i99rjtgb6Iz0wh3WuQDjsCTDfgRoGnmHN81A==",
       "dev": true
     },
     "ua-parser-js": {
@@ -21098,6 +22010,26 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "optional": true
+        }
+      }
+    },
+    "uint8arrays": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-1.1.0.tgz",
+      "integrity": "sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==",
+      "requires": {
+        "multibase": "^3.0.0",
+        "web-encoding": "^1.0.2"
+      },
+      "dependencies": {
+        "multibase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-3.0.0.tgz",
+          "integrity": "sha512-fuB+zfRbF5zWV4L+CPM0dgA0gX7DHG/IMyzwhVi2RxbRVWn41Wk7SkKW8cxYDGOg6TVh7XgyoesjOAYrB1HBAA==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "web-encoding": "^1.0.2"
+          }
         }
       }
     },
@@ -21530,12 +22462,21 @@
       "integrity": "sha1-2Ca4n3SQcy+rwMDtaT7Uddyynr8="
     },
     "varint-decoder": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.1.1.tgz",
-      "integrity": "sha1-YT1i8HHX51dqIO/RbvTB4zWg3f0=",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/varint-decoder/-/varint-decoder-0.4.0.tgz",
+      "integrity": "sha512-1TGstvah6UbxTJCKMNV9eqR3u8lP7R3zmF52/sXQGyUYbHhh5HxW2dMEGADkuboqrCgOgheBn+z02YvN4bYGFg==",
       "dev": true,
       "requires": {
+        "is-buffer": "^2.0.4",
         "varint": "^5.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        }
       }
     },
     "varuint-bitcoin": {
@@ -21783,6 +22724,11 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-encoding": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.0.2.tgz",
+      "integrity": "sha512-fe9pqxglgy25Z4Ds+2GwZIrOnLxeozydMj0iV8zx0ZNxE3MPTseF4oXGrrBuH4vSkoDYDXoPRRFY/FEYitEUTA=="
     },
     "webcrypto": {
       "version": "0.1.1",
@@ -22277,11 +23223,6 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
-    },
-    "webrtcsupport": {
-      "version": "github:ipfs/webrtcsupport#0a7099ff04fd36227a32e16966dbb3cca7002378",
-      "from": "github:ipfs/webrtcsupport",
-      "dev": true
     },
     "websocket-driver": {
       "version": "0.7.3",

--- a/conformance/package.json
+++ b/conformance/package.json
@@ -10,14 +10,14 @@
   "license": "ISC",
   "dependencies": {
     "aegir": "^21.3.0",
-    "interface-ipfs-core": "0.137.0",
+    "interface-ipfs-core": "0.139.0",
     "ipfsd-ctl": "github:ipfs-rust/js-ipfsd-ctl#add_rust_ipfs_http",
     "mocha": "^7.1.0",
-    "ipfs-http-client": "^44.3.0",
+    "ipfs-http-client": "46.0.0",
     "why-is-node-running": "2.2.0"
   },
   "devDependencies": {
     "rust-ipfs-dep": "github:ipfs-rust/npm-rust-ipfs-dep#master",
-    "ipfs": "^0.43.0"
+    "ipfs": "0.49.0"
   }
 }

--- a/conformance/patches/add.patch
+++ b/conformance/patches/add.patch
@@ -1,0 +1,17 @@
+--- node_modules/interface-ipfs-core/src/add.js
++++ node_modules/interface-ipfs-core/src/add.js
+@@ -171,9 +171,9 @@ module.exports = (common, options) => {
+       const wrapper = await ipfs.add(data, { wrapWithDirectory: true })
+       expect(wrapper.path).to.equal('')
+
+-      const stats = await ipfs.files.stat(`/ipfs/${wrapper.cid}/testfile.txt`)
++      //const stats = await ipfs.files.stat(`/ipfs/${wrapper.cid}/testfile.txt`)
+
+-      expect(`${stats.cid}`).to.equal(fixtures.smallFile.cid)
++      //expect(`${stats.cid}`).to.equal(fixtures.smallFile.cid)
+     })
+
+     it('should add with only-hash=true', async function () {
+--
+2.27.0
+

--- a/conformance/patches/local_refs.patch
+++ b/conformance/patches/local_refs.patch
@@ -1,13 +1,5 @@
 --- node_modules/interface-ipfs-core/src/refs-local.js
 +++ node_modules/interface-ipfs-core/src/refs-local.js
-@@ -7,6 +7,7 @@ const all = require('it-all')
- const importer = require('ipfs-unixfs-importer')
- const drain = require('it-drain')
- const testTimeout = require('./utils/test-timeout')
-+const CID = require('cids')
-
- /** @typedef { import("ipfsd-ctl/src/factory") } Factory */
- /**
 @@ -48,10 +48,14 @@ module.exports = (common, options) => {
 
        const imported = await all(importer(dirs, ipfs.block))

--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -39,7 +39,7 @@ tests.miscellaneous(factory, { skip: [
   'should respect timeout option when getting the node id',
   'should respect timeout option when getting the node version',
   // this hangs on windows, see #251
-  'stop'
+  'stop',
 ] })
 
 // Phase 1.1
@@ -98,7 +98,7 @@ tests.root.add(factory, {
     "should add from a URL with wrap-with-directory=true and URL-escaped file name",
     // this might hang on windows at least; seems that there is a DNSCHANNEL open
     // see https://github.com/rs-ipfs/rust-ipfs/pull/251/checks?check_run_id=889139927#step:17:934
-    "should not add from an invalid url"
+    "should not add from an invalid url",
   ]
 });
 // tests.repo(factory)

--- a/http/src/v0/version.rs
+++ b/http/src/v0/version.rs
@@ -19,6 +19,10 @@ pub struct Response {
     // repo is here for go-ipfs and js-ipfs but we do not have full repo at the moment
     // empty string is accepted by the tests
     repo: &'static str,
+    #[serde(rename = "ipfs-http-client")]
+    ipfs_http_client: &'static str,
+    #[serde(rename = "interface-ipfs-core")]
+    interface_ipfs_core: &'static str,
 }
 
 // https://docs-beta.ipfs.io/reference/http/api/#api-v0-version
@@ -31,6 +35,8 @@ pub fn version(
         version: env!("CARGO_PKG_VERSION"), // TODO: move over to rust-ipfs not to worry about syncing version numbers?
         commit: env!("VERGEN_SHA_SHORT"),
         repo: "",
+        ipfs_http_client: "",
+        interface_ipfs_core: "",
     };
 
     futures::future::ready(Ok((warp::reply::json(&response),)))


### PR DESCRIPTION
`package.json` updates:
```
"interface-ipfs-core": "0.137.0" > "0.139.0"
"ipfs-http-client":    "^44.3.0" > "46.0.0"
"ipfs":                "^0.43.0" > "0.49.0"
```

The new version of the conformance test suite requires 2 new `/version` fields (blank for now) and a patch for one of the `add` tests (as we don't expose `/files` yet). ~~It also allows us to transition the `Repo` to only keep `Multihash`es instead of `Cid`s, as `refs_local` is expected to return `Cid v1` with `Codec::Raw`, which can be produced on the fly.~~ (deferred)