### PR TITLE
pass another dht.query conformance test

### DIFF
--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -107,8 +107,6 @@ tests.dht(factory, {
     "should find other peers",
     // no auto-bootstrapping?
     "should be able to find providers",
-    // invalid PeerId encoding
-    "should return the other node in the query",
     // multiple entries in the param
     "should allow multiple CIDs to be passed",
     // unimplemented endpoints

--- a/http/src/v0/dht.rs
+++ b/http/src/v0/dht.rs
@@ -189,7 +189,7 @@ async fn get_closest_peers_query<T: IpfsTypes>(
     } = query;
     let peer_id = arg.into_inner();
     let closest_peers = ipfs
-        .get_closest_peers(peer_id)
+        .get_closest_peers(peer_id.clone())
         .maybe_timeout(timeout.map(StringSerialized::into_inner))
         .await
         .map_err(StringError::from)?
@@ -204,7 +204,7 @@ async fn get_closest_peers_query<T: IpfsTypes>(
     // FIXME: go-ipfs returns just a list of PeerIds
     let response = Response {
         extra: Default::default(),
-        id: Default::default(),
+        id: peer_id.to_string(),
         responses: closest_peers,
         r#type: 2,
     };


### PR DESCRIPTION
A small fix that allows us to pass one more `dht` conformance test, namely `"should return the other node in the query"`.