### PR TITLE
fix: make ipfs-http to use ipfs::IpfsPath

### DIFF
--- a/http/src/v0/dag.rs
+++ b/http/src/v0/dag.rs
@@ -121,12 +121,16 @@ async fn inner_resolve<T: IpfsTypes>(
     ipfs: Ipfs<T>,
     opts: ResolveOptions,
 ) -> Result<impl Reply, Rejection> {
-    use crate::v0::refs::{walk_path, IpfsPath};
+    use crate::v0::refs::{walk_path, IpfsPath, WalkOptions};
     use std::convert::TryFrom;
 
     let path = IpfsPath::try_from(opts.arg.as_str()).map_err(StringError::from)?;
 
-    let (current, _, remaining) = walk_path(&ipfs, path)
+    let walk_opts = WalkOptions {
+        follow_dagpb_data: true,
+    };
+
+    let (current, _, remaining) = walk_path(&ipfs, &walk_opts, path)
         .maybe_timeout(opts.timeout.map(StringSerialized::into_inner))
         .await
         .map_err(StringError::from)?

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -405,7 +405,7 @@ fn handle_dagpb_not_found(
 ) -> Result<(Cid, Loaded, Vec<String>), WalkError> {
     use ipfs::unixfs::ll::dagpb::node_data;
 
-    if needle == "Data" && last_segment && opts.follow_dagpb_data {
+    if opts.follow_dagpb_data && last_segment && needle == "Data" {
         // /dag/resolve needs to "resolve through" a dag-pb node down to the "just data" even
         // though we do not need to extract it ... however this might be good to just filter with
         // refs, as no refs of such path can exist as the links are in the outer structure.

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -468,8 +468,8 @@ fn iplds_refs<T: IpfsTypes>(
                     warn!("failed to load {}, linked from {}: {}", cid, source, e);
                     // TODO: yield error msg
                     // unsure in which cases this happens, because we'll start to search the content
-                    // and stop only when request has been cancelled (FIXME: not yet, because dropping
-                    // all subscriptions doesn't "stop the operation.")
+                    // and stop only when request has been cancelled (FIXME: no way to stop this
+                    // operation)
                     continue;
                 }
             };

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -138,6 +138,7 @@ async fn refs_paths<T: IpfsTypes>(
         follow_dagpb_data: true,
     };
 
+    // added braces to spell it out for borrowck that opts does not outlive this fn
     let iplds = {
         // the assumption is that futuresordered will poll the first N items until the first completes,
         // buffering the others. it might not be 100% parallel but it's probably enough.

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -429,6 +429,7 @@ fn iplds_refs<T: IpfsTypes>(
             return;
         }
 
+        // FIXME: this should be queued_or_visited
         let mut visited = HashSet::new();
         let mut work = VecDeque::new();
 

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -343,7 +343,6 @@ pub async fn walk_path<T: IpfsTypes>(
                 // the "remaining path"
                 let tmp = needle.clone();
                 ipld = match IpfsPath::resolve_segment(&needle, ipld) {
-                    Ok(WalkSuccess::EmptyPath(_)) => unreachable!(),
                     Ok(WalkSuccess::AtDestination(ipld)) => {
                         path_inside_last.push(tmp);
                         ipld

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -72,6 +72,9 @@ async fn refs_inner<T: IpfsTypes>(
     // FIXME: there should be a total timeout arching over path walking to the stream completion.
     // hyper can't do trailer errors on chunked bodies so ... we can't do much.
 
+    // FIXME: the test case 'should print nothing for non-existent hashes' is problematic as it
+    // expects the headers to be blocked before the timeout expires.
+
     let st = st.map(move |res| {
         let res = match res {
             Ok((source, dest, link_name)) => {

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -120,16 +120,6 @@ impl IpfsPath {
         self.follow_dagpb_data
     }
 
-    /*
-    pub fn resolve(&mut self, ipld: Ipld) -> Result<WalkSuccess, WalkFailed> {
-        let key = match self.next() {
-            Some(key) => key,
-            None => return Ok(WalkSuccess::EmptyPath(ipld)),
-        };
-
-        Self::resolve_segment(key, ipld)
-    }*/
-
     pub fn resolve_segment(key: &str, mut ipld: Ipld) -> Result<WalkSuccess, WalkFailed> {
         ipld = match ipld {
             Ipld::Link(cid) if key == "." => {
@@ -164,33 +154,6 @@ impl IpfsPath {
             Ok(WalkSuccess::AtDestination(ipld))
         }
     }
-
-    /*
-    /// Walks the path depicted by self until either the path runs out or a new link needs to be
-    /// traversed to continue the walk. With !dag-pb documents this can result in subtree of an
-    /// Ipld be represented.
-    ///
-    /// # Panics
-    ///
-    /// If the current Ipld is from a dag-pb and the libipld has changed it's dag-pb tree structure.
-    // FIXME: this needs to be removed and ... we should have some generic Ipld::walk
-    pub fn walk(&mut self, current: &Cid, mut ipld: Ipld) -> Result<WalkSuccess, WalkFailed> {
-        if self.len() == 0 {
-            return Ok(WalkSuccess::EmptyPath(ipld));
-        }
-        if current.codec() == cid::Codec::DagProtobuf {
-            return Err(WalkFailed::UnsupportedWalkOnDagPbIpld);
-        }
-
-        loop {
-            ipld = match self.resolve(ipld)? {
-                WalkSuccess::AtDestination(ipld) => ipld,
-                WalkSuccess::EmptyPath(ipld) => return Ok(WalkSuccess::AtDestination(ipld)),
-                ret @ WalkSuccess::Link(_, _) => return Ok(ret),
-            };
-        }
-    }
-    */
 
     pub fn remaining_path(&self) -> &[String] {
         self.path.as_slice()

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -155,10 +155,6 @@ impl IpfsPath {
         }
     }
 
-    pub fn remaining_path(&self) -> &[String] {
-        self.path.as_slice()
-    }
-
     // Currently unused by commited code, but might become handy or easily removed later on.
     #[allow(dead_code)]
     pub fn debug<'a>(&'a self, current: &'a Cid) -> impl fmt::Debug + 'a {

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -34,9 +34,6 @@ pub struct IpfsPath {
     /// Option to support moving the cid
     root: Option<Cid>,
     path: Vec<String>,
-    /// True by default, to allow "finding" `Data` under dag-pb node
-    /// TODO: document why this matters
-    follow_dagpb_data: bool,
 }
 
 impl From<Cid> for IpfsPath {
@@ -46,7 +43,6 @@ impl From<Cid> for IpfsPath {
         IpfsPath {
             root: Some(root),
             path: Vec::new(),
-            follow_dagpb_data: true,
         }
     }
 }
@@ -93,13 +89,7 @@ impl TryFrom<&str> for IpfsPath {
 
         let root = Some(Cid::try_from(root).map_err(PathError::InvalidCid)?);
 
-        let follow_dagpb_data = true;
-
-        Ok(IpfsPath {
-            root,
-            path,
-            follow_dagpb_data,
-        })
+        Ok(IpfsPath { root, path })
     }
 }
 
@@ -110,14 +100,6 @@ impl IpfsPath {
 
     pub fn path(&self) -> &[String] {
         &self.path
-    }
-
-    pub fn set_follow_dagpb_data(&mut self, follow: bool) {
-        self.follow_dagpb_data = follow;
-    }
-
-    pub fn follow_dagpb_data(&self) -> bool {
-        self.follow_dagpb_data
     }
 
     pub fn resolve_segment(key: &str, mut ipld: Ipld) -> Result<WalkSuccess, WalkFailed> {

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -231,13 +231,13 @@ mod tests {
         }
     }
 
-    fn walk<'a>(
+    fn walk(
         mut doc: Ipld,
-        path: &'a IpfsPath,
+        path: &'_ IpfsPath,
     ) -> Result<
         (
             WalkSuccess,
-            impl Iterator<Item = &'a String> + std::fmt::Debug,
+            impl Iterator<Item = &'_ String> + std::fmt::Debug,
         ),
         WalkFailed,
     > {

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -187,9 +187,6 @@ impl IpfsPath {
 /// The success values walking an `IpfsPath` can result to.
 #[derive(Debug, PartialEq)]
 pub enum WalkSuccess {
-    /// IpfsPath was already empty, or became empty during previous walk
-    // FIXME: remove this when migrating away from IpfsPath::walk
-    EmptyPath(Ipld),
     /// IpfsPath arrived at destination, following walk attempts will return EmptyPath
     AtDestination(Ipld),
     /// Path segment lead to a link which needs to be loaded to continue the walk
@@ -467,7 +464,7 @@ mod tests {
         WalkFailed,
     > {
         if path.path().is_empty() {
-            return Ok((WalkSuccess::EmptyPath(doc), path.path().iter()));
+            unreachable!("empty path");
         }
 
         if current.codec() == cid::Codec::DagProtobuf {
@@ -484,9 +481,6 @@ mod tests {
             };
             doc = match IpfsPath::resolve_segment(needle, doc)? {
                 WalkSuccess::AtDestination(ipld) => ipld,
-                WalkSuccess::EmptyPath(ipld) => {
-                    return Ok((WalkSuccess::AtDestination(ipld), iter))
-                }
                 ret @ WalkSuccess::Link(_, _) => return Ok((ret, iter)),
             };
         }

--- a/http/src/v0/refs/path.rs
+++ b/http/src/v0/refs/path.rs
@@ -8,128 +8,7 @@
 use cid::{self, Cid};
 use ipfs::ipld::Ipld;
 use std::collections::BTreeMap;
-use std::convert::TryFrom;
 use std::fmt;
-
-#[derive(Debug)]
-pub enum PathError {
-    InvalidCid(cid::Error),
-    InvalidPath,
-}
-
-impl fmt::Display for PathError {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            PathError::InvalidCid(e) => write!(fmt, "{}", e),
-            PathError::InvalidPath => write!(fmt, "invalid path"),
-        }
-    }
-}
-
-impl std::error::Error for PathError {}
-
-/// Ipfs path following https://github.com/ipfs/go-path/
-#[derive(Debug)]
-pub struct IpfsPath {
-    /// Option to support moving the cid
-    root: Option<Cid>,
-    path: Vec<String>,
-}
-
-impl From<Cid> for IpfsPath {
-    /// Creates a new IpfsPath from just the Cid, which is the same as parsing from a string
-    /// representation of a Cid but cannot fail.
-    fn from(root: Cid) -> IpfsPath {
-        IpfsPath {
-            root: Some(root),
-            path: Vec::new(),
-        }
-    }
-}
-
-impl TryFrom<&str> for IpfsPath {
-    type Error = PathError;
-
-    fn try_from(path: &str) -> Result<Self, Self::Error> {
-        let mut split = path.splitn(2, "/ipfs/");
-        let first = split.next();
-        let (_root, path) = match first {
-            Some("") => {
-                /* started with /ipfs/ */
-                if let Some(x) = split.next() {
-                    // was /ipfs/x
-                    ("ipfs", x)
-                } else {
-                    // just the /ipfs/
-                    return Err(PathError::InvalidPath);
-                }
-            }
-            Some(x) => {
-                /* maybe didn't start with /ipfs/, need to check second */
-                if split.next().is_some() {
-                    // x/ipfs/_
-                    return Err(PathError::InvalidPath);
-                }
-
-                ("", x)
-            }
-            None => return Err(PathError::InvalidPath),
-        };
-
-        let mut split = path.splitn(2, '/');
-        let root = split
-            .next()
-            .expect("first value from splitn(2, _) must exist");
-
-        let path = split
-            .next()
-            .iter()
-            .flat_map(|s| s.split('/').filter(|s| !s.is_empty()).map(String::from))
-            .collect::<Vec<_>>();
-
-        let root = Some(Cid::try_from(root).map_err(PathError::InvalidCid)?);
-
-        Ok(IpfsPath { root, path })
-    }
-}
-
-impl IpfsPath {
-    pub fn take_root(&mut self) -> Option<Cid> {
-        self.root.take()
-    }
-
-    pub fn path(&self) -> &[String] {
-        &self.path
-    }
-
-    // Currently unused by commited code, but might become handy or easily removed later on.
-    #[allow(dead_code)]
-    pub fn debug<'a>(&'a self, current: &'a Cid) -> impl fmt::Debug + 'a {
-        struct DebuggableIpfsPath<'a> {
-            current: &'a Cid,
-            segments: &'a [String],
-        }
-
-        impl<'a> fmt::Debug for DebuggableIpfsPath<'a> {
-            fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-                write!(fmt, "{}", self.current)?;
-                if !self.segments.is_empty() {
-                    write!(fmt, "/...")?;
-                }
-
-                for seg in self.segments {
-                    write!(fmt, "/{}", seg)?;
-                }
-                Ok(())
-            }
-        }
-
-        DebuggableIpfsPath {
-            current,
-            segments: self.path.as_slice(),
-        }
-    }
-}
 
 pub fn resolve_segment(key: &str, mut ipld: Ipld) -> Result<WalkSuccess, WalkFailed> {
     ipld = match ipld {
@@ -228,91 +107,12 @@ impl std::error::Error for WalkFailed {}
 #[cfg(test)]
 mod tests {
     use super::WalkFailed;
-    use super::{resolve_segment, IpfsPath, WalkSuccess};
+    use super::{resolve_segment, WalkSuccess};
     use cid::Cid;
-    use ipfs::{ipld::Ipld, make_ipld};
+    use ipfs::{ipld::Ipld, make_ipld, IpfsPath};
     use std::convert::TryFrom;
 
     // good_paths, good_but_unsupported, bad_paths from https://github.com/ipfs/go-path/blob/master/path_test.go
-
-    #[test]
-    fn good_paths() {
-        let good = [
-            ("/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n", 0),
-            ("/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a", 1),
-            (
-                "/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
-                6,
-            ),
-            (
-                "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
-                6,
-            ),
-            ("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n", 0),
-        ];
-
-        for &(good, len) in &good {
-            let p = IpfsPath::try_from(good).unwrap();
-            assert_eq!(p.path().len(), len);
-        }
-    }
-
-    #[test]
-    fn good_but_unsupported() {
-        let unsupported = [
-            "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
-            "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a",
-            "/ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
-            "/ipns/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a/b/c/d/e/f",
-            "/ipns/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
-        ];
-
-        for &unsupported in &unsupported {
-            // these fail from failing to parse "ipld" or "ipns" as cid
-            IpfsPath::try_from(unsupported).unwrap_err();
-        }
-    }
-
-    #[test]
-    fn bad_paths() {
-        let bad = [
-            "/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
-            "/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/a",
-            "/ipfs/foo",
-            "/ipfs/",
-            "ipfs/",
-            "ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
-            "/ipld/foo",
-            "/ipld/",
-            "ipld/",
-            "ipld/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
-        ];
-
-        for &bad in &bad {
-            IpfsPath::try_from(bad).unwrap_err();
-        }
-    }
-
-    #[test]
-    fn trailing_slash_is_ignored() {
-        let paths = [
-            "/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/",
-            "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n/",
-        ];
-        for &path in &paths {
-            let p = IpfsPath::try_from(path).unwrap();
-            assert_eq!(p.path().len(), 0);
-        }
-    }
-
-    #[test]
-    fn multiple_slashes_are_deduplicated() {
-        // this is similar to behaviour in js-ipfs, as of
-        // https://github.com/ipfs-rust/rust-ipfs/pull/147/files#r408939850
-        let p =
-            IpfsPath::try_from("/ipfs/QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n///a").unwrap();
-        assert_eq!(p.path().len(), 1);
-    }
 
     fn example_doc_and_a_cid() -> (Ipld, Cid) {
         let cid = Cid::try_from("QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n").unwrap();
@@ -357,14 +157,14 @@ mod tests {
         ];
 
         for (path, expected) in &good_examples {
-            let mut p = IpfsPath::try_from(*path).unwrap();
+            let p = IpfsPath::try_from(*path).unwrap();
 
             // not really the document cid but it doesn't matter; it just needs to be !dag-pb
-            let doc_cid = p.take_root().unwrap();
+            //let doc_cid = p.take_root().unwrap();
 
             // projection
             assert_eq!(
-                walk(&doc_cid, example_doc.clone(), &p).map(|r| r.0),
+                walk(example_doc.clone(), &p).map(|r| r.0),
                 Ok(WalkSuccess::AtDestination(expected.clone()))
             );
         }
@@ -376,11 +176,10 @@ mod tests {
         let doc = make_ipld!(cid.clone());
         let path = "bafyreielwgy762ox5ndmhx6kpi6go6il3gzahz3ngagb7xw3bj3aazeita/./foobar";
 
-        let mut p = IpfsPath::try_from(path).unwrap();
-        let doc_cid = p.take_root().unwrap();
+        let p = IpfsPath::try_from(path).unwrap();
 
         assert_eq!(
-            walk(&doc_cid, doc, &p).map(|r| r.0),
+            walk(doc, &p).map(|r| r.0),
             Ok(WalkSuccess::Link(".".into(), cid))
         );
     }
@@ -391,12 +190,11 @@ mod tests {
         let doc = make_ipld!(cid);
         let path = "bafyreielwgy762ox5ndmhx6kpi6go6il3gzahz3ngagb7xw3bj3aazeita/foobar";
 
-        let mut p = IpfsPath::try_from(path).unwrap();
-        let doc_cid = p.take_root().unwrap();
+        let p = IpfsPath::try_from(path).unwrap();
 
         // go-ipfs would walk over the link even without a dot, this will probably come up with
         // dag/get
-        walk(&doc_cid, doc, &p).unwrap_err();
+        walk(doc, &p).unwrap_err();
     }
 
     #[test]
@@ -404,10 +202,9 @@ mod tests {
         let (example_doc, cid) = example_doc_and_a_cid();
 
         let path = "bafyreielwgy762ox5ndmhx6kpi6go6il3gzahz3ngagb7xw3bj3aazeita/nested/even/2/or/something_on_the_next_block";
-        let mut p = IpfsPath::try_from(path).unwrap();
-        let doc_cid = p.take_root().unwrap();
+        let p = IpfsPath::try_from(path).unwrap();
 
-        let (success, mut remaining) = walk(&doc_cid, example_doc, &p).unwrap();
+        let (success, mut remaining) = walk(example_doc, &p).unwrap();
 
         assert_eq!(success, WalkSuccess::Link("or".into(), cid));
         assert_eq!(
@@ -427,15 +224,14 @@ mod tests {
         ];
 
         for path in &mismatches {
-            let mut p = IpfsPath::try_from(*path).unwrap();
-            let doc_cid = p.take_root().unwrap();
+            let p = IpfsPath::try_from(*path).unwrap();
+            // let doc_cid = p.take_root().unwrap();
             // using just unwrap_err as the context would be quite troublesome to write
-            walk(&doc_cid, example_doc.clone(), &p).unwrap_err();
+            walk(example_doc.clone(), &p).unwrap_err();
         }
     }
 
     fn walk<'a>(
-        current: &Cid,
         mut doc: Ipld,
         path: &'a IpfsPath,
     ) -> Result<
@@ -448,6 +244,8 @@ mod tests {
         if path.path().is_empty() {
             unreachable!("empty path");
         }
+
+        let current = path.root().cid().unwrap();
 
         if current.codec() == cid::Codec::DagProtobuf {
             return Err(WalkFailed::UnsupportedWalkOnDagPbIpld);

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -60,8 +60,7 @@ pub fn cat<T: IpfsTypes>(
 }
 
 async fn cat_inner<T: IpfsTypes>(ipfs: Ipfs<T>, args: CatArgs) -> Result<impl Reply, Rejection> {
-    let mut path = IpfsPath::try_from(args.arg.as_str()).map_err(StringError::from)?;
-    path.set_follow_dagpb_data(false);
+    let path = IpfsPath::try_from(args.arg.as_str()).map_err(StringError::from)?;
 
     let range = match (args.offset, args.length) {
         (Some(start), Some(len)) => Some(start..(start + len)),
@@ -73,7 +72,7 @@ async fn cat_inner<T: IpfsTypes>(ipfs: Ipfs<T>, args: CatArgs) -> Result<impl Re
     // FIXME: this is here until we have IpfsPath back at ipfs
     // FIXME: this timeout here is ... not great; the end user could be waiting for 2*timeout
 
-    let (cid, _, _) = walk_path(&ipfs, path)
+    let (cid, _, _) = walk_path(&ipfs, &Default::default(), path)
         .maybe_timeout(args.timeout.clone().map(StringSerialized::into_inner))
         .await
         .map_err(StringError::from)?
@@ -118,12 +117,11 @@ pub fn get<T: IpfsTypes>(
 async fn get_inner<T: IpfsTypes>(ipfs: Ipfs<T>, args: GetArgs) -> Result<impl Reply, Rejection> {
     use futures::stream::TryStreamExt;
 
-    let mut path = IpfsPath::try_from(args.arg.as_str()).map_err(StringError::from)?;
-    path.set_follow_dagpb_data(false);
+    let path = IpfsPath::try_from(args.arg.as_str()).map_err(StringError::from)?;
 
     // FIXME: this is here until we have IpfsPath back at ipfs
     // FIXME: this timeout is only for the first step, should be for the whole walk!
-    let (cid, _, _) = walk_path(&ipfs, path)
+    let (cid, _, _) = walk_path(&ipfs, &Default::default(), path)
         .maybe_timeout(args.timeout.map(StringSerialized::into_inner))
         .await
         .map_err(StringError::from)?

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::ipld::{decode_ipld, encode_ipld, Ipld};
-use crate::path::{IpfsPath, IpfsPathError, SubPath};
+use crate::path::{IpfsPath, IpfsPathError};
 use crate::repo::RepoTypes;
 use crate::Ipfs;
 use bitswap::Block;
@@ -51,7 +51,10 @@ impl<Types: RepoTypes> IpldDag<Types> {
     }
 }
 
-fn can_resolve(ipld: &Ipld, sub_path: &SubPath) -> bool {
+fn can_resolve(ipld: &Ipld, sub_path: &String) -> bool {
+    todo!("need to copy this over from ipfs-http or ... not do anything?")
+
+    /*
     match sub_path {
         SubPath::Key(key) => {
             if let Ipld::Map(ref map) = ipld {
@@ -69,10 +72,12 @@ fn can_resolve(ipld: &Ipld, sub_path: &SubPath) -> bool {
         }
     }
     false
+        */
 }
 
-fn resolve(ipld: Ipld, sub_path: &SubPath) -> Ipld {
-    match sub_path {
+fn resolve(ipld: Ipld, sub_path: &String) -> Ipld {
+    todo!("this would be 1:1 copyable")
+    /*match sub_path {
         SubPath::Key(key) => {
             if let Ipld::Map(mut map) = ipld {
                 return map.remove(key).unwrap();
@@ -87,7 +92,7 @@ fn resolve(ipld: Ipld, sub_path: &SubPath) -> Ipld {
     panic!(
         "Failed to resolved ipld: {:?} sub_path: {:?}",
         ipld, sub_path
-    );
+    );*/
 }
 
 #[cfg(test)]

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::ipld::{decode_ipld, encode_ipld, Ipld};
-use crate::path::{IpfsPath, IpfsPathError};
+use crate::path::IpfsPath;
 use crate::repo::RepoTypes;
 use crate::Ipfs;
 use bitswap::Block;

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -37,11 +37,7 @@ impl<Types: RepoTypes> IpldDag<Types> {
         };
         let mut ipld = decode_ipld(&cid, self.ipfs.repo.get_block(&cid).await?.data())?;
         for sub_path in path.iter() {
-            if !can_resolve(&ipld, sub_path) {
-                let path = sub_path.to_owned();
-                return Err(IpfsPathError::ResolveError { ipld, path }.into());
-            }
-            ipld = resolve(ipld, sub_path);
+            ipld = try_resolve(ipld, sub_path)?;
             ipld = match ipld {
                 Ipld::Link(cid) => decode_ipld(&cid, self.ipfs.repo.get_block(&cid).await?.data())?,
                 ipld => ipld,
@@ -51,48 +47,27 @@ impl<Types: RepoTypes> IpldDag<Types> {
     }
 }
 
-fn can_resolve(ipld: &Ipld, sub_path: &String) -> bool {
-    todo!("need to copy this over from ipfs-http or ... not do anything?")
-
-    /*
-    match sub_path {
-        SubPath::Key(key) => {
-            if let Ipld::Map(ref map) = ipld {
-                if map.contains_key(key) {
-                    return true;
-                }
-            }
-        }
-        SubPath::Index(index) => {
-            if let Ipld::List(ref vec) = ipld {
-                if *index < vec.len() {
-                    return true;
-                }
-            }
-        }
+fn try_resolve(ipld: Ipld, segment: &str) -> Result<Ipld, Error> {
+    match ipld {
+        Ipld::Map(mut map) => map
+            .remove(segment)
+            .ok_or_else(|| anyhow::anyhow!("no such segment: {:?}", segment)),
+        Ipld::List(mut vec) => match segment.parse::<usize>() {
+            Ok(index) if index < vec.len() => Ok(vec.swap_remove(index)),
+            Ok(_) => Err(anyhow::anyhow!(
+                "index out of range 0..{}: {:?}",
+                vec.len(),
+                segment
+            )),
+            Err(_) => Err(anyhow::anyhow!("invalid list index: {:?}", segment)),
+        },
+        link @ Ipld::Link(_) if segment == "." => Ok(link),
+        other => Err(anyhow::anyhow!(
+            "cannot resolve {:?} through: {:?}",
+            segment,
+            other
+        )),
     }
-    false
-        */
-}
-
-fn resolve(ipld: Ipld, sub_path: &String) -> Ipld {
-    todo!("this would be 1:1 copyable")
-    /*match sub_path {
-        SubPath::Key(key) => {
-            if let Ipld::Map(mut map) = ipld {
-                return map.remove(key).unwrap();
-            }
-        }
-        SubPath::Index(index) => {
-            if let Ipld::List(mut vec) = ipld {
-                return vec.swap_remove(*index);
-            }
-        }
-    }
-    panic!(
-        "Failed to resolved ipld: {:?} sub_path: {:?}",
-        ipld, sub_path
-    );*/
 }
 
 #[cfg(test)]

--- a/src/path.rs
+++ b/src/path.rs
@@ -84,6 +84,10 @@ impl IpfsPath {
     pub fn iter(&self) -> impl Iterator<Item = &String> {
         self.path.iter()
     }
+
+    pub fn path(&self) -> &[String] {
+        &self.path
+    }
 }
 
 impl fmt::Display for IpfsPath {

--- a/src/path.rs
+++ b/src/path.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 #[derive(Clone, Debug, PartialEq)]
 pub struct IpfsPath {
     root: PathRoot,
-    path: Vec<SubPath>,
+    path: Vec<String>,
 }
 
 impl FromStr for IpfsPath {
@@ -53,7 +53,7 @@ impl IpfsPath {
         self.root = root;
     }
 
-    pub fn push<T: Into<SubPath>>(&mut self, sub_path: T) {
+    pub fn push<T: Into<String>>(&mut self, sub_path: T) {
         self.path.push(sub_path.into());
     }
 
@@ -65,12 +65,7 @@ impl IpfsPath {
             if sub_path == "" {
                 return Err(IpfsPathError::InvalidPath(string.to_owned()).into());
             }
-            let index = sub_path.parse::<usize>();
-            if let Ok(index) = index {
-                self.push(index);
-            } else {
-                self.push(sub_path);
-            }
+            self.push(sub_path);
         }
         Ok(())
     }
@@ -86,7 +81,7 @@ impl IpfsPath {
         Ok(self)
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = &SubPath> {
+    pub fn iter(&self) -> impl Iterator<Item = &String> {
         self.path.iter()
     }
 }
@@ -227,69 +222,12 @@ impl TryInto<PeerId> for PathRoot {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
-pub enum SubPath {
-    Key(String),
-    Index(usize),
-}
-
-impl From<String> for SubPath {
-    fn from(key: String) -> Self {
-        SubPath::Key(key)
-    }
-}
-
-impl From<&str> for SubPath {
-    fn from(key: &str) -> Self {
-        SubPath::from(key.to_string())
-    }
-}
-
-impl From<usize> for SubPath {
-    fn from(index: usize) -> Self {
-        SubPath::Index(index)
-    }
-}
-
-impl SubPath {
-    pub fn is_key(&self) -> bool {
-        matches!(*self, SubPath::Key(_))
-    }
-
-    pub fn to_key(&self) -> Option<&String> {
-        match self {
-            SubPath::Key(ref key) => Some(key),
-            _ => None,
-        }
-    }
-
-    pub fn is_index(&self) -> bool {
-        matches!(self, SubPath::Index(_))
-    }
-
-    pub fn to_index(&self) -> Option<usize> {
-        match self {
-            SubPath::Index(index) => Some(*index),
-            _ => None,
-        }
-    }
-}
-
-impl fmt::Display for SubPath {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            SubPath::Key(ref key) => write!(fmt, "{}", key),
-            SubPath::Index(index) => write!(fmt, "{}", index),
-        }
-    }
-}
-
 #[derive(Debug, Error)]
 pub enum IpfsPathError {
     #[error("Invalid path {0:?}")]
     InvalidPath(String),
     #[error("Can't resolve {path:?}")]
-    ResolveError { ipld: Ipld, path: SubPath },
+    ResolveError { ipld: Ipld, path: String },
     #[error("Expected ipld path but found ipns path.")]
     ExpectedIpldPath,
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -64,12 +64,6 @@ impl IpfsPath {
         self.root = root;
     }
 
-    // FIXME: would be great to get rid of this
-    #[doc(hidden)]
-    pub fn push<T: Into<String>>(&mut self, sub_path: T) {
-        self.path.push(sub_path.into());
-    }
-
     pub fn push_str(&mut self, string: &str) -> Result<(), Error> {
         if string.is_empty() {
             return Ok(());
@@ -91,7 +85,7 @@ impl IpfsPath {
                     Err(())
                 };
             }
-            self.push(sub_path);
+            self.path.push(sub_path.to_owned());
         }
         Ok(())
     }


### PR DESCRIPTION
First step towards solving the #238 

- fix `ipfs::IpfsPath`
  - swapped `ipfs::path::SubPath` for `String` (commit has reason)
  - removed `IpfsPath::push(&mut self, segment: impl Into<SubPath>)`
  - remove the implicit ending empty path segment (seemed intentional, don't know why that was there)
  - migrate tests
    - most notably add support for `cid/a/b/c` cases
    - move "good_but_unsupported" over to "good_paths" (as ipfs::IpfsPath validates more)
- make ipfs-http use `ipfs::IpfsPath`

This specifically doesn't include:

- separation of different kinds of IpfsPaths (`CidPath`, `IpnsPath`)
  - instead there is currently an expect over at http side for cid paths
- probably a good idea to refactor out the `Vec<String>` (sub)path somehow; it might be heavily reusable for unixfs for example
- moving the resolving over to ipfs from the current not so great `ipfs_http::v0::refs::walk_paths` 

These should be handled on next PRs. The end result here is not too pretty but it shouldn't break much either.

Big unsolved mysteries:

- how to implement conformance test compatible refs once this has been moved over to ipfs (probably need to adjust the test)