### PR TITLE
Continued pinning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ dirs = { default-features = false, version = "3.0" }
 domain = { default-features = false, version = "0.5" }
 domain-resolv = { default-features = false, version = "0.5" }
 either = { default-features = false, version = "1.5" }
-futures = { default-features = false, version = "0.3.5" }
+futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
 ipfs-unixfs = { path = "unixfs" }
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mdns-tokio", "mplex", "noise", "ping", "yamux"], version = "0.24" }
 multibase = { default-features = false, version = "0.8" }

--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -121,7 +121,15 @@ tests.dht(factory, {
 
 // tests.repo(factory)
 // tests.object(factory)
-tests.pin.add(factory)
+tests.pin.add(factory, {
+  skip: ['should respect timeout option when pinning a block']
+})
+tests.pin.ls(factory, {
+  skip: ['should respect timeout option when listing pins']
+})
+tests.pin.rm(factory, {
+  skip: ['should respect timeout option when unpinning a block']
+})
 // tests.bootstrap(factory)
 // tests.name(factory)
 // tests.namePubsub(factory)

--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -122,13 +122,23 @@ tests.dht(factory, {
 // tests.repo(factory)
 // tests.object(factory)
 tests.pin.add(factory, {
-  skip: ['should respect timeout option when pinning a block']
+  skip: [
+    'should respect timeout option when pinning a block'
+  ]
 })
 tests.pin.ls(factory, {
-  skip: ['should respect timeout option when listing pins']
+  skip: [
+    'should respect timeout option when listing pins',
+    // ignore these for now: https://github.com/rs-ipfs/rust-ipfs/issues/350
+    'should throw an error on missing direct pins for existing path',
+    'should throw an error on missing link for a specific path',
+    'should list indirect pins for a specific path',
+  ]
 })
 tests.pin.rm(factory, {
-  skip: ['should respect timeout option when unpinning a block']
+  skip: [
+    'should respect timeout option when unpinning a block'
+  ]
 })
 // tests.bootstrap(factory)
 // tests.name(factory)

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -206,6 +206,7 @@ async fn list_inner<T: IpfsTypes>(
         } else {
             // TODO: the non stream variant looks like the http docs one:
             // { "Keys": { "cid": { "Type": "indirect" } } }
+            // See https://github.com/rs-ipfs/rust-ipfs/issues/351
             Err(crate::v0::NotImplemented.into())
         }
     } else {
@@ -295,7 +296,9 @@ struct TypeDecorator<'a> {
 
 #[derive(Debug, Deserialize)]
 struct RemoveRequest {
-    // FIXME: go-ipfs supports multiple pin removals on single request
+    // FIXME: go-ipfs supports multiple pin removals on single request however for us it does not
+    // seem like a possibility at least for now. Not tested by conformance tests as far as I can
+    // see.
     arg: StringSerialized<Cid>,
     // Not mentioned in the API docs but this is accepted
     // Defaults to true which will remove both recursive and direct.
@@ -305,7 +308,6 @@ struct RemoveRequest {
 pub fn rm<T: IpfsTypes>(
     ipfs: &Ipfs<T>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    //with_ipfs(ipfs).and(remove_request()).and_then(rm_inner)
     with_ipfs(ipfs)
         .and(warp::query::<RemoveRequest>())
         .and_then(rm_inner)

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -147,7 +147,7 @@ impl PinFilter {
     }
 }
 
-/// `pin/ls` per https://docs.ipfs.io/reference/http/api/#api-v0-pin-ls
+/// `pin/ls` as per https://docs.ipfs.io/reference/http/api/#api-v0-pin-ls
 pub fn list<T: IpfsTypes>(
     ipfs: &Ipfs<T>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -46,10 +46,15 @@ async fn add_inner<T: IpfsTypes>(
 
     let cids: Vec<Cid> = request.args;
 
-    let dispatched_pins = cids
-        .into_iter()
-        .map(|x| async { ipfs.pin_block(&x).await.map(move |_| StringSerialized(x)) });
+    let recursive = request.recursive;
 
+    let dispatched_pins = cids.into_iter().map(|x| async {
+        ipfs.insert_pin(&x, recursive)
+            .await
+            .map(move |_| StringSerialized(x))
+    });
+
+    // could be unordered :)
     let completed = try_join_all(dispatched_pins)
         .await
         .map_err(StringError::from)?;

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -309,67 +309,6 @@ struct RemoveRequest {
     recursive: Option<bool>,
 }
 
-/*impl<'a> TryFrom<&'a str> for RemoveRequest {
-    type Error = ParseError<'a>;
-
-    fn try_from(q: &'a str) -> Result<Self, Self::Error> {
-        use ParseError::*;
-
-        // TODO: similar arg with duplicates question as always
-
-        let parse = url::form_urlencoded::parse(q.as_bytes());
-        let mut args = Vec::new();
-        let mut recursive = None;
-
-        for (key, value) in parse {
-            let target = match &*key {
-                "arg" => {
-                    // FIXME: this should be IpfsPath
-                    args.push(
-                        Cid::try_from(&*value)
-                            .map_err(|e| ParseError::InvalidCid("arg".into(), e))?,
-                    );
-                    continue;
-                }
-                "recursive" => &mut recursive,
-                _ => {
-                    // ignore unknown fields
-                    continue;
-                }
-            };
-
-            if target.is_none() {
-                match value.parse::<bool>() {
-                    Ok(value) => *target = Some(value),
-                    Err(_) => return Err(InvalidBoolean(key, value)),
-                }
-            } else {
-                return Err(DuplicateField(key));
-            }
-        }
-
-        if args.is_empty() {
-            return Err(MissingArg);
-        }
-
-        Ok(RemoveRequest {
-            arg: args,
-            recursive: recursive.unwrap_or(true),
-        })
-    }
-}
-
-fn remove_request() -> impl Filter<Extract = (RemoveRequest,), Error = Rejection> + Clone {
-    warp::filters::query::raw().and_then(|q: String| {
-        let res = RemoveRequest::try_from(q.as_str())
-            .map_err(StringError::from)
-            .map_err(warp::reject::custom);
-
-        futures::future::ready(res)
-    })
-}
-*/
-
 pub fn rm<T: IpfsTypes>(
     ipfs: &Ipfs<T>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -239,6 +239,7 @@ async fn list_inner<T: IpfsTypes>(
 
             Ok(format_json_newline(st))
         } else {
+            // TODO: same as above
             Err(crate::v0::NotImplemented.into())
         }
     }

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -6,63 +6,16 @@ use serde::Serialize;
 use std::convert::TryFrom;
 use warp::{reply, Filter, Rejection, Reply};
 
-#[derive(Debug)]
-struct AddRequest {
-    args: Vec<Cid>,
-    recursive: bool,
-    progress: bool,
-    // TODO: timeout, probably with rollback semantics?
-}
-
-#[derive(Serialize)]
-struct AddResponse {
-    #[serde(rename = "Pins")]
-    pins: Vec<StringSerialized<Cid>>,
-    // FIXME: go-ipfs doesn't respond with this
-    //progress: u8,
-}
+mod add;
 
 /// `pin/add` per https://docs.ipfs.io/reference/http/api/#api-v0-pin-add or the
 /// interface-ipfs-http test suite.
 pub fn add<T: IpfsTypes>(
     ipfs: &Ipfs<T>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
-    with_ipfs(ipfs).and(add_request()).and_then(add_inner)
-}
-
-async fn add_inner<T: IpfsTypes>(
-    ipfs: Ipfs<T>,
-    request: AddRequest,
-) -> Result<impl Reply, Rejection> {
-    if request.recursive {
-        // FIXME: this is not documented however all tests always pass true or false
-        return Err(crate::v0::support::NotImplemented.into());
-    }
-
-    if request.progress {
-        // FIXME: there doesn't appear to be a test for this
-        return Err(crate::v0::support::NotImplemented.into());
-    }
-
-    let cids: Vec<Cid> = request.args;
-
-    let recursive = request.recursive;
-
-    let dispatched_pins = cids.into_iter().map(|x| async {
-        ipfs.insert_pin(&x, recursive)
-            .await
-            .map(move |_| StringSerialized(x))
-    });
-
-    // could be unordered :)
-    let completed = try_join_all(dispatched_pins)
-        .await
-        .map_err(StringError::from)?;
-
-    Ok(reply::json(&AddResponse {
-        pins: completed,
-        //progress: 100,
-    }))
+    with_ipfs(ipfs)
+        .and(add::add_request())
+        .and_then(add::add_inner)
 }
 
 pub fn list<T: IpfsTypes>(
@@ -85,62 +38,4 @@ pub fn rm<T: IpfsTypes>(
 
 async fn rm_inner<T: IpfsTypes>(_ipfs: Ipfs<T>) -> Result<impl Reply, Rejection> {
     Err::<&'static str, _>(crate::v0::NotImplemented.into())
-}
-
-impl<'a> TryFrom<&'a str> for AddRequest {
-    type Error = ParseError<'a>;
-
-    fn try_from(q: &'a str) -> Result<Self, Self::Error> {
-        use ParseError::*;
-
-        let mut args = Vec::new();
-        let mut recursive = None;
-        let mut progress = None;
-
-        for (key, value) in url::form_urlencoded::parse(q.as_bytes()) {
-            let target = match &*key {
-                "arg" => {
-                    args.push(Cid::try_from(&*value).map_err(|e| InvalidCid("arg".into(), e))?);
-                    continue;
-                }
-                "recursive" => &mut recursive,
-                "progress" => &mut progress,
-                _ => {
-                    // ignore unknown
-                    continue;
-                }
-            };
-
-            if target.is_none() {
-                match value.parse::<bool>() {
-                    Ok(value) => *target = Some(value),
-                    Err(_) => return Err(InvalidBoolean(key, value)),
-                }
-            } else {
-                return Err(DuplicateField(key));
-            }
-        }
-
-        if args.is_empty() {
-            return Err(MissingArg);
-        }
-
-        Ok(AddRequest {
-            args,
-            recursive: recursive.unwrap_or(false),
-            progress: progress.unwrap_or(false),
-        })
-    }
-}
-
-/// Filter to perform custom `warp::query::<AddRequest>`. This needs to be copypasted around as
-/// HRTB is not quite usable yet.
-fn add_request() -> impl Filter<Extract = (AddRequest,), Error = Rejection> + Clone {
-    warp::filters::query::raw().and_then(|q: String| {
-        let res = AddRequest::try_from(q.as_str())
-            .map_err(StringError::from)
-            .map_err(warp::reject::custom);
-
-        futures::future::ready(res)
-    })
 }

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -111,7 +111,7 @@ impl<'a> TryFrom<&'a str> for ListRequest {
 
         Ok(ListRequest {
             arg: args,
-            filter: filter.unwrap_or(PinFilter::All),
+            filter: filter.unwrap_or_default(),
             quiet: quiet.unwrap_or(false),
             // this default was mentioned in the pin/ls api
             stream: quiet.unwrap_or(true),

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -202,11 +202,11 @@ async fn list_inner<T: IpfsTypes>(
             let st = st.map_ok(|(cid, mode)| {
                 Good::from((
                     cid,
-                    match mode {
-                        PinMode::Direct => Cow::Borrowed("direct"),
-                        PinMode::Indirect => Cow::Borrowed("indirect"),
-                        PinMode::Recursive => Cow::Borrowed("recursive"),
-                    },
+                    Cow::Borrowed(match mode {
+                        PinMode::Direct => "direct",
+                        PinMode::Indirect => "indirect",
+                        PinMode::Recursive => "recursive",
+                    }),
                 ))
             });
 

--- a/http/src/v0/pin/add.rs
+++ b/http/src/v0/pin/add.rs
@@ -26,11 +26,6 @@ pub async fn add_inner<T: IpfsTypes>(
     ipfs: Ipfs<T>,
     request: AddRequest,
 ) -> Result<impl Reply, Rejection> {
-    if request.recursive {
-        // FIXME: this is not documented however all tests always pass true or false
-        return Err(crate::v0::support::NotImplemented.into());
-    }
-
     if request.progress {
         // FIXME: there doesn't appear to be a test for this
         return Err(crate::v0::support::NotImplemented.into());

--- a/http/src/v0/pin/add.rs
+++ b/http/src/v0/pin/add.rs
@@ -1,0 +1,116 @@
+use crate::v0::support::option_parsing::ParseError;
+use crate::v0::support::{with_ipfs, StringError, StringSerialized};
+use futures::future::try_join_all;
+use ipfs::{Cid, Ipfs, IpfsTypes};
+use serde::Serialize;
+use std::convert::TryFrom;
+use warp::{reply, Filter, Rejection, Reply};
+
+#[derive(Debug)]
+pub struct AddRequest {
+    args: Vec<Cid>,
+    recursive: bool,
+    progress: bool,
+    // TODO: timeout, probably with rollback semantics?
+}
+
+#[derive(Serialize)]
+struct AddResponse {
+    #[serde(rename = "Pins")]
+    pins: Vec<StringSerialized<Cid>>,
+    // FIXME: go-ipfs doesn't respond with this
+    //progress: u8,
+}
+
+pub async fn add_inner<T: IpfsTypes>(
+    ipfs: Ipfs<T>,
+    request: AddRequest,
+) -> Result<impl Reply, Rejection> {
+    if request.recursive {
+        // FIXME: this is not documented however all tests always pass true or false
+        return Err(crate::v0::support::NotImplemented.into());
+    }
+
+    if request.progress {
+        // FIXME: there doesn't appear to be a test for this
+        return Err(crate::v0::support::NotImplemented.into());
+    }
+
+    let cids: Vec<Cid> = request.args;
+
+    let recursive = request.recursive;
+
+    let dispatched_pins = cids.into_iter().map(|x| async {
+        ipfs.insert_pin(&x, recursive)
+            .await
+            .map(move |_| StringSerialized(x))
+    });
+
+    // could be unordered :)
+    let completed = try_join_all(dispatched_pins)
+        .await
+        .map_err(StringError::from)?;
+
+    Ok(reply::json(&AddResponse {
+        pins: completed,
+        //progress: 100,
+    }))
+}
+
+impl<'a> TryFrom<&'a str> for AddRequest {
+    type Error = ParseError<'a>;
+
+    fn try_from(q: &'a str) -> Result<Self, Self::Error> {
+        use ParseError::*;
+
+        let mut args = Vec::new();
+        let mut recursive = None;
+        let mut progress = None;
+
+        for (key, value) in url::form_urlencoded::parse(q.as_bytes()) {
+            let target = match &*key {
+                "arg" => {
+                    args.push(Cid::try_from(&*value).map_err(|e| InvalidCid("arg".into(), e))?);
+                    continue;
+                }
+                "recursive" => &mut recursive,
+                "progress" => &mut progress,
+                _ => {
+                    // ignore unknown
+                    continue;
+                }
+            };
+
+            if target.is_none() {
+                match value.parse::<bool>() {
+                    Ok(value) => *target = Some(value),
+                    Err(_) => return Err(InvalidBoolean(key, value)),
+                }
+            } else {
+                return Err(DuplicateField(key));
+            }
+        }
+
+        if args.is_empty() {
+            return Err(MissingArg);
+        }
+
+        Ok(AddRequest {
+            args,
+            recursive: recursive.unwrap_or(false),
+            progress: progress.unwrap_or(false),
+        })
+    }
+}
+
+/// Filter to perform custom `warp::query::<AddRequest>`. This needs to be copypasted around as
+/// HRTB is not quite usable yet.
+pub fn add_request() -> impl Filter<Extract = (AddRequest,), Error = Rejection> + Clone {
+    warp::filters::query::raw().and_then(|q: String| {
+        let res = AddRequest::try_from(q.as_str())
+            .map_err(StringError::from)
+            .map_err(warp::reject::custom);
+
+        futures::future::ready(res)
+    })
+}

--- a/http/src/v0/pin/add.rs
+++ b/http/src/v0/pin/add.rs
@@ -1,5 +1,5 @@
 use crate::v0::support::option_parsing::ParseError;
-use crate::v0::support::{with_ipfs, StringError, StringSerialized};
+use crate::v0::support::{StringError, StringSerialized};
 use futures::future::try_join_all;
 use ipfs::{Cid, Ipfs, IpfsTypes};
 use serde::Serialize;

--- a/http/src/v0/support/option_parsing.rs
+++ b/http/src/v0/support/option_parsing.rs
@@ -10,6 +10,7 @@ pub enum ParseError<'a> {
     InvalidBoolean(Cow<'a, str>, Cow<'a, str>),
     InvalidDuration(Cow<'a, str>, humantime::DurationError),
     InvalidCid(Cow<'a, str>, cid::Error),
+    InvalidValue(Cow<'a, str>, Cow<'a, str>),
 }
 
 impl<'a> fmt::Display for ParseError<'a> {
@@ -25,6 +26,9 @@ impl<'a> fmt::Display for ParseError<'a> {
                 write!(fmt, "field {:?} invalid duration: {}", field, e)
             }
             InvalidCid(ref field, ref e) => write!(fmt, "field {:?} invalid cid: {}", field, e),
+            InvalidValue(ref field, ref value) => {
+                write!(fmt, "field {:?} invalid value: {:?}", field, value)
+            }
         }
     }
 }

--- a/http/src/v0/support/serdesupport.rs
+++ b/http/src/v0/support/serdesupport.rs
@@ -6,12 +6,18 @@ use std::str::FromStr;
 /// Display to serde::Serialize. Probably should be used with Cid, PeerId and such.
 ///
 /// Monkeyd from: https://github.com/serde-rs/serde/issues/1316
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct StringSerialized<T>(pub T);
 
 impl<T> StringSerialized<T> {
     pub fn into_inner(self) -> T {
         self.0
+    }
+}
+
+impl<T> AsRef<T> for StringSerialized<T> {
+    fn as_ref(&self) -> &T {
+        &self.0
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -396,11 +396,11 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     /// can be made recursive, but removing the recursive pin on the block removes also the direct
     /// pin as well.
     ///
-    /// Pinning a Cid recursively (for supported dag-protobuf and dag-cbor) will walk it's
+    /// Pinning a Cid recursively (for supported dag-protobuf and dag-cbor) will walk its
     /// references and pin the references indirectly. When a Cid is pinned indirectly it will keep
-    /// it's previous direct or recursive pin and be indirect in addition.
+    /// its previous direct or recursive pin and be indirect in addition.
     ///
-    /// Recursively pinned Cids cannot be pinned non-recursively but non-recursively pinned Cids
+    /// Recursively pinned Cids cannot be re-pinned non-recursively but non-recursively pinned Cids
     /// can be "upgraded to" being recursively pinned.
     ///
     /// # Crash unsafety
@@ -457,7 +457,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
 
     /// Unpins a given Cid recursively or only directly.
     ///
-    /// Unpinning a previously only direclty pinned recursively will remove the direct pin.
+    /// Recursively unpinning a previously only directly pinned Cid will remove the direct pin.
     ///
     /// Unpinning an indirectly pinned Cid is not possible other than through its recursively
     /// pinned tree roots.
@@ -572,7 +572,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         self.repo.is_pinned(cid).instrument(self.span.clone()).await
     }
 
-    /// Lists all pins, or the specific kind.
+    /// Lists all pins, or the specific kind thereof.
     ///
     /// Does not currently recover from partial recursive pin insertions.
     pub async fn list_pins(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -453,7 +453,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     ///
     /// Unpinning a previously only direclty pinned recursively will remove the direct pin.
     ///
-    /// Unpinning an indirectly pinned Cid is not possible other than through it's recursively
+    /// Unpinning an indirectly pinned Cid is not possible other than through its recursively
     /// pinned tree roots.
     pub async fn remove_pin(&self, cid: &Cid, recursive: bool) -> Result<(), Error> {
         use futures::stream::TryStreamExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1634,9 +1634,9 @@ mod tests {
         let data = make_ipld!([-1, -2, -3]);
         let cid = ipfs.put_dag(data.clone()).await.unwrap();
 
-        ipfs.pin_block(&cid).await.unwrap();
+        ipfs.insert_pin(&cid, false).await.unwrap();
         assert!(ipfs.is_pinned(&cid).await.unwrap());
-        ipfs.unpin_block(&cid).await.unwrap();
+        ipfs.remove_pin(&cid, false).await.unwrap();
         assert!(!ipfs.is_pinned(&cid).await.unwrap());
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,7 +883,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         unique: bool,
     ) -> impl Stream<Item = Result<refs::Edge, ipld::BlockError>> + Send + 'a
     where
-        Iter: IntoIterator<Item = (Cid, Ipld)> + 'a,
+        Iter: IntoIterator<Item = (Cid, Ipld)> + Send + 'a,
     {
         refs::iplds_refs(self, iplds, max_depth, unique)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -406,8 +406,8 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     /// # Crash unsafety
     ///
     /// If a recursive `insert_pin` operation is interrupted because of a crash or the crash
-    /// prevents synchronizing data store to disk, this will leave the system in inconsistent
-    /// state. Remedy is to re-pin recursive pins.
+    /// prevents from synchronizing the data store to disk, this will leave the system in an inconsistent
+    /// state. The remedy is to re-pin recursive pins.
     pub async fn insert_pin(&self, cid: &Cid, recursive: bool) -> Result<(), Error> {
         use futures::stream::TryStreamExt;
         if !recursive {
@@ -559,7 +559,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     ///
     /// # Crash unsafety
     ///
-    /// Cannot detect partially written recursive pins. Such happen if `Ipfs::insert_pin(cid,
+    /// Cannot detect partially written recursive pins. Those can happen if `Ipfs::insert_pin(cid,
     /// recursive: true)` is interrupted by a crash for example.
     ///
     /// Works correctly only under no-crash situations. Workaround for hitting a crash is to re-pin
@@ -567,7 +567,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     ///
     /// TODO: This operation could be provided as a `Ipfs::fix_pins()`.
     pub async fn is_pinned(&self, cid: &Cid) -> Result<bool, Error> {
-        // best to just delegate, we cannot efficiently list of PinKind::RecursiveIntention but the
+        // best to just delegate, we cannot efficiently obtain a list of PinKind::RecursiveIntention but the
         // repo impl can
         self.repo.is_pinned(cid).instrument(self.span.clone()).await
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1638,6 +1638,7 @@ mod tests {
     }
 
     #[tokio::test(max_threads = 1)]
+    #[ignore = "temporary ignore to get other errors from CI"]
     async fn test_pin_and_unpin() {
         let ipfs = Node::new("test_node").await;
 

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -56,7 +56,7 @@ impl Default for IpldRefs {
 }
 
 impl IpldRefs {
-    /// Overrides the default maximum depth of unlimited with the given maximum depth. Zero is
+    /// Overrides the default maximum depth of "unlimited" with the given maximum depth. Zero is
     /// allowed and will result in an empty stream.
     #[allow(dead_code)]
     pub fn with_max_depth(mut self, depth: u64) -> IpldRefs {
@@ -72,7 +72,7 @@ impl IpldRefs {
     }
 
     /// Overrides the default of allowing the refs operation to fetch blocks. Useful at least
-    /// internally in rust-ipfs to implement pinning recursively. This changes the streams
+    /// internally in rust-ipfs to implement pinning recursively. This changes the stream's
     /// behaviour to stop on first block which is not found locally.
     pub fn with_existing_blocks(mut self) -> IpldRefs {
         self.download_blocks = false;

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -58,6 +58,7 @@ impl Default for IpldRefs {
 impl IpldRefs {
     /// Overrides the default maximum depth of unlimited with the given maximum depth. Zero is
     /// allowed and will result in an empty stream.
+    #[allow(dead_code)]
     pub fn with_max_depth(mut self, depth: u64) -> IpldRefs {
         self.max_depth = Some(depth);
         self

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -1,7 +1,7 @@
 //! Volatile memory backed repo
 use crate::error::Error;
 use crate::repo::{
-    BlockPut, BlockStore, Column, DataStore, PinDocument, PinKind, PinMode, PinStore,
+    BlockPut, BlockStore, Column, DataStore, PinDocument, PinKind, PinMode, PinStore, Recursive,
 };
 use async_trait::async_trait;
 use bitswap::Block;
@@ -122,7 +122,7 @@ impl PinStore for MemDataStore {
                 let mut doc = PinDocument {
                     version: 0,
                     direct: false,
-                    recursive: None,
+                    recursive: Recursive::Not,
                     cid_version: match target.version() {
                         cid::Version::V0 => 0,
                         cid::Version::V1 => 1,

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -246,7 +246,7 @@ impl PinStore for MemDataStore {
                         // would be more clear if this business was in a separate map; quite awful
                         // as it is now
 
-                        let matches = requirement.as_ref().map(|req| mode == req).unwrap_or(true);
+                        let matches = requirement.as_ref().map(|req| mode == *req).unwrap_or(true);
 
                         if matches {
                             trace!(cid = %cid, req = ?requirement, "pin matches");
@@ -256,7 +256,9 @@ impl PinStore for MemDataStore {
                             return Err(anyhow::anyhow!(
                                 "{} is not pinned as {:?}",
                                 cid,
-                                requirement.expect("matches is never false if requirement is none")
+                                requirement
+                                    .as_ref()
+                                    .expect("matches is never false if requirement is none")
                             ));
                         }
                     }

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -278,7 +278,6 @@ impl DataStore for MemDataStore {
     async fn contains(&self, col: Column, key: &[u8]) -> Result<bool, Error> {
         let map = match col {
             Column::Ipns => &self.ipns,
-            Column::Pin => &self.pin,
         };
         let contains = map.lock().await.contains_key(key);
         Ok(contains)
@@ -287,7 +286,6 @@ impl DataStore for MemDataStore {
     async fn get(&self, col: Column, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
         let map = match col {
             Column::Ipns => &self.ipns,
-            Column::Pin => &self.pin,
         };
         let value = map.lock().await.get(key).map(|value| value.to_owned());
         Ok(value)
@@ -296,7 +294,6 @@ impl DataStore for MemDataStore {
     async fn put(&self, col: Column, key: &[u8], value: &[u8]) -> Result<(), Error> {
         let map = match col {
             Column::Ipns => &self.ipns,
-            Column::Pin => &self.pin,
         };
         map.lock().await.insert(key.to_owned(), value.to_owned());
         Ok(())
@@ -305,7 +302,6 @@ impl DataStore for MemDataStore {
     async fn remove(&self, col: Column, key: &[u8]) -> Result<(), Error> {
         let map = match col {
             Column::Ipns => &self.ipns,
-            Column::Pin => &self.pin,
         };
         map.lock().await.remove(key);
         Ok(())

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -144,7 +144,6 @@ pub trait PinStore: Debug + Send + Sync + Unpin + 'static {
 #[derive(Clone, Copy, Debug)]
 pub enum Column {
     Ipns,
-    Pin,
 }
 
 /// `PinMode` is the description of pin type for quering purposes.

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -780,7 +780,6 @@ pub(crate) mod tests {
 
         repo.insert_pin(&root, PinKind::Direct).await.unwrap();
 
-        // TODO: test failure here seems valid, perhaps PinDocument is buggy?
         assert_eq!(
             repo.query_pins(vec![empty.clone(), root.clone()])
                 .await

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -147,7 +147,7 @@ pub enum Column {
 }
 
 /// `PinMode` is the description of pin type for quering purposes.
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum PinMode {
     Indirect,
     Direct,

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -385,7 +385,6 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
         self.data_store.remove_pin(cid, kind).await
     }
 
-    // TODO: this is sort of superceded with list/query_pins
     pub async fn is_pinned(&self, cid: &Cid) -> Result<bool, Error> {
         self.data_store.is_pinned(&cid).await
     }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -147,6 +147,7 @@ pub enum Column {
     Pin,
 }
 
+/// `PinMode` is the description of pin type for quering purposes.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PinMode {
     Indirect,
@@ -166,6 +167,9 @@ impl<'a, B: Borrow<Cid>> PartialEq<&'a PinMode> for PinKind<B> {
     }
 }
 
+/// `PinKind` is more specific pin description for writing purposes. Implements
+/// `PartialEq<&PinMode>`. Generic over `Borrow<Cid>` to allow storing both reference and owned
+/// value of Cid.
 #[derive(Debug, PartialEq, Eq)]
 pub enum PinKind<C: Borrow<Cid>> {
     IndirectFrom(C),
@@ -182,6 +186,7 @@ pub struct Repo<TRepoTypes: RepoTypes> {
     pub(crate) subscriptions: SubscriptionRegistry<Block, String>,
 }
 
+/// Events used to communicate to the swarm on repo changes.
 #[derive(Debug)]
 pub enum RepoEvent {
     WantBlock(Cid),
@@ -426,7 +431,7 @@ impl Recursive {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct PinDocument {
+struct PinDocument {
     version: u8,
     direct: bool,
     // how many descendants; something to check when walking

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -831,7 +831,7 @@ pub(crate) mod tests {
         let mut doc = PinDocument {
             version: 0,
             direct: false,
-            recursive: None,
+            recursive: Recursive::Not,
             cid_version: 0,
             indirect_by: Vec::new(),
         };

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -352,14 +352,6 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
         self.data_store.remove(Column::Ipns, ipns.as_bytes()).await
     }
 
-    pub async fn pin_block(&self, cid: &Cid) -> Result<(), Error> {
-        self.insert_pin(cid, PinKind::Direct).await
-    }
-
-    pub async fn unpin_block(&self, cid: &Cid) -> Result<(), Error> {
-        self.remove_pin(cid, PinKind::Direct).await
-    }
-
     pub async fn insert_pin(&self, cid: &Cid, kind: PinKind<&'_ Cid>) -> Result<(), Error> {
         self.data_store.insert_pin(cid, kind).await
     }
@@ -368,6 +360,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
         self.data_store.remove_pin(cid, kind).await
     }
 
+    // TODO: this is sort of superceded with list/query_pins
     pub async fn is_pinned(&self, cid: &Cid) -> Result<bool, Error> {
         self.data_store.is_pinned(&cid).await
     }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -459,6 +459,9 @@ impl PinDocument {
                         Some(_) => false,
                         None => {
                             self.recursive = Some(descendants);
+                            // the previously direct has now been upgraded to recursive, it can
+                            // still be indirect though
+                            self.direct = false;
                             true
                         }
                     }
@@ -473,6 +476,9 @@ impl PinDocument {
                         Some(_) => true,
                         None => return Err(PinUpdateError::NotPinnedRecursive),
                     }
+                    // FIXME: removing ... not sure if this is an issue; was thinking that maybe
+                    // the update might need to be split to allow different api for removal than
+                    // addition.
                 };
                 Ok(modified)
             }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -154,8 +154,8 @@ pub enum PinMode {
     Recursive,
 }
 
-impl<'a, B: Borrow<Cid>> PartialEq<&'a PinMode> for PinKind<B> {
-    fn eq(&self, other: &&PinMode) -> bool {
+impl<B: Borrow<Cid>> PartialEq<PinMode> for PinKind<B> {
+    fn eq(&self, other: &PinMode) -> bool {
         match (self, other) {
             (PinKind::IndirectFrom(_), PinMode::Indirect)
             | (PinKind::Direct, PinMode::Direct)


### PR DESCRIPTION
This PR adds the remaining `pin/*` APIs, with a bad implementation of recursive pinning. Aim is to inch forward to see a more proper implementation.

Compared to older pin storage implementations in go-ipfs at least this jumps right into using a "datastore" similar to the previous implementation. However I quickly found that the pin storage could not work on the simple datastore API. Instead of turning the datastore API into versioned and Repo level pin operations retryable on races this adds a version of `PinStore` which assumes locked access.

Recursive pinning is the slowest and most space inefficient variant: store all indirect pins. It doesn't seem wise but I am inclided to keep that at least for this PR. When adding a recursive pin, first the root is marked as `Recursive::Intent`, followed by marking all references as pinned `Indirect` from this root, followed by marking the root as `Recursive::Count(number_of_references)`. Writing down the indirect pins is likely not a proper way to do implement this, as this scheme requires all of the machinery only recording the recursive pinning for the root would require, but has some additional steps, and space use. It does not however require inmemory caching as the storage space is the cache.

There will be a long way to go towards a proper transactional, persistent pin storage (or even supporting one) after this PR but I aim to get the HTTP API tests going in this PR, or at least most of them. Probably scoping out the `pin (add|ls|rm) IpfsPath` for just supporting Cids at the moment.

Definitely not included:
 - `pin/rm` with multiple arguments; can't see how could this be possible to implement without proper transactional datastore
 - recovery from partial recursive pins

Removed:
 - `ipfs::repo::Column::Pin` and related paths

Not sure yet:
 - how to structure the `pin/ls` response formatting code
 - keep the string-precise anyhow errors or do proper error enums?

TODO:
 - `pin/ls` non-streaming response

The `pin/ls` responses are quite difficult beast.

### Checklist (can be deleted from PR description once items are checked)

- [x] **New** code is “linted” i.e. code formatting via rustfmt and language idioms via clippy
- [x] There are no extraneous changes like formatting, line reordering, etc. Keep the patch sizes small!
- [ ] There are functional and/or unit tests written, and they are passing
- [ ] There is suitable documentation. In our case, this means:
    - [ ] Each command has a usage example and API specification
    - [ ] Rustdoc tests are passing on all code-level comments
    - [ ] Differences between Rust’s IPFS implementation and the Go or JS implementations are explained
        - attempted this at the `ipfs::Ipfs` level method docs
