### PR TITLE
Simplified node internals and creation

### DIFF
--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -137,7 +137,6 @@ fn main() {
         let opts: IpfsOptions = IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None);
 
         let (ipfs, task): (Ipfs<ipfs::TestTypes>, _) = UninitializedIpfs::new(opts, None)
-            .await
             .start()
             .await
             .expect("Initialization failed");

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -134,9 +134,10 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
-        let opts: IpfsOptions = IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None);
+        let opts: IpfsOptions =
+            IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None, None);
 
-        let (ipfs, task): (Ipfs<ipfs::TestTypes>, _) = UninitializedIpfs::new(opts, None)
+        let (ipfs, task): (Ipfs<ipfs::TestTypes>, _) = UninitializedIpfs::new(opts)
             .start()
             .await
             .expect("Initialization failed");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -295,7 +295,7 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
     /// The span is attached to all operations called on the later created `Ipfs` along with all
     /// operations done in the background task as well as tasks spawned by the underlying
     /// `libp2p::Swarm`.
-    pub async fn new(options: IpfsOptions, span: Option<Span>) -> Self {
+    pub fn new(options: IpfsOptions, span: Option<Span>) -> Self {
         let repo_options = RepoOptions::from(&options);
         let (repo, repo_events) = create_repo(repo_options);
         let keys = options.keypair.clone();
@@ -310,8 +310,8 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
         }
     }
 
-    pub async fn default() -> Self {
-        Self::new(IpfsOptions::default(), None).await
+    pub fn default() -> Self {
+        Self::new(IpfsOptions::default(), None)
     }
 
     /// Initialize the ipfs node. The returned `Ipfs` value is cloneable, send and sync, and the
@@ -1248,8 +1248,6 @@ mod node {
             let span = Some(Span::current());
 
             let (ipfs, fut): (Ipfs<TestTypes>, _) = UninitializedIpfs::new(opts, span)
-                .in_current_span()
-                .await
                 .start()
                 .in_current_span()
                 .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ impl<Types: IpfsTypes> Clone for Ipfs<Types> {
 /// for interacting with IPFS.
 #[derive(Debug)]
 pub struct IpfsInner<Types: IpfsTypes> {
-    pub span: Span,
+    span: Span,
     repo: Repo<Types>,
     keys: DebuggableKeypair<Keypair>,
     to_task: Sender<IpfsEvent>,

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -52,7 +52,7 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     // Set up an encrypted TCP transport over the Mplex protocol.
     let transport = transport::build_transport(options.keypair.clone());
 
-    let swarm_span = ipfs.0.span.clone();
+    let swarm_span = ipfs.span.clone();
 
     // Create a Kademlia behaviour
     let behaviour = behaviour::build_behaviour(options, ipfs).await;


### PR DESCRIPTION
Obviates https://github.com/rs-ipfs/rust-ipfs/pull/343, which was similar, but also removed the `UninitializedIpfs` object.