### PR TITLE
fix: make the ProvideBlock rx behavior match the sender in put_block

### DIFF
--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -203,6 +203,10 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
         self.subscriptions
             .finish_subscription(cid.clone().into(), Ok(block));
 
+        // FIXME: this doesn't cause actual DHT providing yet, only some
+        // bitswap housekeeping; RepoEvent::ProvideBlock should probably
+        // be renamed to ::NewBlock and we might want to not ignore the
+        // channel errors when we actually start providing on the DHT
         if let BlockPut::NewBlock = res {
             // sending only fails if no one is listening anymore
             // and that is okay with us.

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -214,7 +214,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
                 .await
                 .ok();
 
-            if let Ok(kad_subscription) = rx.await? {
+            if let Ok(Ok(kad_subscription)) = rx.await {
                 kad_subscription.await?;
             }
         }


### PR DESCRIPTION
This one was funny to debug: when calling `add` in our [ipfs-enabled substrate fork](https://github.com/rs-ipfs/substrate/tree/offchain_ipfs_bleeding_edge), I was sometimes getting a `oneshot canceled` eror, even though there was no usual `Ipfs` vs. `IpfsFuture` communication to issue the top-level call; a little bit of investigation suggests that this is caused by the fact the `offchain::ipfs` calls are restricted by a deadline and thus the temporary sender (for `RepoEvent::ProvideBlock`) can die during execution. Since we are pretty lax (and rightfully so, as it's not a crucial functionality) in terms of that event reaching its destination, we should do the same about receiving the related answer.