### PR TITLE
refactor: move refs as Ipfs::refs and ipfs::refs::iplds_refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,12 +1040,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
-
-[[package]]
 name = "hex-literal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1204,7 +1198,6 @@ dependencies = [
  "bytes",
  "cid",
  "futures",
- "hex",
  "hex-literal",
  "humantime",
  "hyper",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -39,6 +39,5 @@ url = { default-features = false, version = "2.1" }
 warp = { default-features = false, version = "0.2" }
 
 [dev-dependencies]
-hex = { default-features = false, version = "0.4" }
 hex-literal = { default-features = false, version = "0.3" }
 tempfile = { default-features = false, version = "3.1" }

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -53,10 +53,6 @@ async fn refs_inner<T: IpfsTypes>(
         .maybe_timeout(opts.timeout)
         .await
         .map_err(StringError::from)?
-        .map_err(|e| {
-            warn!("refs path on {:?} failed with {}", &opts.arg, e);
-            e
-        })
         .map_err(StringError::from)?;
 
     // FIXME: there should be a total timeout arching over path walking to the stream completion.
@@ -78,7 +74,7 @@ async fn refs_inner<T: IpfsTypes>(
             }
             Err(e) => serde_json::to_string(&Edge {
                 ok: "".into(),
-                err: e.into(),
+                err: e.to_string().into(),
             }),
         };
 
@@ -126,7 +122,7 @@ async fn refs_paths<T: IpfsTypes>(
     max_depth: Option<u64>,
     unique: bool,
 ) -> Result<
-    impl Stream<Item = Result<(Cid, Cid, Option<String>), String>> + Send + 'static,
+    impl Stream<Item = Result<(Cid, Cid, Option<String>), ipfs::ipld::BlockError>> + Send + 'static,
     ResolveError,
 > {
     use ipfs::dag::ResolvedNode;

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -391,45 +391,45 @@ mod tests {
     }
 
     async fn preloaded_testing_ipfs() -> Node {
+        use hex_literal::hex;
         let ipfs = Node::new("test_node").await;
 
         let blocks = [
             (
                 // echo -n '{ "foo": { "/": "bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily" }, "bar": { "/": "QmPJ4A6Su27ABvvduX78x2qdWMzkdAYxqeH5TVrHeo3xyy" } }' | /ipfs dag put
                 "bafyreidquig3arts3bmee53rutt463hdyu6ff4zeas2etf2h2oh4dfms44",
-                "a263626172d82a58230012200e317512b6f9f86e015a154cb97a9ddcdc7e372cccceb3947921634953c6537463666f6fd82a58250001711220354d455ff3a641b8cac25c38a77e64aa735dc8a48966a60f1a78caa172a4885e"
+                &hex!("a263626172d82a58230012200e317512b6f9f86e015a154cb97a9ddcdc7e372cccceb3947921634953c6537463666f6fd82a58250001711220354d455ff3a641b8cac25c38a77e64aa735dc8a48966a60f1a78caa172a4885e")[..]
             ),
             (
                 // echo barfoo > file2 && ipfs add file2
                 "QmPJ4A6Su27ABvvduX78x2qdWMzkdAYxqeH5TVrHeo3xyy",
-                "0a0d08021207626172666f6f0a1807"
+                &hex!("0a0d08021207626172666f6f0a1807")[..]
             ),
             (
                 // echo -n '{ "foo": { "/": "QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL" } }' | ipfs dag put
                 "bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily",
-                "a163666f6fd82a582300122031c3d57080d8463a3c63b2923df5a1d40ad7a73eae5a14af584213e5f504ac33"),
+                &hex!("a163666f6fd82a582300122031c3d57080d8463a3c63b2923df5a1d40ad7a73eae5a14af584213e5f504ac33")[..]
+            ),
             (
                 // echo foobar > file1 && ipfs add file1
                 "QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL",
-                "0a0d08021207666f6f6261720a1807"
+                &hex!("0a0d08021207666f6f6261720a1807")[..]
             ),
             (
                 // echo -e '[{"/":"bafyreidquig3arts3bmee53rutt463hdyu6ff4zeas2etf2h2oh4dfms44"},{"/":"QmPJ4A6Su27ABvvduX78x2qdWMzkdAYxqeH5TVrHeo3xyy"},{"/":"bafyreibvjvcv745gig4mvqs4hctx4zfkono4rjejm2ta6gtyzkqxfjeily"},{"/":"QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL"}]' | ./ipfs dag put
                 "bafyreihpc3vupfos5yqnlakgpjxtyx3smkg26ft7e2jnqf3qkyhromhb64",
-                "84d82a5825000171122070a20db04672d858427771a4e7cf6ce3c53c52f32404b4499747d38fc19592e7d82a58230012200e317512b6f9f86e015a154cb97a9ddcdc7e372cccceb3947921634953c65374d82a58250001711220354d455ff3a641b8cac25c38a77e64aa735dc8a48966a60f1a78caa172a4885ed82a582300122031c3d57080d8463a3c63b2923df5a1d40ad7a73eae5a14af584213e5f504ac33"
+                &hex!("84d82a5825000171122070a20db04672d858427771a4e7cf6ce3c53c52f32404b4499747d38fc19592e7d82a58230012200e317512b6f9f86e015a154cb97a9ddcdc7e372cccceb3947921634953c65374d82a58250001711220354d455ff3a641b8cac25c38a77e64aa735dc8a48966a60f1a78caa172a4885ed82a582300122031c3d57080d8463a3c63b2923df5a1d40ad7a73eae5a14af584213e5f504ac33")[..]
             )
         ];
 
-        for (cid_str, hex_str) in blocks.iter() {
+        for (cid_str, data) in blocks.iter() {
             let cid = Cid::try_from(*cid_str).unwrap();
-            let data = hex::decode(hex_str).unwrap();
-
             validate(&cid, &data).unwrap();
             decode_ipld(&cid, &data).unwrap();
 
             let block = Block {
                 cid,
-                data: data.into(),
+                data: (*data).into(),
             };
 
             ipfs.put_block(block).await.unwrap();

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -437,30 +437,4 @@ mod tests {
 
         ipfs
     }
-
-    /*
-    #[test]
-    fn dagpb_links() {
-        // this is the same as in v0::refs::path::tests::walk_dagpb_links
-        let payload = hex::decode(
-            "12330a2212206aad27d7e2fc815cd15bf679535062565dc927a831547281\
-            fc0af9e5d7e67c74120b6166726963616e2e747874180812340a221220fd\
-            36ac5279964db0cba8f7fa45f8c4c44ef5e2ff55da85936a378c96c9c632\
-            04120c616d6572696361732e747874180812360a2212207564c20415869d\
-            77a8a40ca68a9158e397dd48bdff1325cdb23c5bcd181acd17120e617573\
-            7472616c69616e2e7478741808",
-        )
-        .unwrap();
-
-        let cid = Cid::try_from("QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa").unwrap();
-
-        let decoded = decode_ipld(&cid, &payload).unwrap();
-
-        let links = ipld_links(&cid, decoded)
-            .map(|(name, _)| name.unwrap())
-            .collect::<Vec<_>>();
-
-        assert_eq!(links, ["african.txt", "americas.txt", "australian.txt",]);
-    }
-    */
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,6 +840,10 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         }
     }
 
+    /// Walk the given Iplds for links up until `max_depth` (or infinite, when `None`). Will return
+    /// any duplicate trees unless `unique` is `true`.
+    ///
+    /// More information and `'static` lifetime version available at [`refs::iplds_refs`].
     pub fn refs<'a, Iter>(
         &'a self,
         iplds: Iter,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -849,7 +849,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         iplds: Iter,
         max_depth: Option<u64>,
         unique: bool,
-    ) -> impl Stream<Item = Result<(Cid, Cid, Option<String>), ipld::BlockError>> + Send + 'a
+    ) -> impl Stream<Item = Result<refs::Edge, ipld::BlockError>> + Send + 'a
     where
         Iter: IntoIterator<Item = (Cid, Ipld)> + 'a,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub mod ipld;
 pub mod ipns;
 pub mod p2p;
 pub mod path;
+pub mod refs;
 pub mod repo;
 mod subscription;
 pub mod unixfs;
@@ -837,6 +838,18 @@ impl<Types: IpfsTypes> Ipfs<Types> {
             Ok(_) => unreachable!(),
             Err(e) => Err(anyhow!(e)),
         }
+    }
+
+    pub fn refs<'a, Iter>(
+        &'a self,
+        iplds: Iter,
+        max_depth: Option<u64>,
+        unique: bool,
+    ) -> impl Stream<Item = Result<(Cid, Cid, Option<String>), String>> + Send + 'a
+    where
+        Iter: IntoIterator<Item = (Cid, Ipld)> + 'a,
+    {
+        refs::iplds_refs(self, iplds, max_depth, unique)
     }
 
     /// Exit daemon.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -845,7 +845,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         iplds: Iter,
         max_depth: Option<u64>,
         unique: bool,
-    ) -> impl Stream<Item = Result<(Cid, Cid, Option<String>), String>> + Send + 'a
+    ) -> impl Stream<Item = Result<(Cid, Cid, Option<String>), ipld::BlockError>> + Send + 'a
     where
         Iter: IntoIterator<Item = (Cid, Ipld)> + 'a,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,10 +840,10 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         }
     }
 
-    /// Walk the given Iplds for links up until `max_depth` (or infinite, when `None`). Will return
+    /// Walk the given Iplds' links up to `max_depth` (or indefinitely for `None`). Will return
     /// any duplicate trees unless `unique` is `true`.
     ///
-    /// More information and `'static` lifetime version available at [`refs::iplds_refs`].
+    /// More information and a `'static` lifetime version available at [`refs::iplds_refs`].
     pub fn refs<'a, Iter>(
         &'a self,
         iplds: Iter,

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -29,7 +29,7 @@ pub fn iplds_refs<'a, Types, MaybeOwned, Iter>(
     iplds: Iter,
     max_depth: Option<u64>,
     unique: bool,
-) -> impl Stream<Item = Result<(Cid, Cid, Option<String>), String>> + Send + 'a
+) -> impl Stream<Item = Result<(Cid, Cid, Option<String>), crate::ipld::BlockError>> + Send + 'a
 where
     Types: IpfsTypes,
     MaybeOwned: Borrow<Ipfs<Types>> + Send + 'a,
@@ -90,7 +90,7 @@ where
                     warn!("failed to parse {}, linked from {}: {}", cid, source, e);
                     // go-ipfs on raw Qm hash:
                     // > failed to decode Protocol Buffers: incorrectly formatted merkledag node: unmarshal failed. proto: illegal wireType 6
-                    yield Err(e.to_string());
+                    yield Err(e);
                     continue;
                 }
             };

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -195,3 +195,35 @@ fn dagpb_links(ipld: Ipld) -> Vec<(Option<String>, Cid)> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ipld_links;
+    use crate::ipld::decode_ipld;
+    use cid::Cid;
+    use hex_literal::hex;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn dagpb_links() {
+        // this is the same as in ipfs-http::v0::refs::path::tests::walk_dagpb_links
+        let payload = hex!(
+            "12330a2212206aad27d7e2fc815cd15bf679535062565dc927a831547281
+            fc0af9e5d7e67c74120b6166726963616e2e747874180812340a221220fd
+            36ac5279964db0cba8f7fa45f8c4c44ef5e2ff55da85936a378c96c9c632
+            04120c616d6572696361732e747874180812360a2212207564c20415869d
+            77a8a40ca68a9158e397dd48bdff1325cdb23c5bcd181acd17120e617573
+            7472616c69616e2e7478741808"
+        );
+
+        let cid = Cid::try_from("QmbrFTo4s6H23W6wmoZKQC2vSogGeQ4dYiceSqJddzrKVa").unwrap();
+
+        let decoded = decode_ipld(&cid, &payload).unwrap();
+
+        let links = ipld_links(&cid, decoded)
+            .map(|(name, _)| name.unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(links, ["african.txt", "americas.txt", "australian.txt",]);
+    }
+}

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -1,0 +1,197 @@
+use crate::ipld::{decode_ipld, Ipld};
+use crate::{Block, Ipfs, IpfsTypes};
+use async_stream::stream;
+use cid::{self, Cid};
+use futures::stream::Stream;
+use std::borrow::Borrow;
+use std::collections::HashSet;
+use std::collections::VecDeque;
+
+/// Gather links as edges between two documents from all of the `iplds` which represent the
+/// document and it's original `Cid`, as the `Ipld` can be a subtree of the document.
+///
+/// **Stream** does not stop on **error**.
+///
+/// # Differences from other implementations
+///
+/// `js-ipfs` does seem to do a recursive descent on all links. Looking at the tests it would
+/// appear that `go-ipfs` implements this in similar fashion. This implementation is breadth-first
+/// to be simpler at least.
+///
+/// Related: https://github.com/ipfs/js-ipfs/pull/2982
+///
+/// # Lifetime of returned stream
+///
+/// Depending on how this function is called, the lifetime will be tied to the lifetime of given
+/// `&Ipfs` or `'static` when given ownership of `Ipfs`.
+pub fn iplds_refs<'a, Types, MaybeOwned, Iter>(
+    ipfs: MaybeOwned,
+    iplds: Iter,
+    max_depth: Option<u64>,
+    unique: bool,
+) -> impl Stream<Item = Result<(Cid, Cid, Option<String>), String>> + Send + 'a
+where
+    Types: IpfsTypes,
+    MaybeOwned: Borrow<Ipfs<Types>> + Send + 'a,
+    Iter: IntoIterator<Item = (Cid, Ipld)>,
+{
+    let mut work = VecDeque::new();
+    let mut queued_or_visited = HashSet::new();
+
+    // double check the max_depth before filling the work and queued_or_visited up just in case we
+    // are going to be returning an empty stream
+    if max_depth.map(|n| n > 0).unwrap_or(true) {
+        for (origin, ipld) in iplds {
+            for (link_name, next_cid) in ipld_links(&origin, ipld) {
+                if unique && !queued_or_visited.insert(next_cid.clone()) {
+                    trace!("skipping already queued {}", next_cid);
+                    continue;
+                }
+                work.push_back((0, next_cid, origin.clone(), link_name));
+            }
+        }
+    }
+
+    stream! {
+        if let Some(0) = max_depth {
+            return;
+        }
+
+        while let Some((depth, cid, source, link_name)) = work.pop_front() {
+            let traverse_links = match max_depth {
+                Some(d) if d <= depth => {
+                    // important to continue instead of stopping
+                    continue;
+                },
+                // no need to list links which would be filtered out
+                Some(d) if d + 1 == depth => false,
+                _ => true
+            };
+
+            // if this is not bound to a local variable it'll introduce a Sync requirement on
+            // `MaybeOwned` which we don't necessarily need.
+            let borrowed = ipfs.borrow();
+
+            let data = match borrowed.get_block(&cid).await {
+                Ok(Block { data, .. }) => data,
+                Err(e) => {
+                    warn!("failed to load {}, linked from {}: {}", cid, source, e);
+                    // TODO: yield error msg
+                    // unsure in which cases this happens, because we'll start to search the content
+                    // and stop only when request has been cancelled (FIXME: no way to stop this
+                    // operation)
+                    continue;
+                }
+            };
+
+            let ipld = match decode_ipld(&cid, &data) {
+                Ok(ipld) => ipld,
+                Err(e) => {
+                    warn!("failed to parse {}, linked from {}: {}", cid, source, e);
+                    // go-ipfs on raw Qm hash:
+                    // > failed to decode Protocol Buffers: incorrectly formatted merkledag node: unmarshal failed. proto: illegal wireType 6
+                    yield Err(e.to_string());
+                    continue;
+                }
+            };
+
+            if traverse_links {
+                for (link_name, next_cid) in ipld_links(&cid, ipld) {
+                    if unique && !queued_or_visited.insert(next_cid.clone()) {
+                        trace!("skipping already queued {}", next_cid);
+                        continue;
+                    }
+
+                    work.push_back((depth + 1, next_cid, cid.clone(), link_name));
+                }
+            }
+
+            yield Ok((source, cid, link_name));
+        }
+    }
+}
+
+fn ipld_links(
+    cid: &Cid,
+    ipld: Ipld,
+) -> impl Iterator<Item = (Option<String>, Cid)> + Send + 'static {
+    // a wrapping iterator without there being a libipld_base::IpldIntoIter might not be doable
+    // with safe code
+    let items = if cid.codec() == cid::Codec::DagProtobuf {
+        dagpb_links(ipld)
+    } else {
+        ipld.iter()
+            .filter_map(|val| match val {
+                Ipld::Link(cid) => Some(cid),
+                _ => None,
+            })
+            .cloned()
+            // only dag-pb ever has any link names, probably because in cbor the "name" on the LHS
+            // might have a different meaning from a "link name" in dag-pb ... Doesn't seem
+            // immediatedly obvious why this is done.
+            .map(|cid| (None, cid))
+            .collect::<Vec<(Option<String>, Cid)>>()
+    };
+
+    items.into_iter()
+}
+
+/// Special handling for the structure created while loading dag-pb as ipld.
+///
+/// # Panics
+///
+/// If the dag-pb ipld tree doesn't conform to expectations, as in, we are out of sync with the
+/// libipld crate. This is on purpose.
+fn dagpb_links(ipld: Ipld) -> Vec<(Option<String>, Cid)> {
+    let links = match ipld {
+        Ipld::Map(mut m) => m.remove("Links"),
+        // lets assume this means "no links"
+        _ => return Vec::new(),
+    };
+
+    let links = match links {
+        Some(Ipld::List(v)) => v,
+        x => panic!("Expected dag-pb2ipld \"Links\" to be a list, got: {:?}", x),
+    };
+
+    links
+        .into_iter()
+        .enumerate()
+        .filter_map(|(i, ipld)| {
+            match ipld {
+                Ipld::Map(mut m) => {
+                    let link = match m.remove("Hash") {
+                        Some(Ipld::Link(cid)) => cid,
+                        Some(x) => panic!(
+                            "Expected dag-pb2ipld \"Links[{}]/Hash\" to be a link, got: {:?}",
+                            i, x
+                        ),
+                        None => return None,
+                    };
+                    let name = match m.remove("Name") {
+                        // not sure of this, not covered by tests, though these are only
+                        // present for multi-block files so maybe it's better to panic
+                        Some(Ipld::String(s)) if s == "/" => {
+                            unimplemented!("Slashes as the name of link")
+                        }
+                        Some(Ipld::String(s)) => Some(s),
+                        Some(x) => panic!(
+                            "Expected dag-pb2ipld \"Links[{}]/Name\" to be a string, got: {:?}",
+                            i, x
+                        ),
+                        // not too sure of this, this could be the index as string as well?
+                        None => unimplemented!(
+                            "Default name for dag-pb2ipld links, should it be index?"
+                        ),
+                    };
+
+                    Some((name, link))
+                }
+                x => panic!(
+                    "Expected dag-pb2ipld \"Links[{}]\" to be a map, got: {:?}",
+                    i, x
+                ),
+            }
+        })
+        .collect()
+}

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -38,9 +38,13 @@ where
     let mut work = VecDeque::new();
     let mut queued_or_visited = HashSet::new();
 
+    let empty_stream = max_depth.map(|n| n == 0).unwrap_or(false);
+
     // double check the max_depth before filling the work and queued_or_visited up just in case we
     // are going to be returning an empty stream
-    if max_depth.map(|n| n > 0).unwrap_or(true) {
+    if !empty_stream {
+        // not building these before moving the work and hashset into the stream would impose
+        // apparently impossible bounds on `Iter`, in addition to `Send + 'a`.
         for (origin, ipld) in iplds {
             for (link_name, next_cid) in ipld_links(&origin, ipld) {
                 if unique && !queued_or_visited.insert(next_cid.clone()) {
@@ -53,7 +57,7 @@ where
     }
 
     stream! {
-        if let Some(0) = max_depth {
+        if empty_stream {
             return;
         }
 


### PR DESCRIPTION
This PR moves `refs` from `ipfs-http` to `ipfs`. Ended up moving only a `iplds_refs` which needs pre-resolved `IpfsPaths`. As for short term I think this should help towards #11.

I was originally planning to make this into a version which would accept both `IpfsPath` (or `CidPath`) and already projected `(Cid, Ipld)` but the duplication of code would be quite unavoidable, as the http side will have to "buffer" all IpfsPath resolution *before* calling a version of `iplds_refs` which would accept a `TryStream<Ok = (Cid, Ipld), Error = _>` instead of `IntoIterator<Item = (Cid, Ipld)>`. I did continue this solution and did try out prefetching options for unixfs_cat for example, but I'll leave them for next PRs since they will complicate the API quite a bit.

While moving the tests, I removed of the "duplicate" dependency on `hex` as `hex-literal` is a bit more straight forward.

### Checklist (can be deleted from PR description once items are checked)

- [x] **New** code is “linted” i.e. code formatting via rustfmt and language idioms via clippy
- [x] There are no extraneous changes like formatting, line reordering, etc. Keep the patch sizes small!
- [x] There are functional and/or unit tests written, and they are passing
- [x] There is suitable documentation. In our case, this means:
    - [x] Each command has a usage example and API specification
    - [x] Rustdoc tests are passing on all code-level comments
    - [x] Differences between Rust’s IPFS implementation and the Go or JS implementations are explained
