### PR TITLE
Implement /dns and /resolve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
+dependencies = [
+ "socket2",
+ "widestring",
+ "winapi 0.3.9",
+ "winreg",
+]
+
+[[package]]
 name = "ipfs"
 version = "0.1.0"
 dependencies = [
@@ -1184,6 +1196,7 @@ dependencies = [
  "either",
  "futures",
  "hex-literal",
+ "ipconfig",
  "ipfs-unixfs",
  "libp2p",
  "multibase",
@@ -3185,6 +3198,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a763e303c0e0f23b0da40888724762e802a8ffefbc22de4127ef42493c2ea68c"
+
+[[package]]
 name = "winapi"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,6 +3245,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "ws2_32-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,10 @@ tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = ["std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }
 
+[target.'cfg(windows)'.dependencies]
+# required for DNS resolution
+ipconfig = { default-features = false, version = "0.2" }
+
 [build-dependencies]
 prost-build = { default-features = false, version = "0.6" }
 

--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -34,7 +34,16 @@ const factory = createFactory(options)
 //
 tests.miscellaneous(factory, { skip: [
   'dns',
-  'resolve',
+  // the cidBase param is not implemented yet
+  'should resolve an IPFS hash and return a base64url encoded CID in path',
+  // different Cid, the /path/to/testfile.txt suffix shouldn't be there
+  'should resolve an IPFS path link',
+  // different Cid, missing "/path/to" in the middle
+  'should resolve up to the last node across multiple nodes',
+  // expected "true", got "false"
+  'should resolve an IPNS DNS link',
+  // HTTP: not implemented
+  'should resolve IPNS link recursively',
   // these cause a hang 20% of time:
   'should respect timeout option when getting the node id',
   'should respect timeout option when getting the node version',

--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -33,7 +33,8 @@ const factory = createFactory(options)
 // Phase 1.0-ish
 //
 tests.miscellaneous(factory, { skip: [
-  'dns',
+  // recursive resolving is not implemented yet
+  'should recursively resolve ipfs.io',
   // the cidBase param is not implemented yet
   'should resolve an IPFS hash and return a base64url encoded CID in path',
   // different Cid, the /path/to/testfile.txt suffix shouldn't be there

--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -33,8 +33,6 @@ const factory = createFactory(options)
 // Phase 1.0-ish
 //
 tests.miscellaneous(factory, { skip: [
-  // recursive resolving is not implemented yet
-  'should recursively resolve ipfs.io',
   // the cidBase param is not implemented yet
   'should resolve an IPFS hash and return a base64url encoded CID in path',
   // different Cid, the /path/to/testfile.txt suffix shouldn't be there

--- a/examples/ipfs_ipns_test.rs
+++ b/examples/ipfs_ipns_test.rs
@@ -21,15 +21,15 @@ async fn main() {
         .unwrap();
 
     // Resolve a Block
-    let new_ipfs_path = ipfs.resolve_ipns(&ipns_path).await.unwrap();
+    let new_ipfs_path = ipfs.resolve_ipns(&ipns_path, false).await.unwrap();
     assert_eq!(ipfs_path, new_ipfs_path);
 
     // Resolve dnslink
     let ipfs_path = IpfsPath::from_str("/ipns/ipfs.io").unwrap();
     println!("Resolving {:?}", ipfs_path.to_string());
-    let ipfs_path = ipfs.resolve_ipns(&ipfs_path).await.unwrap();
+    let ipfs_path = ipfs.resolve_ipns(&ipfs_path, false).await.unwrap();
     println!("Resolved stage 1: {:?}", ipfs_path.to_string());
-    let ipfs_path = ipfs.resolve_ipns(&ipfs_path).await.unwrap();
+    let ipfs_path = ipfs.resolve_ipns(&ipfs_path, false).await.unwrap();
     println!("Resolved stage 2: {:?}", ipfs_path.to_string());
 
     ipfs.exit_daemon().await;

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -88,6 +88,7 @@ pub fn routes<T: IpfsTypes>(
         and_boxed!(warp::path!("id"), id::identity(ipfs)),
         and_boxed!(warp::path!("add"), root_files::add(ipfs)),
         and_boxed!(warp::path!("cat"), root_files::cat(ipfs)),
+        and_boxed!(warp::path!("dns"), ipns::dns(ipfs)),
         and_boxed!(warp::path!("get"), root_files::get(ipfs)),
         and_boxed!(warp::path!("refs" / "local"), refs::local(ipfs)),
         and_boxed!(warp::path!("refs"), refs::refs(ipfs)),

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -6,6 +6,7 @@ pub mod block;
 pub mod dag;
 pub mod dht;
 pub mod id;
+pub mod ipns;
 pub mod pin;
 pub mod pubsub;
 pub mod refs;
@@ -90,6 +91,7 @@ pub fn routes<T: IpfsTypes>(
         and_boxed!(warp::path!("get"), root_files::get(ipfs)),
         and_boxed!(warp::path!("refs" / "local"), refs::local(ipfs)),
         and_boxed!(warp::path!("refs"), refs::refs(ipfs)),
+        and_boxed!(warp::path!("resolve"), ipns::resolve(ipfs)),
         warp::path!("version")
             .and(query::<version::Query>())
             .and_then(version::version),

--- a/http/src/v0/ipns.rs
+++ b/http/src/v0/ipns.rs
@@ -1,0 +1,45 @@
+use crate::v0::support::{with_ipfs, StringError, StringSerialized};
+use ipfs::{Ipfs, IpfsPath, IpfsTypes};
+use serde::{Deserialize, Serialize};
+use warp::{query, Filter, Rejection, Reply};
+
+#[derive(Debug, Deserialize)]
+pub struct ResolveQuery {
+    // the name to resolve
+    arg: StringSerialized<IpfsPath>,
+    #[serde(rename = "dht-record-count")]
+    dht_record_count: Option<usize>,
+    #[serde(rename = "dht-timeout")]
+    dht_timeout: Option<String>,
+}
+
+pub fn resolve<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    with_ipfs(ipfs)
+        .and(query::<ResolveQuery>())
+        .and_then(resolve_query)
+}
+
+async fn resolve_query<T: IpfsTypes>(
+    ipfs: Ipfs<T>,
+    query: ResolveQuery,
+) -> Result<impl Reply, Rejection> {
+    let ResolveQuery { arg, .. } = query;
+    let name = arg.into_inner();
+    let path = ipfs
+        .resolve(&name)
+        .await
+        .map_err(StringError::from)?
+        .to_string();
+
+    let response = ResolveResponse { path };
+
+    Ok(warp::reply::json(&response))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct ResolveResponse {
+    path: String,
+}

--- a/http/src/v0/ipns.rs
+++ b/http/src/v0/ipns.rs
@@ -28,7 +28,7 @@ async fn resolve_query<T: IpfsTypes>(
     let ResolveQuery { arg, .. } = query;
     let name = arg.into_inner();
     let path = ipfs
-        .resolve(&name, false)
+        .resolve_ipns(&name, false)
         .await
         .map_err(StringError::from)?
         .to_string();
@@ -73,7 +73,7 @@ async fn dns_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: DnsQuery) -> Result<impl 
     .map_err(StringError::from)?;
 
     let path = ipfs
-        .resolve(&path, recursive.unwrap_or(false))
+        .resolve_ipns(&path, recursive.unwrap_or(false))
         .await
         .map_err(StringError::from)?
         .to_string();

--- a/http/src/v0/ipns.rs
+++ b/http/src/v0/ipns.rs
@@ -43,3 +43,34 @@ async fn resolve_query<T: IpfsTypes>(
 struct ResolveResponse {
     path: String,
 }
+
+#[derive(Debug, Deserialize)]
+pub struct DnsQuery {
+    // the name to resolve
+    arg: StringSerialized<IpfsPath>,
+}
+
+pub fn dns<T: IpfsTypes>(
+    ipfs: &Ipfs<T>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
+    with_ipfs(ipfs).and(query::<DnsQuery>()).and_then(dns_query)
+}
+
+async fn dns_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: DnsQuery) -> Result<impl Reply, Rejection> {
+    let DnsQuery { arg, .. } = query;
+    let path = ipfs
+        .resolve(&arg.into_inner())
+        .await
+        .map_err(StringError::from)?
+        .to_string();
+
+    let response = DnsResponse { path };
+
+    Ok(warp::reply::json(&response))
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct DnsResponse {
+    path: String,
+}

--- a/http/src/v0/ipns.rs
+++ b/http/src/v0/ipns.rs
@@ -28,7 +28,7 @@ async fn resolve_query<T: IpfsTypes>(
     let ResolveQuery { arg, .. } = query;
     let name = arg.into_inner();
     let path = ipfs
-        .resolve(&name)
+        .resolve(&name, false)
         .await
         .map_err(StringError::from)?
         .to_string();
@@ -48,6 +48,7 @@ struct ResolveResponse {
 pub struct DnsQuery {
     // the name to resolve
     arg: String,
+    recursive: Option<bool>,
 }
 
 pub fn dns<T: IpfsTypes>(
@@ -57,7 +58,7 @@ pub fn dns<T: IpfsTypes>(
 }
 
 async fn dns_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: DnsQuery) -> Result<impl Reply, Rejection> {
-    let DnsQuery { arg, .. } = query;
+    let DnsQuery { arg, recursive } = query;
     // attempt to parse the argument prepended with "/ipns/" if it fails to parse like a compliant
     // IpfsPath and there is no leading slash
     let path = if !arg.starts_with('/') {
@@ -70,8 +71,9 @@ async fn dns_query<T: IpfsTypes>(ipfs: Ipfs<T>, query: DnsQuery) -> Result<impl 
         arg.parse()
     }
     .map_err(StringError::from)?;
+
     let path = ipfs
-        .resolve(&path)
+        .resolve(&path, recursive.unwrap_or(false))
         .await
         .map_err(StringError::from)?
         .to_string();

--- a/src/ipns/dns.rs
+++ b/src/ipns/dns.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 #[error("no dnslink entry")]
 pub struct DnsLinkError;
 
-type FutureAnswer = Pin<Box<dyn Future<Output = Result<Answer, io::Error>>>>;
+type FutureAnswer = Pin<Box<dyn Future<Output = Result<Answer, io::Error>> + Send>>;
 
 pub struct DnsLinkFuture {
     query: SelectOk<FutureAnswer>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,11 +446,26 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     }
 
     /// Resolves a ipns path to an ipld path.
-    pub async fn resolve_ipns(&self, path: &IpfsPath) -> Result<IpfsPath, Error> {
-        self.ipns()
-            .resolve(path)
-            .instrument(self.span.clone())
-            .await
+    pub async fn resolve_ipns(&self, path: &IpfsPath, recursive: bool) -> Result<IpfsPath, Error> {
+        let ipns = self.ipns();
+        let mut resolved = ipns.resolve(path).await;
+
+        if recursive {
+            let mut previous = None;
+            while let Ok(ref res) = resolved {
+                if let Some(ref prev) = previous {
+                    if prev == res {
+                        break;
+                    }
+                }
+                previous = Some(res.clone());
+                resolved = ipns.resolve(&res).await;
+            }
+
+            resolved
+        } else {
+            resolved
+        }
     }
 
     /// Publishes an ipld path.
@@ -857,28 +872,6 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         Iter: IntoIterator<Item = (Cid, Ipld)> + 'a,
     {
         refs::iplds_refs(self, iplds, max_depth, unique)
-    }
-
-    pub async fn resolve(&self, path: &IpfsPath, recursive: bool) -> Result<IpfsPath, Error> {
-        let ipns = self.ipns();
-        let mut resolved = ipns.resolve(path).await;
-
-        if recursive {
-            let mut previous = None;
-            while let Ok(ref res) = resolved {
-                if let Some(ref prev) = previous {
-                    if prev == res {
-                        break;
-                    }
-                }
-                previous = Some(res.clone());
-                resolved = ipns.resolve(&res).await;
-            }
-
-            resolved
-        } else {
-            resolved
-        }
     }
 
     /// Exit daemon.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -859,6 +859,10 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         refs::iplds_refs(self, iplds, max_depth, unique)
     }
 
+    pub async fn resolve(&self, path: &IpfsPath) -> Result<IpfsPath, Error> {
+        self.ipns().resolve(path).await
+    }
+
     /// Exit daemon.
     pub async fn exit_daemon(self) {
         // FIXME: this is a stopgap measure needed while repo is part of the struct Ipfs instead of

--- a/src/path.rs
+++ b/src/path.rs
@@ -10,7 +10,7 @@ use thiserror::Error;
 // TODO: it might be useful to split this into CidPath and IpnsPath, then have Ipns resolve through
 // latter into CidPath (recursively) and have dag.rs support only CidPath. Keep IpfsPath as a
 // common abstraction which can be either.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct IpfsPath {
     root: PathRoot,
     pub(crate) path: SlashedPath,
@@ -161,7 +161,7 @@ impl TryInto<PeerId> for IpfsPath {
 ///
 /// UTF-8 originates likely from UnixFS related protobuf descriptions, where dag-pb links have
 /// UTF-8 names, which equal to SlashedPath segments.
-#[derive(Debug, PartialEq, Eq, Clone, Default)]
+#[derive(Debug, PartialEq, Eq, Clone, Default, Hash)]
 pub struct SlashedPath {
     path: Vec<String>,
 }
@@ -241,7 +241,7 @@ impl<'a> PartialEq<[&'a str]> for SlashedPath {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub enum PathRoot {
     Ipld(Cid),
     Ipns(PeerId),


### PR DESCRIPTION
Add a rudimentary implementation of the `/dns` and `/resolve` endpoints; putting it out there already, as due to the similarity of these two endpoints I'm not 100% sure how much we want to "condense" their inner workings.

This upgrades or conformance suite stats from
```
170 passing
50 pending
```
to
```
178 passing
42 pending
```