### PR TITLE
fix: fs blockstore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rand = { default-features = false, version = "0.7" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, features = ["fs", "rt-threaded", "stream"], version = "0.2" }
+tokio = { default-features = false, features = ["fs", "rt-threaded", "stream", "sync"], version = "0.2" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = ["std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ rand = { default-features = false, version = "0.7" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, features = ["fs", "rt-threaded", "stream", "sync"], version = "0.2" }
+tokio = { default-features = false, features = ["fs", "rt-threaded", "stream", "sync", "blocking"], version = "0.2" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = ["std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -136,7 +136,7 @@ fn main() {
     rt.block_on(async move {
         let opts: IpfsOptions = IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None);
 
-        let (ipfs, task): (Ipfs<ipfs::TestTypes>, _) = UninitializedIpfs::new(opts, None)
+        let (ipfs, task): (Ipfs<ipfs::Types>, _) = UninitializedIpfs::new(opts, None)
             .await
             .start()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,11 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     }
 
     /// Puts a block into the ipfs repo.
+    ///
+    /// # Forget safety
+    ///
+    /// Forgetting the returned future will not result in memory unsafety, but it can
+    /// deadlock other tasks.
     pub async fn put_block(&self, block: Block) -> Result<Cid, Error> {
         self.repo
             .put_block(block)

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -388,7 +388,9 @@ impl BlockStore for FsBlockStore {
         .await
     }
 
-    async fn wipe(&self) {}
+    async fn wipe(&self) {
+        unimplemented!("wipe")
+    }
 }
 
 fn block_path(mut base: PathBuf, cid: &Cid) -> PathBuf {

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -118,10 +118,9 @@ impl BlockStore for FsBlockStore {
     async fn get(&self, cid: &Cid) -> Result<Option<Block>, Error> {
         use std::io::Read;
 
-        match self.write_completion(cid).await {
-            WriteCompletion::KnownBad => return Ok(None),
-            _ => {}
-        };
+        if let WriteCompletion::KnownBad = self.write_completion(cid).await {
+            return Ok(None);
+        }
 
         let path = block_path(self.path.clone(), cid);
 

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -104,7 +104,7 @@ impl BlockStore for FsBlockStore {
         // lot; might be better to just guard with mutex to enforce single task file access.. the
         // current implementation will write over the same file multiple times, each time believing
         // it was the first.
-        Ok((block.cid().to_owned(), retval))
+        Ok((block.cid, retval))
     }
 
     async fn remove(&self, cid: &Cid) -> Result<Result<BlockRm, BlockRmError>, Error> {

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -7,21 +7,25 @@ use cid::Cid;
 use core::convert::TryFrom;
 use futures::lock::Mutex;
 use futures::stream::StreamExt;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use tokio::{
-    fs,
-    io::{AsyncReadExt, AsyncWriteExt},
-};
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+use tokio::{fs, io::AsyncReadExt};
 
 use super::{BlockRm, BlockRmError, RepoCid};
+
+// mod flatfs;
 
 #[derive(Debug)]
 pub struct FsBlockStore {
     path: PathBuf,
     cids: Mutex<HashSet<RepoCid>>,
+    writes: Arc<Mutex<HashMap<Cid, broadcast::Sender<Result<(), ()>>>>>,
     written_bytes: AtomicU64,
 }
 
@@ -31,13 +35,13 @@ impl BlockStore for FsBlockStore {
         FsBlockStore {
             path,
             cids: Default::default(),
+            writes: Arc::new(Mutex::new(HashMap::with_capacity(8))),
             written_bytes: Default::default(),
         }
     }
 
     async fn init(&self) -> Result<(), Error> {
-        let path = self.path.clone();
-        fs::create_dir_all(path).await?;
+        fs::create_dir_all(self.path.clone()).await?;
         Ok(())
     }
 
@@ -92,32 +96,130 @@ impl BlockStore for FsBlockStore {
     }
 
     async fn put(&self, block: Block) -> Result<(Cid, BlockPut), Error> {
-        let path = block_path(self.path.clone(), &block.cid());
+        use std::collections::hash_map::Entry;
+
+        let target_path = block_path(self.path.clone(), &block.cid());
         let cids = &self.cids;
-        let data = block.data();
+        let cid = block.cid;
+        let data = block.data;
 
-        let written = {
-            let mut file = fs::File::create(path).await?;
-            file.write_all(&*data).await?;
-            file.flush().await?;
-            data.len()
+        // why synchronize here? because when we lose the race we cant know if there was someone
+        // else interested in writing this block or not
+
+        let (tx, mut rx, created) = {
+            let mut g = self.writes.lock().await;
+
+            match g.entry(cid.to_owned()) {
+                Entry::Occupied(oe) => {
+                    // someone is already writing this, nice
+                    (oe.get().clone(), oe.get().subscribe(), false)
+                }
+                Entry::Vacant(ve) => {
+                    // we might be the first, or then the block exists already
+                    let (tx, rx) = broadcast::channel(1);
+                    ve.insert(tx.clone());
+                    (tx, rx, true)
+                }
+            }
         };
 
-        let retval = if cids.lock().await.insert(RepoCid(block.cid().to_owned())) {
-            BlockPut::NewBlock
-        } else {
-            BlockPut::Existed
-        };
+        // pick the next writer by chance
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&target_path)
+        {
+            Ok(target) => {
+                // we get to write first!
+                let je = tokio::task::spawn_blocking(move || {
+                    let temp_path = target_path.with_extension("tmp");
 
-        // FIXME: checking if the file existed already while creating complicates this function a
-        // lot; might be better to just guard with mutex to enforce single task file access.. the
-        // current implementation will write over the same file multiple times, each time believing
-        // it was the first.
+                    match write_through_tempfile(target, &target_path, temp_path, &data) {
+                        Ok(()) => Ok::<_, std::io::Error>(data.len()),
+                        Err(e) => {
+                            let _ = std::fs::remove_file(target_path);
+                            Err(e)
+                        }
+                    }
+                })
+                .await;
 
-        self.written_bytes
-            .fetch_add(written as u64, Ordering::SeqCst);
+                let written = match je {
+                    Ok(Ok(written)) => written,
+                    Ok(Err(e)) => {
+                        // write failed but hopefully the target was removed
+                        // no point in trying to remove it now
+                        // ignore if no one is listening
+                        let _ = tx.send(Err(()));
+                        return Err(Error::new(e).context("write failed"));
+                    }
+                    Err(e) => {
+                        // blocking task panicked or the runtime is going down, but we don't know
+                        // if the thread has stopped or not (like not)
+                        return Err(e.into());
+                    }
+                };
 
-        Ok((block.cid, retval))
+                cids.lock().await.insert(RepoCid(cid.to_owned()));
+
+                let _ = tx
+                    .send(Ok(()))
+                    .expect("this cannot fail as we have at least one receiver on stack");
+
+                drop(tx);
+                drop(rx);
+
+                if created {
+                    let mut g = self.writes.lock().await;
+                    // last one turns off the lights; the explicit drops for tx and rx are there
+                    // only to make sure they are dropped before this point; removing the value
+                    // will remove the last sender for any loser waiting on the AlreadyExists arm.
+                    g.remove(&cid).expect("must exist; we created it");
+                }
+
+                self.written_bytes
+                    .fetch_add(written as u64, Ordering::SeqCst);
+
+                Ok((cid, BlockPut::NewBlock))
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                // At least the following cases:
+                // - the block existed already
+                // - the block is being written to and we should await for this to complete
+
+                drop(tx);
+
+                if created {
+                    // need to remove this *before* we start awaiting since otherwise the sender
+                    // would still be alive
+                    let mut g = self.writes.lock().await;
+                    // note comment on Ok(target) arm
+                    g.remove(&cid).expect("must exist; we created it");
+                }
+
+                let message = match rx.recv().await {
+                    Ok(message) => message,
+                    Err(broadcast::RecvError::Closed) => {
+                        // there were never any write intention by any party, and we may have just
+                        // closed the last sender above
+                        Ok(())
+                    }
+                    Err(broadcast::RecvError::Lagged(_)) => {
+                        unreachable!("broadcast channel should only be messaged once here")
+                    }
+                };
+
+                drop(rx);
+
+                if message.is_err() {
+                    // could loop, however if one write failed, the next should probably
+                    Err(anyhow::anyhow!("other concurrent write failed"))
+                } else {
+                    Ok((cid.to_owned(), BlockPut::Existed))
+                }
+            }
+            Err(e) => Err(Error::new(e).context("creating target file failed")),
+        }
     }
 
     async fn remove(&self, cid: &Cid) -> Result<Result<BlockRm, BlockRmError>, Error> {
@@ -150,6 +252,36 @@ fn block_path(mut base: PathBuf, cid: &Cid) -> PathBuf {
     file.push_str(".data");
     base.push(file);
     base
+}
+
+fn write_through_tempfile(
+    target: std::fs::File,
+    target_path: impl AsRef<std::path::Path>,
+    temp_path: impl AsRef<std::path::Path>,
+    data: &[u8],
+) -> Result<(), std::io::Error> {
+    use std::io::Write;
+
+    let mut temp = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&temp_path)?;
+
+    temp.write_all(&*data)?;
+    temp.flush()?;
+
+    // safe default
+    temp.sync_all()?;
+
+    drop(temp);
+    drop(target);
+
+    std::fs::rename(temp_path, target_path)?;
+
+    // FIXME: there should be a directory fsync here as well
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -249,11 +381,11 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 4)]
-    async fn race_to_insert() {
+    #[tokio::test(max_threads = 1)]
+    async fn race_to_insert_new() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();
-        tmp.push("race_to_insert");
+        tmp.push("race_to_insert_new");
         std::fs::remove_dir_all(&tmp).ok();
 
         let single = FsBlockStore::new(tmp.clone());
@@ -264,19 +396,68 @@ mod tests {
         let cid = Cid::try_from("QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL").unwrap();
         let data = hex!("0a0d08021207666f6f6261720a1807");
 
+        let block = Block {
+            cid,
+            data: data.into(),
+        };
+
         let count = 10;
 
-        let barrier = Arc::new(tokio::sync::Barrier::new(count));
+        let (writes, existing) = race_to_insert_scenario(count, block, &single).await;
+
+        let single = Arc::try_unwrap(single).unwrap();
+        assert_eq!(single.written_bytes.into_inner(), 15);
+
+        assert_eq!(writes, 1);
+        assert_eq!(existing, count - 1);
+    }
+
+    #[tokio::test(max_threads = 1)]
+    async fn race_to_insert_with_existing() {
+        // FIXME: why not tempdir?
+        let mut tmp = temp_dir();
+        tmp.push("race_to_insert_existing");
+        std::fs::remove_dir_all(&tmp).ok();
+
+        let single = FsBlockStore::new(tmp.clone());
+        single.init().await.unwrap();
+
+        let single = Arc::new(single);
+
+        let cid = Cid::try_from("QmRgutAxd8t7oGkSm4wmeuByG6M51wcTso6cubDdQtuEfL").unwrap();
+        let data = hex!("0a0d08021207666f6f6261720a1807");
 
         let block = Block {
             cid,
             data: data.into(),
         };
 
+        single.put(block.clone()).await.unwrap();
+
+        assert_eq!(single.written_bytes.load(Ordering::SeqCst), 15);
+
+        let count = 10;
+
+        let (writes, existing) = race_to_insert_scenario(count, block, &single).await;
+
+        let single = Arc::try_unwrap(single).unwrap();
+        assert_eq!(single.written_bytes.into_inner(), 15);
+
+        assert_eq!(writes, 0);
+        assert_eq!(existing, count);
+    }
+
+    async fn race_to_insert_scenario(
+        count: usize,
+        block: Block,
+        blockstore: &Arc<FsBlockStore>,
+    ) -> (usize, usize) {
+        let barrier = Arc::new(tokio::sync::Barrier::new(count));
+
         let join_handles = (0..count)
             .map(|_| {
                 tokio::spawn({
-                    let bs = Arc::clone(&single);
+                    let bs = Arc::clone(&blockstore);
                     let barrier = Arc::clone(&barrier);
                     let block = block.clone();
                     async move {
@@ -287,19 +468,20 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let mut successes = 0;
+        let mut writes = 0usize;
+        let mut existing = 0usize;
+
         for jh in join_handles {
             let res = jh.await;
 
             match res {
-                Ok(_) => successes += 1,
-                Err(e) => println!("{}", e),
+                Ok(Ok((_, BlockPut::NewBlock))) => writes += 1,
+                Ok(Ok((_, BlockPut::Existed))) => existing += 1,
+                Ok(Err(e)) => println!("joinhandle err: {}", e),
+                _ => unreachable!("join error"),
             }
         }
 
-        let single = Arc::try_unwrap(single).unwrap();
-        assert_eq!(single.written_bytes.into_inner(), 15);
-
-        assert_eq!(successes, count);
+        (writes, existing)
     }
 }

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -303,8 +303,13 @@ impl BlockStore for FsBlockStore {
 }
 
 fn block_path(mut base: PathBuf, cid: &Cid) -> PathBuf {
-    // this is ascii always
-    let mut file = cid.to_string();
+    // this is ascii always, and wasteful until we can drop the cid for multihash ... which is
+    // probably soon, we just need turn /refs/local to use /pin/list.
+    let mut file = if cid.version() == cid::Version::V1 {
+        cid.to_string()
+    } else {
+        Cid::new_v1(cid.codec(), cid.hash().to_owned()).to_string()
+    };
 
     // second-to-last/2
     let start = file.len() - 3;


### PR DESCRIPTION
This fixes the racing writers issue which the implementation has had for a long time; multiple writers would come in and all would write over the same file, multiple times, allowing readers to observe partial writes in the meantime. This covers most of the changes.

In addition ipfs-http now uses the file block store. There was some transient macosx failures.

### Checklist (can be deleted from PR description once items are checked)

- [x] **New** code is “linted” i.e. code formatting via rustfmt and language idioms via clippy
- [x] There are no extraneous changes like formatting, line reordering, etc. Keep the patch sizes small!
- [x] There are functional and/or unit tests written, and they are passing
- [x] There is suitable documentation. In our case, this means:
    - [ ] Each command has a usage example and API specification
    - [ ] Rustdoc tests are passing on all code-level comments
    - [ ] Differences between Rust’s IPFS implementation and the Go or JS implementations are explained