### PR TITLE
Simplified node creation

### DIFF
--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -137,7 +137,6 @@ fn main() {
         let opts: IpfsOptions = IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None);
 
         let (ipfs, task): (Ipfs<ipfs::TestTypes>, _) = UninitializedIpfs::new(opts, None)
-            .await
             .start()
             .await
             .expect("Initialization failed");

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU16;
 use std::path::PathBuf;
 use structopt::StructOpt;
 
-use ipfs::{Ipfs, IpfsOptions, IpfsTypes, UninitializedIpfs};
+use ipfs::{Ipfs, IpfsOptions, IpfsTypes};
 use ipfs_http::{config, v0};
 
 #[derive(Debug, StructOpt)]
@@ -136,10 +136,9 @@ fn main() {
     rt.block_on(async move {
         let opts: IpfsOptions = IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None);
 
-        let (ipfs, task): (Ipfs<ipfs::TestTypes>, _) = UninitializedIpfs::new(opts, None)
-            .start()
-            .await
-            .expect("Initialization failed");
+        let mut ipfs: Ipfs<ipfs::TestTypes> = Ipfs::new(opts, None);
+
+        let task = ipfs.start().await.expect("Initialization failed");
 
         tokio::spawn(task);
 

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -134,9 +134,10 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
-        let opts: IpfsOptions = IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None);
+        let opts: IpfsOptions =
+            IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None, None);
 
-        let mut ipfs: Ipfs<ipfs::TestTypes> = Ipfs::new(opts, None);
+        let mut ipfs: Ipfs<ipfs::TestTypes> = Ipfs::new(opts);
 
         let task = ipfs.start().await.expect("Initialization failed");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,7 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
     /// The span is attached to all operations called on the later created `Ipfs` along with all
     /// operations done in the background task as well as tasks spawned by the underlying
     /// `libp2p::Swarm`.
-    pub async fn new(options: IpfsOptions, span: Option<Span>) -> Self {
+    pub fn new(options: IpfsOptions, span: Option<Span>) -> Self {
         let repo_options = RepoOptions::from(&options);
         let (repo, repo_events) = create_repo(repo_options);
         let keys = options.keypair.clone();
@@ -308,8 +308,8 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
         }
     }
 
-    pub async fn default() -> Self {
-        Self::new(IpfsOptions::default(), None).await
+    pub fn default() -> Self {
+        Self::new(IpfsOptions::default(), None)
     }
 
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
@@ -1254,8 +1254,6 @@ mod node {
             let span = Some(Span::current());
 
             let (ipfs, fut): (Ipfs<TestTypes>, _) = UninitializedIpfs::new(opts, span)
-                .in_current_span()
-                .await
                 .start()
                 .in_current_span()
                 .await

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -26,7 +26,7 @@ pub struct SwarmOptions {
 
 impl From<&IpfsOptions> for SwarmOptions {
     fn from(options: &IpfsOptions) -> Self {
-        let keypair = options.keypair.clone();
+        let keypair = options.keypair.0.clone();
         let peer_id = keypair.public().into_peer_id();
         let bootstrap = options.bootstrap.clone();
         let mdns = options.mdns;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -52,7 +52,7 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     // Set up an encrypted TCP transport over the Mplex protocol.
     let transport = transport::build_transport(options.keypair.clone());
 
-    let swarm_span = ipfs.0.span.clone();
+    let swarm_span = ipfs.span.clone();
 
     // Create a Kademlia behaviour
     let behaviour = behaviour::build_behaviour(options, ipfs).await;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -52,7 +52,7 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     // Set up an encrypted TCP transport over the Mplex protocol.
     let transport = transport::build_transport(options.keypair.clone());
 
-    let swarm_span = ipfs.span.clone();
+    let swarm_span = ipfs.span().clone();
 
     // Create a Kademlia behaviour
     let behaviour = behaviour::build_behaviour(options, ipfs).await;


### PR DESCRIPTION
The `UninitializedIpfs` struct neither has to be created using `async` nor is it necessary as a proxy object at all. We can simplify things even further, by not having the proxy `IpfsInner` object either.

This is a draft to "gauge the room" - if this is indeed a preferable course of action, I'll fix the docs, tests etc.