### PR TITLE
Remove top-level command item from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,5 @@
 - [ ] There are functional and/or unit tests written, and they are passing
 - [ ] There is suitable documentation. In our case, this means:
     - [ ] Each command has a usage example and API specification
-    - [ ] Top-level commands with subcommands display usage instructions
     - [ ] Rustdoc tests are passing on all code-level comments
     - [ ] Differences between Rust’s IPFS implementation and the Go or JS implementations are explained


### PR DESCRIPTION
This PR removes the "top-level command" requirement from the PR template. We don't have a CLI yet and we can add it back in when we do.