### PR TITLE
Use alloc and core crates where they are applicable

### DIFF
--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -1,11 +1,11 @@
 use crate::{Error, Ipfs, IpfsTypes};
 use async_stream::stream;
 use cid::Cid;
-use futures::stream::Stream;
-use ipfs_unixfs::file::{visit::IdleFileVisit, FileReadFailed};
 use core::borrow::Borrow;
 use core::fmt;
 use core::ops::Range;
+use futures::stream::Stream;
+use ipfs_unixfs::file::{visit::IdleFileVisit, FileReadFailed};
 
 /// IPFS cat operation, producing a stream of file bytes. This is generic over the different kinds
 /// of ways to own an `Ipfs` value in order to support both operating with borrowed `Ipfs` value

--- a/src/unixfs/cat.rs
+++ b/src/unixfs/cat.rs
@@ -3,9 +3,9 @@ use async_stream::stream;
 use cid::Cid;
 use futures::stream::Stream;
 use ipfs_unixfs::file::{visit::IdleFileVisit, FileReadFailed};
-use std::borrow::Borrow;
-use std::fmt;
-use std::ops::Range;
+use core::borrow::Borrow;
+use core::fmt;
+use core::ops::Range;
 
 /// IPFS cat operation, producing a stream of file bytes. This is generic over the different kinds
 /// of ways to own an `Ipfs` value in order to support both operating with borrowed `Ipfs` value

--- a/unixfs/src/dagpb.rs
+++ b/unixfs/src/dagpb.rs
@@ -2,7 +2,7 @@
 ///! follows from the inseparability of dag-pb and UnixFS.
 use crate::pb::PBNode;
 use std::borrow::Cow;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// Extracts the PBNode::Data field from the block as it appears on the block.
 pub fn node_data(block: &[u8]) -> Result<Option<&[u8]>, quick_protobuf::Error> {

--- a/unixfs/src/dagpb.rs
+++ b/unixfs/src/dagpb.rs
@@ -1,7 +1,7 @@
 ///! dag-pb support operations. Placing this module inside unixfs module is a bit unfortunate but
 ///! follows from the inseparability of dag-pb and UnixFS.
 use crate::pb::PBNode;
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 use core::convert::TryFrom;
 
 /// Extracts the PBNode::Data field from the block as it appears on the block.

--- a/unixfs/src/dir.rs
+++ b/unixfs/src/dir.rs
@@ -1,8 +1,8 @@
 use crate::pb::{FlatUnixFs, PBLink, PBNode, ParsingFailed, UnixFsType};
 use crate::{InvalidCidInLink, UnexpectedNodeType};
 use cid::Cid;
-use std::convert::TryFrom;
-use std::fmt;
+use core::convert::TryFrom;
+use core::fmt;
 
 mod sharded_lookup;
 pub use sharded_lookup::{Cache, LookupError, ShardError, ShardedLookup};
@@ -217,7 +217,7 @@ mod tests {
     use crate::test_support::FakeBlockstore;
     use cid::Cid;
     use hex_literal::hex;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn resolve_paths_from_plain_dagpb() {

--- a/unixfs/src/dir.rs
+++ b/unixfs/src/dir.rs
@@ -216,8 +216,8 @@ mod tests {
     use super::{resolve, MaybeResolved};
     use crate::test_support::FakeBlockstore;
     use cid::Cid;
-    use hex_literal::hex;
     use core::convert::TryFrom;
+    use hex_literal::hex;
 
     #[test]
     fn resolve_paths_from_plain_dagpb() {

--- a/unixfs/src/dir/builder.rs
+++ b/unixfs/src/dir/builder.rs
@@ -1,5 +1,5 @@
 use cid::Cid;
-use std::fmt;
+use core::fmt;
 
 mod dir_builder;
 use dir_builder::DirBuilder;

--- a/unixfs/src/dir/builder/buffered.rs
+++ b/unixfs/src/dir/builder/buffered.rs
@@ -189,7 +189,7 @@ mod tests {
         super::OwnedTreeNode, BufferingTreeBuilder, Metadata, TreeBuildingFailed, TreeOptions,
     };
     use cid::Cid;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn some_directories() {
@@ -398,12 +398,12 @@ mod tests {
 
     fn verify_results(
         mut expected: Vec<(
-            impl AsRef<str> + std::fmt::Debug,
-            impl AsRef<str> + std::fmt::Debug,
+            impl AsRef<str> + core::fmt::Debug,
+            impl AsRef<str> + core::fmt::Debug,
         )>,
         mut actual: Vec<(String, Cid, Box<[u8]>)>,
     ) {
-        use std::fmt;
+        use core::fmt;
 
         struct Hex<'a>(&'a [u8]);
 

--- a/unixfs/src/dir/builder/buffered.rs
+++ b/unixfs/src/dir/builder/buffered.rs
@@ -1,7 +1,7 @@
 use super::{DirBuilder, Entry, Leaf, PostOrderIterator, TreeBuildingFailed, TreeOptions};
 use crate::Metadata;
-use cid::Cid;
 use alloc::collections::btree_map::Entry::*;
+use cid::Cid;
 
 /// UnixFs directory tree builder which buffers entries until `build()` is called.
 #[derive(Debug)]

--- a/unixfs/src/dir/builder/buffered.rs
+++ b/unixfs/src/dir/builder/buffered.rs
@@ -1,7 +1,7 @@
 use super::{DirBuilder, Entry, Leaf, PostOrderIterator, TreeBuildingFailed, TreeOptions};
 use crate::Metadata;
 use cid::Cid;
-use std::collections::btree_map::Entry::*;
+use alloc::collections::btree_map::Entry::*;
 
 /// UnixFs directory tree builder which buffers entries until `build()` is called.
 #[derive(Debug)]

--- a/unixfs/src/dir/builder/dir_builder.rs
+++ b/unixfs/src/dir/builder/dir_builder.rs
@@ -1,7 +1,7 @@
 use super::{Entry, Leaf};
 use crate::Metadata;
-use std::collections::btree_map::Entry::*;
-use std::collections::BTreeMap;
+use alloc::collections::btree_map::Entry::*;
+use alloc::collections::BTreeMap;
 
 pub(super) struct DuplicateName;
 pub(super) struct FoundLeaf;

--- a/unixfs/src/dir/builder/iter.rs
+++ b/unixfs/src/dir/builder/iter.rs
@@ -3,7 +3,7 @@ use super::{
 };
 use cid::Cid;
 use std::collections::HashMap;
-use std::fmt;
+use core::fmt;
 
 /// Constructs the directory nodes required for a tree.
 ///
@@ -132,7 +132,7 @@ impl PostOrderIterator {
                 needed_zeroes -= zeroes.len();
             }
 
-            buffer.extend(std::iter::repeat(0).take(needed_zeroes));
+            buffer.extend(core::iter::repeat(0).take(needed_zeroes));
         }
 
         let mut writer = Writer::new(BytesWriter::new(&mut buffer[..]));

--- a/unixfs/src/dir/builder/iter.rs
+++ b/unixfs/src/dir/builder/iter.rs
@@ -2,8 +2,8 @@ use super::{
     CustomFlatUnixFs, DirBuilder, Entry, Leaf, NamedLeaf, TreeConstructionFailed, TreeOptions,
 };
 use cid::Cid;
-use std::collections::HashMap;
 use core::fmt;
+use std::collections::HashMap;
 
 /// Constructs the directory nodes required for a tree.
 ///

--- a/unixfs/src/dir/directory.rs
+++ b/unixfs/src/dir/directory.rs
@@ -1,5 +1,5 @@
 use crate::pb::FlatUnixFs;
-use std::fmt;
+use core::fmt;
 
 /// Ensures the directory looks like something we actually support.
 pub(crate) fn check_directory_supported(

--- a/unixfs/src/dir/sharded_lookup.rs
+++ b/unixfs/src/dir/sharded_lookup.rs
@@ -1,9 +1,9 @@
 use super::{try_convert_cid, MaybeResolved, MultipleMatchingLinks, ResolveError};
 use crate::pb::{FlatUnixFs, PBLink, ParsingFailed, UnixFsType};
 use crate::{InvalidCidInLink, UnexpectedNodeType};
-use cid::Cid;
 use alloc::borrow::Cow;
 use alloc::collections::VecDeque;
+use cid::Cid;
 use core::convert::TryFrom;
 use core::fmt;
 
@@ -337,8 +337,8 @@ impl std::error::Error for LookupError {
 mod tests {
     use super::{LookupError, MaybeResolved, ShardError, ShardedLookup};
     use crate::pb::FlatUnixFs;
-    use hex_literal::hex;
     use core::convert::TryFrom;
+    use hex_literal::hex;
 
     // a directory from some linux kernel tree import: linux-5.5-rc5/tools/testing/selftests/rcutorture/
     const DIR: &[u8] = &hex!("122e0a2212204baf5104fe53d495223f8e2ba95375a31fda6b18e926cb54edd61f30b5f1de6512053641646f6318b535122c0a221220fd9f545068048e647d5d0b275ed171596e0c1c04b8fed09dc13bee7607e75bc7120242391883c00312330a2212208a4a68f6b88594ce373419586c12d24bde2d519ab636b1d2dcc986eb6265b7a3120a43444d616b6566696c65189601122f0a2212201ededc99d23a7ef43a8f17e6dd8b89934993245ef39e18936a37e412e536ed681205463562696e18c5ad030a280805121f200000000020000200000000000000000004000000000000000000000000002822308002");

--- a/unixfs/src/dir/sharded_lookup.rs
+++ b/unixfs/src/dir/sharded_lookup.rs
@@ -2,8 +2,8 @@ use super::{try_convert_cid, MaybeResolved, MultipleMatchingLinks, ResolveError}
 use crate::pb::{FlatUnixFs, PBLink, ParsingFailed, UnixFsType};
 use crate::{InvalidCidInLink, UnexpectedNodeType};
 use cid::Cid;
-use std::borrow::Cow;
-use std::collections::VecDeque;
+use alloc::borrow::Cow;
+use alloc::collections::VecDeque;
 use core::convert::TryFrom;
 use core::fmt;
 
@@ -397,7 +397,7 @@ mod tests {
     #[test]
     fn unsupported_hash_type_or_fanout() {
         use crate::pb::{FlatUnixFs, UnixFs, UnixFsType};
-        use std::borrow::Cow;
+        use alloc::borrow::Cow;
 
         let example = FlatUnixFs {
             data: UnixFs {
@@ -429,7 +429,7 @@ mod tests {
     #[test]
     fn unexpected_properties() {
         use crate::pb::{FlatUnixFs, UnixFs, UnixFsType};
-        use std::borrow::Cow;
+        use alloc::borrow::Cow;
 
         let example = FlatUnixFs {
             data: UnixFs {

--- a/unixfs/src/dir/sharded_lookup.rs
+++ b/unixfs/src/dir/sharded_lookup.rs
@@ -4,8 +4,8 @@ use crate::{InvalidCidInLink, UnexpectedNodeType};
 use cid::Cid;
 use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::convert::TryFrom;
-use std::fmt;
+use core::convert::TryFrom;
+use core::fmt;
 
 /// A cache of data structures used while traversing. Reduces allocations when walking over multiple
 /// path segments.
@@ -148,7 +148,7 @@ impl<'needle> ShardedLookup<'needle> {
         } else if hamt.data.filesize.is_some() || !hamt.data.blocksizes.is_empty() {
             Err(ShardError::UnexpectedProperties {
                 filesize: hamt.data.filesize,
-                blocksizes: std::mem::take(&mut hamt.data.blocksizes),
+                blocksizes: core::mem::take(&mut hamt.data.blocksizes),
             })
         } else {
             Ok(())
@@ -338,7 +338,7 @@ mod tests {
     use super::{LookupError, MaybeResolved, ShardError, ShardedLookup};
     use crate::pb::FlatUnixFs;
     use hex_literal::hex;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     // a directory from some linux kernel tree import: linux-5.5-rc5/tools/testing/selftests/rcutorture/
     const DIR: &[u8] = &hex!("122e0a2212204baf5104fe53d495223f8e2ba95375a31fda6b18e926cb54edd61f30b5f1de6512053641646f6318b535122c0a221220fd9f545068048e647d5d0b275ed171596e0c1c04b8fed09dc13bee7607e75bc7120242391883c00312330a2212208a4a68f6b88594ce373419586c12d24bde2d519ab636b1d2dcc986eb6265b7a3120a43444d616b6566696c65189601122f0a2212201ededc99d23a7ef43a8f17e6dd8b89934993245ef39e18936a37e412e536ed681205463562696e18c5ad030a280805121f200000000020000200000000000000000004000000000000000000000000002822308002");

--- a/unixfs/src/file.rs
+++ b/unixfs/src/file.rs
@@ -4,7 +4,7 @@
 ///! [`ipfs_unixfs::walk::Walker`] should typically be used for accessing file content.
 use crate::pb::ParsingFailed;
 use crate::{InvalidCidInLink, Metadata, UnexpectedNodeType};
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 use core::fmt;
 
 /// Low level UnixFS file descriptor reader support.

--- a/unixfs/src/file.rs
+++ b/unixfs/src/file.rs
@@ -5,7 +5,7 @@
 use crate::pb::ParsingFailed;
 use crate::{InvalidCidInLink, Metadata, UnexpectedNodeType};
 use std::borrow::Cow;
-use std::fmt;
+use core::fmt;
 
 /// Low level UnixFS file descriptor reader support.
 mod reader;

--- a/unixfs/src/file/adder.rs
+++ b/unixfs/src/file/adder.rs
@@ -2,7 +2,7 @@ use cid::Cid;
 
 use crate::pb::{FlatUnixFs, PBLink, UnixFs, UnixFsType};
 use quick_protobuf::{MessageWrite, Writer};
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 use core::fmt;
 
 use sha2::{Digest, Sha256};

--- a/unixfs/src/file/adder.rs
+++ b/unixfs/src/file/adder.rs
@@ -1,9 +1,9 @@
 use cid::Cid;
 
 use crate::pb::{FlatUnixFs, PBLink, UnixFs, UnixFsType};
-use quick_protobuf::{MessageWrite, Writer};
 use alloc::borrow::Cow;
 use core::fmt;
+use quick_protobuf::{MessageWrite, Writer};
 
 use sha2::{Digest, Sha256};
 
@@ -646,8 +646,8 @@ mod tests {
     use super::{BalancedCollector, Chunker, FileAdder};
     use crate::test_support::FakeBlockstore;
     use cid::Cid;
-    use hex_literal::hex;
     use core::convert::TryFrom;
+    use hex_literal::hex;
 
     #[test]
     fn test_size_chunker() {

--- a/unixfs/src/file/adder.rs
+++ b/unixfs/src/file/adder.rs
@@ -3,11 +3,11 @@ use cid::Cid;
 use crate::pb::{FlatUnixFs, PBLink, UnixFs, UnixFsType};
 use quick_protobuf::{MessageWrite, Writer};
 use std::borrow::Cow;
-use std::fmt;
+use core::fmt;
 
 use sha2::{Digest, Sha256};
 
-/// File tree builder. Implements [`std::default::Default`] which tracks the recent defaults.
+/// File tree builder. Implements [`core::default::Default`] which tracks the recent defaults.
 ///
 /// Custom file tree builder can be created with [`FileAdder::builder()`] and configuring the
 /// chunker and collector.
@@ -327,7 +327,7 @@ pub enum Chunker {
     Size(usize),
 }
 
-impl std::default::Default for Chunker {
+impl core::default::Default for Chunker {
     /// Returns a default chunker which matches go-ipfs 0.6
     fn default() -> Self {
         Chunker::Size(256 * 1024)
@@ -367,7 +367,7 @@ pub enum Collector {
     Balanced(BalancedCollector),
 }
 
-impl std::default::Default for Collector {
+impl core::default::Default for Collector {
     fn default() -> Self {
         Collector::Balanced(Default::default())
     }
@@ -404,7 +404,7 @@ impl fmt::Debug for BalancedCollector {
     }
 }
 
-impl std::default::Default for BalancedCollector {
+impl core::default::Default for BalancedCollector {
     /// Returns a default collector which matches go-ipfs 0.6
     ///
     /// The origin for 174 is not described in the the [specs], but has likely to do something
@@ -487,8 +487,8 @@ impl BalancedCollector {
 
         let mut ret = Vec::new();
 
-        let mut reused_links = std::mem::take(&mut self.reused_links);
-        let mut reused_blocksizes = std::mem::take(&mut self.reused_blocksizes);
+        let mut reused_links = core::mem::take(&mut self.reused_links);
+        let mut reused_blocksizes = core::mem::take(&mut self.reused_blocksizes);
 
         if let Some(need) = self.branching_factor.checked_sub(reused_links.capacity()) {
             reused_links.reserve(need);
@@ -647,7 +647,7 @@ mod tests {
     use crate::test_support::FakeBlockstore;
     use cid::Cid;
     use hex_literal::hex;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn test_size_chunker() {

--- a/unixfs/src/file/reader.rs
+++ b/unixfs/src/file/reader.rs
@@ -1,7 +1,7 @@
 use crate::pb::{FlatUnixFs, PBLink, RangeLinks, UnixFsType};
-use std::convert::TryFrom;
-use std::fmt;
-use std::ops::Range;
+use core::convert::TryFrom;
+use core::fmt;
+use core::ops::Range;
 
 use crate::file::{FileError, FileReadFailed, Metadata, UnwrapBorrowedExt};
 

--- a/unixfs/src/file/visit.rs
+++ b/unixfs/src/file/visit.rs
@@ -1,6 +1,6 @@
 use cid::Cid;
-use std::convert::TryFrom;
-use std::ops::Range;
+use core::convert::TryFrom;
+use core::ops::Range;
 
 use crate::file::reader::{FileContent, FileReader, Traversal};
 use crate::file::{FileReadFailed, Metadata};
@@ -225,7 +225,7 @@ fn to_pending(
 /// Returns true if the blocks byte offsets are interesting for our target range, false otherwise.
 /// If there is no target, all blocks are of interest.
 fn block_is_in_target_range(block: &Range<u64>, target: Option<&Range<u64>>) -> bool {
-    use std::cmp::{max, min};
+    use core::cmp::{max, min};
 
     if let Some(target) = target {
         max(block.start, target.start) <= min(block.end, target.end)
@@ -249,7 +249,7 @@ fn maybe_target_slice<'a>(
 }
 
 fn target_slice<'a>(content: &'a [u8], block: &Range<u64>, target: &Range<u64>) -> &'a [u8] {
-    use std::cmp::min;
+    use core::cmp::min;
 
     if !block_is_in_target_range(block, Some(target)) {
         // defaulting to empty slice is good, and similar to the "cat" HTTP API operation.
@@ -284,7 +284,7 @@ mod tests {
     #[test]
     #[allow(clippy::type_complexity)]
     fn slice_for_target() {
-        use std::ops::Range;
+        use core::ops::Range;
 
         // turns out these examples are not easy to determine at all
         // writing out the type here avoids &b""[..] inside the array.

--- a/unixfs/src/lib.rs
+++ b/unixfs/src/lib.rs
@@ -8,7 +8,9 @@
 //! `ipfs_unixfs::walk::Walker`. To resolve `IpfsPath` segments over dag-pb nodes,
 //! `ipfs_unixfs::resolve` should be used.
 
-use std::borrow::Cow;
+extern crate alloc;
+
+use alloc::borrow::Cow;
 use core::fmt;
 
 /// File support.

--- a/unixfs/src/lib.rs
+++ b/unixfs/src/lib.rs
@@ -9,7 +9,7 @@
 //! `ipfs_unixfs::resolve` should be used.
 
 use std::borrow::Cow;
-use std::fmt;
+use core::fmt;
 
 /// File support.
 pub mod file;
@@ -148,7 +148,7 @@ impl Metadata {
 
     /// Returns the raw timestamp of last modification time, if specified.
     ///
-    /// The timestamp is `(seconds, nanos)` - similar to `std::time::Duration`, with the exception of
+    /// The timestamp is `(seconds, nanos)` - similar to `core::time::Duration`, with the exception of
     /// allowing seconds to be negative. The seconds are calculated from `1970-01-01 00:00:00` or
     /// the common "unix epoch".
     pub fn mtime(&self) -> Option<(i64, u32)> {

--- a/unixfs/src/pb.rs
+++ b/unixfs/src/pb.rs
@@ -1,8 +1,8 @@
 use quick_protobuf::{errors::Result as ProtobufResult, Writer, WriterBackend};
 use std::borrow::Cow;
-use std::convert::TryFrom;
-use std::fmt;
-use std::ops::Range;
+use core::convert::TryFrom;
+use core::fmt;
+use core::ops::Range;
 
 pub(crate) mod merkledag;
 pub(crate) use merkledag::PBLink;
@@ -198,11 +198,10 @@ where
 
 #[cfg(test)]
 mod test {
-
     use super::{FlatUnixFs, PBNode, UnixFs, UnixFsType};
     use hex_literal::hex;
     use std::borrow::Cow;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn parse_content() {

--- a/unixfs/src/pb.rs
+++ b/unixfs/src/pb.rs
@@ -1,5 +1,5 @@
 use quick_protobuf::{errors::Result as ProtobufResult, Writer, WriterBackend};
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 use core::convert::TryFrom;
 use core::fmt;
 use core::ops::Range;
@@ -200,7 +200,7 @@ where
 mod test {
     use super::{FlatUnixFs, PBNode, UnixFs, UnixFsType};
     use hex_literal::hex;
-    use std::borrow::Cow;
+    use alloc::borrow::Cow;
     use core::convert::TryFrom;
 
     #[test]

--- a/unixfs/src/pb.rs
+++ b/unixfs/src/pb.rs
@@ -1,8 +1,8 @@
-use quick_protobuf::{errors::Result as ProtobufResult, Writer, WriterBackend};
 use alloc::borrow::Cow;
 use core::convert::TryFrom;
 use core::fmt;
 use core::ops::Range;
+use quick_protobuf::{errors::Result as ProtobufResult, Writer, WriterBackend};
 
 pub(crate) mod merkledag;
 pub(crate) use merkledag::PBLink;
@@ -199,9 +199,9 @@ where
 #[cfg(test)]
 mod test {
     use super::{FlatUnixFs, PBNode, UnixFs, UnixFsType};
-    use hex_literal::hex;
     use alloc::borrow::Cow;
     use core::convert::TryFrom;
+    use hex_literal::hex;
 
     #[test]
     fn parse_content() {

--- a/unixfs/src/pb/merkledag.rs
+++ b/unixfs/src/pb/merkledag.rs
@@ -9,7 +9,7 @@
 use super::*;
 use quick_protobuf::sizeofs::*;
 use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Result, Writer, WriterBackend};
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 use core::convert::TryFrom;
 use std::io::Write;
 use core::ops::Deref;

--- a/unixfs/src/pb/merkledag.rs
+++ b/unixfs/src/pb/merkledag.rs
@@ -10,10 +10,11 @@ use super::*;
 use quick_protobuf::sizeofs::*;
 use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Result, Writer, WriterBackend};
 use std::borrow::Cow;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 use std::io::Write;
-use std::ops::Deref;
-use std::ops::DerefMut;
+use core::ops::Deref;
+use core::ops::DerefMut;
+
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct PBLink<'a> {
     pub Hash: Option<Cow<'a, [u8]>>,

--- a/unixfs/src/pb/unixfs.rs
+++ b/unixfs/src/pb/unixfs.rs
@@ -10,7 +10,7 @@
 use super::*;
 use quick_protobuf::sizeofs::*;
 use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Result, Writer, WriterBackend};
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 use core::convert::TryFrom;
 use std::io::Write;
 use core::ops::Deref;

--- a/unixfs/src/pb/unixfs.rs
+++ b/unixfs/src/pb/unixfs.rs
@@ -6,14 +6,16 @@
 #![allow(unknown_lints)]
 #![allow(clippy::all)]
 #![cfg_attr(rustfmt, rustfmt_skip)]
+
 use super::*;
 use quick_protobuf::sizeofs::*;
 use quick_protobuf::{BytesReader, MessageRead, MessageWrite, Result, Writer, WriterBackend};
 use std::borrow::Cow;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 use std::io::Write;
-use std::ops::Deref;
-use std::ops::DerefMut;
+use core::ops::Deref;
+use core::ops::DerefMut;
+
 #[derive(Debug, Default, PartialEq, Clone)]
 pub struct Data<'a> {
     pub Type: mod_Data::DataType,

--- a/unixfs/src/symlink.rs
+++ b/unixfs/src/symlink.rs
@@ -5,7 +5,7 @@
 
 use crate::pb::{FlatUnixFs, UnixFs, UnixFsType};
 use quick_protobuf::{MessageWrite, Writer};
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 /// Appends a dag-pb block for for a symlink to the given target_path. It is expected that the
 /// `target_path` is valid relative unix path relative to the place in which this is used but

--- a/unixfs/src/symlink.rs
+++ b/unixfs/src/symlink.rs
@@ -34,7 +34,7 @@ mod tests {
     use super::serialize_symlink_block;
     use cid::Cid;
     use sha2::{Digest, Sha256};
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     #[test]
     fn simple_symlink() {
@@ -172,7 +172,7 @@ mod tests {
                 ContinuedWalk::Symlink(link_name, _cid, path, _metadata) => {
                     actual.push(Entry::Symlink(
                         path.into(),
-                        std::str::from_utf8(link_name).unwrap().to_owned(),
+                        core::str::from_utf8(link_name).unwrap().to_owned(),
                     ));
                 }
             };

--- a/unixfs/src/symlink.rs
+++ b/unixfs/src/symlink.rs
@@ -4,8 +4,8 @@
 //! this is wrong.
 
 use crate::pb::{FlatUnixFs, UnixFs, UnixFsType};
-use quick_protobuf::{MessageWrite, Writer};
 use alloc::borrow::Cow;
+use quick_protobuf::{MessageWrite, Writer};
 
 /// Appends a dag-pb block for for a symlink to the given target_path. It is expected that the
 /// `target_path` is valid relative unix path relative to the place in which this is used but
@@ -33,8 +33,8 @@ pub fn serialize_symlink_block(target_path: &str, block_buffer: &mut Vec<u8>) {
 mod tests {
     use super::serialize_symlink_block;
     use cid::Cid;
-    use sha2::{Digest, Sha256};
     use core::convert::TryFrom;
+    use sha2::{Digest, Sha256};
 
     #[test]
     fn simple_symlink() {

--- a/unixfs/src/test_support.rs
+++ b/unixfs/src/test_support.rs
@@ -1,7 +1,7 @@
 use cid::Cid;
 use hex_literal::hex;
 use std::collections::HashMap;
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 #[derive(Default)]
 pub struct FakeBlockstore {

--- a/unixfs/src/test_support.rs
+++ b/unixfs/src/test_support.rs
@@ -1,7 +1,7 @@
 use cid::Cid;
+use core::convert::TryFrom;
 use hex_literal::hex;
 use std::collections::HashMap;
-use core::convert::TryFrom;
 
 #[derive(Default)]
 pub struct FakeBlockstore {

--- a/unixfs/src/walk.rs
+++ b/unixfs/src/walk.rs
@@ -3,11 +3,11 @@ use crate::file::visit::{Cache, FileVisit, IdleFileVisit};
 use crate::file::{FileError, FileReadFailed};
 use crate::pb::{FlatUnixFs, PBLink, ParsingFailed, UnixFsType};
 use crate::{InvalidCidInLink, Metadata, UnexpectedNodeType};
-use cid::Cid;
-use either::Either;
 use alloc::borrow::Cow;
+use cid::Cid;
 use core::convert::TryFrom;
 use core::fmt;
+use either::Either;
 use std::path::{Path, PathBuf};
 
 /// `Walker` helps with walking a UnixFS tree, including all of the content and files. It is

--- a/unixfs/src/walk.rs
+++ b/unixfs/src/walk.rs
@@ -6,8 +6,8 @@ use crate::{InvalidCidInLink, Metadata, UnexpectedNodeType};
 use cid::Cid;
 use either::Either;
 use std::borrow::Cow;
-use std::convert::TryFrom;
-use std::fmt;
+use core::convert::TryFrom;
+use core::fmt;
 use std::path::{Path, PathBuf};
 
 /// `Walker` helps with walking a UnixFS tree, including all of the content and files. It is
@@ -772,7 +772,7 @@ mod tests {
     }
 
     fn sharded_dir_scenario(root_name: &str) {
-        use std::fmt::Write;
+        use core::fmt::Write;
 
         // the hamt sharded directory is such that the root only has buckets so all of the actual files
         // are at second level buckets, each bucket should have 2 files. the actual files, in fact, constitute a single empty

--- a/unixfs/src/walk.rs
+++ b/unixfs/src/walk.rs
@@ -5,7 +5,7 @@ use crate::pb::{FlatUnixFs, PBLink, ParsingFailed, UnixFsType};
 use crate::{InvalidCidInLink, Metadata, UnexpectedNodeType};
 use cid::Cid;
 use either::Either;
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 use core::convert::TryFrom;
 use core::fmt;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
First step towards no_std compatibility for unixfs