### PR TITLE
Introduce KadResult

### DIFF
--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -84,8 +84,14 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                 }
 
                 match result {
-                    Bootstrap(Ok(BootstrapOk { .. })) => {
-                        debug!("kad: finished bootstrapping");
+                    Bootstrap(Ok(BootstrapOk {
+                        peer,
+                        num_remaining,
+                    })) => {
+                        debug!(
+                            "kad: bootstrapped with {}, {} peers remain",
+                            peer, num_remaining
+                        );
                     }
                     Bootstrap(Err(BootstrapError::Timeout { .. })) => {
                         warn!("kad: failed to bootstrap");

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -78,8 +78,10 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
 
         match event {
             QueryResult { result, id, .. } => {
-                self.kad_subscriptions
-                    .finish_subscription(id.into(), Ok(KadResult::Complete));
+                if self.kademlia.query(&id).is_none() {
+                    self.kad_subscriptions
+                        .finish_subscription(id.into(), Ok(KadResult::Complete));
+                }
 
                 match result {
                     Bootstrap(Ok(BootstrapOk { .. })) => {

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -12,7 +12,7 @@ mod swarm;
 mod transport;
 
 pub use addr::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
-pub use swarm::Connection;
+pub use {behaviour::KadResult, swarm::Connection};
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -1,5 +1,6 @@
 //! IPFS repo
 use crate::error::Error;
+use crate::p2p::KadResult;
 use crate::path::IpfsPath;
 use crate::subscription::{RequestKind, SubscriptionFuture, SubscriptionRegistry};
 use crate::IpfsOptions;
@@ -130,7 +131,7 @@ pub enum RepoEvent {
     UnwantBlock(Cid),
     ProvideBlock(
         Cid,
-        oneshot::Sender<Result<SubscriptionFuture<(), String>, anyhow::Error>>,
+        oneshot::Sender<Result<SubscriptionFuture<KadResult, String>, anyhow::Error>>,
     ),
     UnprovideBlock(Cid),
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -161,7 +161,7 @@ impl<T: Debug + Clone + PartialEq, E: Debug + Clone> SubscriptionRegistry<T, E> 
             return;
         }
 
-        debug!("Shutting down {:?}", self);
+        trace!("Shutting down {:?}", self);
 
         let mut cancelled = 0;
         let mut subscriptions = mem::take(&mut *self.subscriptions.lock().unwrap());
@@ -173,7 +173,7 @@ impl<T: Debug + Clone + PartialEq, E: Debug + Clone> SubscriptionRegistry<T, E> 
             }
         }
 
-        debug!("Cancelled {} subscriptions", cancelled);
+        trace!("Cancelled {} subscriptions", cancelled);
     }
 }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -144,16 +144,12 @@ impl<T: Debug + Clone + PartialEq, E: Debug + Clone> SubscriptionRegistry<T, E> 
 
             // ensure that the subscriptions are being handled correctly: normally
             // finish_subscriptions should result in some related futures being awoken
-            // FIXME: it appears that Kademlia sometimes reports a duplicate QueryResult
-            // and breaks this check; therefore exclude KadQuery, at least for now
-            if !matches!(req_kind, RequestKind::KadQuery(_)) {
-                debug_assert!(
-                    awoken != 0,
-                    "no subscriptions to be awoken! subs: {:?}; req_kind: {:?}",
-                    subscriptions,
-                    req_kind
-                );
-            }
+            debug_assert!(
+                awoken != 0,
+                "no subscriptions to be awoken! subs: {:?}; req_kind: {:?}",
+                subscriptions,
+                req_kind
+            );
 
             trace!("Woke {} related subscription(s)", awoken);
         }


### PR DESCRIPTION
I've been planning to add some of the `/dht` functionalities and since it looks like it's going to be a bit complicated, I'd like to split these upcoming changes into meaningful bits.

First up: the ability to get results from `Kademlia`'s `SubscriptionRegistry`. While working on this I noticed that some of the results can be provided multiple times (e.g. `BootstrapOk` that indicates the number of peers left to bootstrap against), which should solve the mystery of `Kademlia` not adhering to the `debug_assert` we have in `SubscriptionRegistry::finish_subscription`.

As an accidental drive-by there's also a fix to the `Kademlia` bootstrap test which was silently failing after we introduced the `Multiaddr` wrappers.