### PR TITLE
example: fetch_and_cat tuneup

### DIFF
--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -1,6 +1,6 @@
 use futures::pin_mut;
 use futures::stream::StreamExt; // needed for StreamExt::next
-use ipfs::{Ipfs, IpfsPath, TestTypes, UninitializedIpfs};
+use ipfs::{Ipfs, IpfsOptions, IpfsPath, MultiaddrWithPeerId, TestTypes, UninitializedIpfs};
 use std::env;
 use std::process::exit;
 use tokio::io::AsyncWriteExt;
@@ -48,8 +48,13 @@ async fn main() {
         .map(|s| s.parse::<MultiaddrWithPeerId>().unwrap());
 
     // Start daemon and initialize repo
-    let (ipfs, fut): (Ipfs<TestTypes>, _) =
-        UninitializedIpfs::default().await.start().await.unwrap();
+    let mut opts = IpfsOptions::inmemory_with_generated_keys();
+    opts.mdns = false;
+    let (ipfs, fut): (Ipfs<TestTypes>, _) = UninitializedIpfs::new(opts, None)
+        .await
+        .start()
+        .await
+        .unwrap();
     tokio::task::spawn(fut);
 
     if let Some(target) = target {

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -30,7 +30,7 @@ async fn main() {
                 stdout."
             );
             eprintln!("If second argument is present, it is expected to be a Multiaddr with \
-                peer_id. The given multiaddr will be connected to instead of waiting an incoming connection.");
+                peer_id. The given Multiaddr will be connected to instead of awaiting an incoming connection.");
             exit(0);
         }
     };


### PR DESCRIPTION
Minor changes to fetch_and_cat I found useful while testing the prefetching (and so the streaming ipfspath refs).

### Checklist (can be deleted from PR description once items are checked)

- [x] **New** code is “linted” i.e. code formatting via rustfmt and language idioms via clippy
- [x] There are no extraneous changes like formatting, line reordering, etc. Keep the patch sizes small!
- [x] There are functional and/or unit tests written, and they are passing
- [x] There is suitable documentation. In our case, this means:
    - [x] Each command has a usage example and API specification
    - [x] Rustdoc tests are passing on all code-level comments
    - [x] Differences between Rust’s IPFS implementation and the Go or JS implementations are explained
