### PR TITLE
Implement Ipfs::find_peer and /dht/findpeer

### DIFF
--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -4,6 +4,7 @@ use warp::{query, Filter};
 pub mod bitswap;
 pub mod block;
 pub mod dag;
+pub mod dht;
 pub mod id;
 pub mod pubsub;
 pub mod refs;
@@ -105,6 +106,7 @@ pub fn routes<T: IpfsTypes>(
             and_boxed!(warp::path!("put"), dag::put(ipfs)),
             and_boxed!(warp::path!("resolve"), dag::resolve(ipfs)),
         )),
+        and_boxed!(warp::path!("dht" / "findpeer"), dht::find_peer(ipfs)),
         warp::path("pubsub").and(combine!(
             and_boxed!(warp::path!("peers"), pubsub::peers(ipfs)),
             and_boxed!(warp::path!("ls"), pubsub::list_subscriptions(ipfs)),
@@ -124,7 +126,11 @@ pub fn routes<T: IpfsTypes>(
         combine_unify!(
             warp::path!("bootstrap" / ..),
             warp::path!("config" / ..),
-            warp::path!("dht" / ..),
+            warp::path!("dht" / "get"),
+            warp::path!("dht" / "findprovs"),
+            warp::path!("dht" / "provide"),
+            warp::path!("dht" / "put"),
+            warp::path!("dht" / "query"),
             warp::path!("key" / ..),
             warp::path!("name" / ..),
             warp::path!("object" / ..),

--- a/http/src/v0/dht.rs
+++ b/http/src/v0/dht.rs
@@ -1,0 +1,75 @@
+use crate::v0::support::{with_ipfs, MaybeTimeoutExt, StringError, StringSerialized};
+use ipfs::{Ipfs, IpfsTypes, PeerId};
+use serde::{Deserialize, Serialize};
+use warp::{query, Filter, Rejection, Reply};
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct Response {
+    // blank
+    extra: String,
+    // blank
+    #[serde(rename = "ID")]
+    id: String,
+    // the actual response
+    responses: Vec<ResponsesMember>,
+    // TODO: what's this?
+    r#type: usize,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct ResponsesMember {
+    // Multiaddrs
+    addrs: Vec<String>,
+    // PeerId
+    #[serde(rename = "ID")]
+    id: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FindPeerQuery {
+    arg: String,
+    // FIXME: doesn't seem to be used at the moment
+    verbose: Option<bool>,
+    timeout: Option<StringSerialized<humantime::Duration>>,
+}
+
+async fn find_peer_query<T: IpfsTypes>(
+    ipfs: Ipfs<T>,
+    query: FindPeerQuery,
+) -> Result<impl Reply, Rejection> {
+    let FindPeerQuery {
+        arg,
+        verbose: _,
+        timeout,
+    } = query;
+    let peer_id = arg.parse::<PeerId>().map_err(StringError::from)?;
+    let addrs = ipfs
+        .find_peer(peer_id.clone())
+        .maybe_timeout(timeout.map(StringSerialized::into_inner))
+        .await
+        .map_err(StringError::from)?
+        .map_err(StringError::from)?
+        .into_iter()
+        .map(|addr| addr.to_string())
+        .collect();
+    let id = peer_id.to_string();
+
+    let response = Response {
+        extra: Default::default(),
+        id: Default::default(),
+        responses: vec![ResponsesMember { addrs, id }],
+        r#type: 2,
+    };
+
+    Ok(warp::reply::json(&response))
+}
+
+pub fn find_peer<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    with_ipfs(ipfs)
+        .and(query::<FindPeerQuery>())
+        .and_then(find_peer_query)
+}

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -46,6 +46,13 @@ impl TryFrom<Multiaddr> for MultiaddrWithoutPeerId {
     }
 }
 
+impl From<MultiaddrWithPeerId> for MultiaddrWithoutPeerId {
+    fn from(addr: MultiaddrWithPeerId) -> Self {
+        let MultiaddrWithPeerId { multiaddr, .. } = addr;
+        MultiaddrWithoutPeerId(multiaddr.into())
+    }
+}
+
 impl From<MultiaddrWithoutPeerId> for Multiaddr {
     fn from(addr: MultiaddrWithoutPeerId) -> Self {
         let MultiaddrWithoutPeerId(multiaddr) = addr;

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -84,8 +84,14 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                 }
 
                 match result {
-                    Bootstrap(Ok(BootstrapOk { .. })) => {
-                        debug!("kad: finished bootstrapping");
+                    Bootstrap(Ok(BootstrapOk {
+                        peer,
+                        num_remaining,
+                    })) => {
+                        debug!(
+                            "kad: bootstrapped with {}, {} peers remain",
+                            peer, num_remaining
+                        );
                     }
                     Bootstrap(Err(BootstrapError::Timeout { .. })) => {
                         warn!("kad: failed to bootstrap");

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -33,7 +33,7 @@ pub struct Behaviour<Types: IpfsTypes> {
     ping: Ping,
     identify: Identify,
     pubsub: Pubsub,
-    swarm: SwarmApi,
+    pub swarm: SwarmApi,
 }
 
 /// Represents the result of a Kademlia query.
@@ -486,6 +486,10 @@ impl<Types: IpfsTypes> Behaviour<Types> {
                 Err(anyhow!("kad: can't bootstrap the node: {:?}", e))
             }
         }
+    }
+
+    pub fn kademlia(&mut self) -> &mut Kademlia<MemoryStore> {
+        &mut self.kademlia
     }
 
     pub fn get_closest_peers(&mut self, id: PeerId) -> SubscriptionFuture<KadResult, String> {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -78,8 +78,10 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
 
         match event {
             QueryResult { result, id, .. } => {
-                self.kad_subscriptions
-                    .finish_subscription(id.into(), Ok(KadResult::Complete));
+                if self.kademlia.query(&id).is_none() {
+                    self.kad_subscriptions
+                        .finish_subscription(id.into(), Ok(KadResult::Complete));
+                }
 
                 match result {
                     Bootstrap(Ok(BootstrapOk { .. })) => {

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -12,7 +12,7 @@ mod swarm;
 mod transport;
 
 pub use addr::{MultiaddrWithPeerId, MultiaddrWithoutPeerId};
-pub use swarm::Connection;
+pub use {behaviour::KadResult, swarm::Connection};
 
 pub type TSwarm<T> = Swarm<behaviour::Behaviour<T>>;
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -1,5 +1,6 @@
 //! IPFS repo
 use crate::error::Error;
+use crate::p2p::KadResult;
 use crate::path::IpfsPath;
 use crate::subscription::{RequestKind, SubscriptionFuture, SubscriptionRegistry};
 use crate::IpfsOptions;
@@ -130,7 +131,7 @@ pub enum RepoEvent {
     UnwantBlock(Cid),
     ProvideBlock(
         Cid,
-        oneshot::Sender<Result<SubscriptionFuture<(), String>, anyhow::Error>>,
+        oneshot::Sender<Result<SubscriptionFuture<KadResult, String>, anyhow::Error>>,
     ),
     UnprovideBlock(Cid),
 }

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -161,7 +161,7 @@ impl<T: Debug + Clone + PartialEq, E: Debug + Clone> SubscriptionRegistry<T, E> 
             return;
         }
 
-        debug!("Shutting down {:?}", self);
+        trace!("Shutting down {:?}", self);
 
         let mut cancelled = 0;
         let mut subscriptions = mem::take(&mut *self.subscriptions.lock().unwrap());
@@ -173,7 +173,7 @@ impl<T: Debug + Clone + PartialEq, E: Debug + Clone> SubscriptionRegistry<T, E> 
             }
         }
 
-        debug!("Cancelled {} subscriptions", cancelled);
+        trace!("Cancelled {} subscriptions", cancelled);
     }
 }
 

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -144,16 +144,12 @@ impl<T: Debug + Clone + PartialEq, E: Debug + Clone> SubscriptionRegistry<T, E> 
 
             // ensure that the subscriptions are being handled correctly: normally
             // finish_subscriptions should result in some related futures being awoken
-            // FIXME: it appears that Kademlia sometimes reports a duplicate QueryResult
-            // and breaks this check; therefore exclude KadQuery, at least for now
-            if !matches!(req_kind, RequestKind::KadQuery(_)) {
-                debug_assert!(
-                    awoken != 0,
-                    "no subscriptions to be awoken! subs: {:?}; req_kind: {:?}",
-                    subscriptions,
-                    req_kind
-                );
-            }
+            debug_assert!(
+                awoken != 0,
+                "no subscriptions to be awoken! subs: {:?}; req_kind: {:?}",
+                subscriptions,
+                req_kind
+            );
 
             trace!("Woke {} related subscription(s)", awoken);
         }


### PR DESCRIPTION
Builds on https://github.com/rs-ipfs/rust-ipfs/pull/319, only the last 2 commits are new.

Introduces `Ipfs::find_peer` and `/dht/findpeer` that return addresses belonging to the given `PeerId`; if they are connected to already, the values are returned right away, otherwise the local DHT records are checked.

Blocked by https://github.com/rs-ipfs/rust-ipfs/pull/319.

