### PR TITLE
This PR uses libp2p dns, so that /dns4 and /dns6 multiaddrs can be dialed.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "libp2p-core-derive",
+ "libp2p-dns",
  "libp2p-floodsub",
  "libp2p-identify",
  "libp2p-kad",
@@ -1394,6 +1395,17 @@ checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "libp2p-dns"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fce8769cfe677a567d2677dc02a9e5be27a24acf1ff78a59cef425caae009a6a"
+dependencies = [
+ "futures",
+ "libp2p-core",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ domain-resolv = { default-features = false, version = "0.5" }
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
 ipfs-unixfs = { path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mdns-tokio", "mplex", "noise", "ping", "yamux"], version = "0.24" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mdns-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.24" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,7 +338,7 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
         }));
 
         let swarm_options = SwarmOptions::from(&self.options);
-        let swarm = create_swarm(swarm_options, ipfs.clone()).await;
+        let swarm = create_swarm(swarm_options, ipfs.clone()).await?;
 
         let fut = IpfsFuture {
             repo_events: repo_events.fuse(),

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -3,6 +3,7 @@ use crate::{Ipfs, IpfsOptions, IpfsTypes};
 use libp2p::identity::Keypair;
 use libp2p::Swarm;
 use libp2p::{Multiaddr, PeerId};
+use std::io;
 use tracing::Span;
 
 mod addr;
@@ -46,11 +47,11 @@ impl From<&IpfsOptions> for SwarmOptions {
 pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     options: SwarmOptions,
     ipfs: Ipfs<TIpfsTypes>,
-) -> TSwarm<TIpfsTypes> {
+) -> io::Result<TSwarm<TIpfsTypes>> {
     let peer_id = options.peer_id.clone();
 
     // Set up an encrypted TCP transport over the Mplex protocol.
-    let transport = transport::build_transport(options.keypair.clone());
+    let transport = transport::build_transport(options.keypair.clone())?;
 
     let swarm_span = ipfs.0.span.clone();
 
@@ -65,7 +66,7 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     // Listen on all interfaces and whatever port the OS assigns
     Swarm::listen_on(&mut swarm, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
-    swarm
+    Ok(swarm)
 }
 
 struct SpannedExecutor(Span);

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -290,7 +290,7 @@ mod tests {
     fn mk_transport() -> (PeerId, TTransport) {
         let key = Keypair::generate_ed25519();
         let peer_id = key.public().into_peer_id();
-        let transport = build_transport(key);
+        let transport = build_transport(key).unwrap();
         (peer_id, transport)
     }
 }

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -2,13 +2,14 @@ use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::boxed::Boxed;
 use libp2p::core::transport::upgrade::Version;
 use libp2p::core::upgrade::SelectUpgrade;
+use libp2p::dns::DnsConfig;
 use libp2p::identity;
 use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseConfig};
 use libp2p::tcp::TokioTcpConfig;
 use libp2p::yamux::Config as YamuxConfig;
 use libp2p::{PeerId, Transport};
-use std::io::{Error, ErrorKind};
+use std::io::{self, Error, ErrorKind};
 use std::time::Duration;
 
 /// Transport type.
@@ -17,14 +18,13 @@ pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox), Error>;
 /// Builds the transport that serves as a common ground for all connections.
 ///
 /// Set up an encrypted TCP transport over the Mplex protocol.
-pub fn build_transport(keypair: identity::Keypair) -> TTransport {
+pub fn build_transport(keypair: identity::Keypair) -> io::Result<TTransport> {
     let xx_keypair = noise::Keypair::<noise::X25519Spec>::new()
         .into_authentic(&keypair)
         .unwrap();
     let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
 
-    TokioTcpConfig::new()
-        .nodelay(true)
+    Ok(DnsConfig::new(TokioTcpConfig::new().nodelay(true))?
         .upgrade(Version::V1)
         .authenticate(noise_config)
         .multiplex(SelectUpgrade::new(
@@ -34,5 +34,5 @@ pub fn build_transport(keypair: identity::Keypair) -> TTransport {
         .timeout(Duration::from_secs(20))
         .map(|(peer_id, muxer), _| (peer_id, StreamMuxerBox::new(muxer)))
         .map_err(|err| Error::new(ErrorKind::Other, err))
-        .boxed()
+        .boxed())
 }


### PR DESCRIPTION
Not quite sure how to best test this without having a test that uses the dns of the CI server. Any ideas?