### PR TITLE
add DHT get and put

### DIFF
--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -525,15 +525,16 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         }
     }
 
-    pub fn dht_get(&mut self, key: Key) -> SubscriptionFuture<KadResult, String> {
+    pub fn dht_get(&mut self, key: Key, quorum: Quorum) -> SubscriptionFuture<KadResult, String> {
         self.kad_subscriptions
-            .create_subscription(self.kademlia.get_record(&key, Quorum::One).into(), None)
+            .create_subscription(self.kademlia.get_record(&key, quorum).into(), None)
     }
 
     pub fn dht_put(
         &mut self,
         key: Key,
         value: Vec<u8>,
+        quorum: Quorum,
     ) -> Result<SubscriptionFuture<KadResult, String>, anyhow::Error> {
         let record = Record {
             key,
@@ -541,7 +542,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
             publisher: None,
             expires: None,
         };
-        match self.kademlia.put_record(record, Quorum::One) {
+        match self.kademlia.put_record(record, quorum) {
             Ok(id) => Ok(self.kad_subscriptions.create_subscription(id.into(), None)),
             Err(e) => {
                 error!("kad: can't put a record: {:?}", e);

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -1,6 +1,6 @@
 use cid::{Cid, Codec};
 use ipfs::{p2p::MultiaddrWithPeerId, Block, Node};
-use libp2p::{multiaddr::Protocol, Multiaddr, PeerId};
+use libp2p::{kad::Quorum, multiaddr::Protocol, Multiaddr, PeerId};
 use multihash::Sha2_256;
 #[cfg(feature = "test_dht_with_go")]
 use rand::prelude::*;
@@ -327,13 +327,14 @@ async fn dht_get_put() {
     let last_index = CHAIN_LEN - if go_node.is_none() { 1 } else { 2 };
 
     let (key, value) = (b"key".to_vec(), b"value".to_vec());
+    let quorum = Quorum::One;
 
     // the last node puts a key+value record
     nodes[last_index]
-        .dht_put(key.clone(), value.clone())
+        .dht_put(key.clone(), value.clone(), quorum)
         .await
         .unwrap();
 
     // and the first node should be able to get it
-    assert_eq!(nodes[0].dht_get(key).await.unwrap(), vec![value]);
+    assert_eq!(nodes[0].dht_get(key, quorum).await.unwrap(), vec![value]);
 }

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -318,3 +318,22 @@ async fn dht_providing() {
         .unwrap()
         .contains(&ids_and_addrs[last_index].0.clone()));
 }
+
+/// Check if Ipfs::{get, put} does its job.
+#[tokio::test(max_threads = 1)]
+async fn dht_get_put() {
+    const CHAIN_LEN: usize = 10;
+    let (nodes, _ids_and_addrs, go_node) = start_nodes_in_chain(CHAIN_LEN).await;
+    let last_index = CHAIN_LEN - if go_node.is_none() { 1 } else { 2 };
+
+    let (key, value) = (b"key".to_vec(), b"value".to_vec());
+
+    // the last node puts a key+value record
+    nodes[last_index]
+        .dht_put(key.clone(), value.clone())
+        .await
+        .unwrap();
+
+    // and the first node should be able to get it
+    assert_eq!(nodes[0].dht_get(key).await.unwrap(), vec![value]);
+}


### PR DESCRIPTION
While I'm looking at the curious Windows crashes with `/dns` and `/resolve`, we can expand territories elsewhere: I've had these functionalities implemented in a branch building one the recently merged PRs; there's no counterpart HTTP endpoints yet, as the conformance tests use functionalities that we're not implementing yet; these features are less interesting for the HTTP API anyway.