### PR TITLE
add go-ipfs DHT interop tests to the CI, enable jsipfs interop tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
       CARGO_INCREMENTAL: 0
       LLVM_CONFIG_PATH: /usr/local/opt/llvm/bin/llvm-config
       NDK_HOME: /usr/local/lib/android/sdk/ndk-bundle
+      GO_IPFS_PATH: /home/runner/work/rust-ipfs/rust-ipfs/go-ipfs/ipfs
       VCPKGRS_DYNAMIC: 1
       DEBUG: ipfsd-ctl:* # enables all debug output from javascript 'debug' lib used by js-ipfsd-ctl
 
@@ -89,6 +90,12 @@ jobs:
       if: matrix.platform.host == 'macos-latest'
       run: brew install llvm openssl
 
+    - name: Download go-ipfs on Linux
+      if: matrix.platform.host == 'ubuntu-latest'
+      run: |
+        curl -L https://github.com/ipfs/go-ipfs/releases/download/v0.6.0/go-ipfs_v0.6.0_linux-amd64.tar.gz --output go_ipfs.tar.gz
+        tar -xf go_ipfs.tar.gz
+
     - name: Install dependencies windows (openssl)
       uses: lukka/run-vcpkg@v3.3
       id: windows-runvcpkg
@@ -112,6 +119,10 @@ jobs:
     - name: Build (others)
       if: matrix.platform.cross == false
       run: cargo build --locked --workspace --all-targets
+
+    - name: Run interop DHT tests with go-ipfs
+      if: matrix.platform.host == 'ubuntu-latest'
+      run: cargo test --features=test_dht_with_go dht
 
     - name: Setup conformance tests (non-cross targets)
       if: matrix.platform.cross == false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,7 @@ jobs:
 
     - name: Run interop DHT tests with go-ipfs
       if: matrix.platform.host == 'ubuntu-latest'
-      run: cargo test --features=test_dht_with_go dht
+      run: cargo test --features=test_go_interop dht
 
     - name: Setup conformance tests (non-cross targets)
       if: matrix.platform.cross == false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 [features]
 default = []
 nightly = []
-test_dht_with_go = []
+test_go_interop = []
 
 [dependencies]
 anyhow = { default-features = false, version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 default = []
 nightly = []
 test_go_interop = []
+test_js_interop = []
 
 [dependencies]
 anyhow = { default-features = false, version = "1.0" }

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -1,17 +1,8 @@
-#[cfg(feature = "test_go_interop")]
-pub mod go {
-    pub use super::common::*;
-}
-
-#[cfg(feature = "test_js_interop")]
-pub mod js {
-    pub use super::common::*;
-}
+#[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
+pub use common::ForeignNode;
 
 #[cfg(all(not(feature = "test_go_interop"), not(feature = "test_js_interop")))]
-pub mod none {
-    pub struct ForeignNode;
-}
+pub struct ForeignNode;
 
 #[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
 pub mod common {

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -1,110 +1,106 @@
 #[cfg(feature = "test_go_interop")]
-use libp2p::{Multiaddr, PeerId};
-#[cfg(feature = "test_go_interop")]
-use rand::prelude::*;
-#[cfg(feature = "test_go_interop")]
-use serde::Deserialize;
-#[cfg(feature = "test_go_interop")]
-use std::time::Duration;
-#[cfg(feature = "test_go_interop")]
-use std::{
-    env, fs,
-    path::PathBuf,
-    process::{Child, Command, Stdio},
-    thread,
-};
+pub mod go {
+    use libp2p::{Multiaddr, PeerId};
+    use rand::prelude::*;
+    use serde::Deserialize;
+    use std::time::Duration;
+    use std::{
+        env, fs,
+        path::PathBuf,
+        process::{Child, Command, Stdio},
+        thread,
+    };
 
-#[cfg(feature = "test_go_interop")]
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "PascalCase")]
-pub struct GoNodeId {
-    #[serde(rename = "ID")]
-    pub id: String,
-    #[serde(skip)]
-    pub public_key: String,
-    pub addresses: Vec<String>,
-    #[serde(skip)]
-    agent_version: String,
-    #[serde(skip)]
-    protocol_version: String,
-}
+    #[derive(Deserialize, Debug)]
+    #[serde(rename_all = "PascalCase")]
+    pub struct GoNodeId {
+        #[serde(rename = "ID")]
+        pub id: String,
+        #[serde(skip)]
+        pub public_key: String,
+        pub addresses: Vec<String>,
+        #[serde(skip)]
+        agent_version: String,
+        #[serde(skip)]
+        protocol_version: String,
+    }
 
-#[cfg(feature = "test_go_interop")]
-pub struct ForeignNode {
-    dir: PathBuf,
-    daemon: Child,
-    pub id: PeerId,
-    pub addrs: Vec<Multiaddr>,
-}
+    pub struct ForeignNode {
+        dir: PathBuf,
+        daemon: Child,
+        pub id: PeerId,
+        pub addrs: Vec<Multiaddr>,
+    }
 
-impl ForeignNode {
-    #[cfg(feature = "test_go_interop")]
-    pub fn new() -> ForeignNode {
-        // GO_IPFS_PATH should point to the location of the go-ipfs binary
-        let go_ipfs_path = env::vars()
-            .find(|(key, _val)| key == "GO_IPFS_PATH")
-            .expect("the GO_IPFS_PATH environment variable was not found")
-            .1;
+    impl ForeignNode {
+        pub fn new() -> ForeignNode {
+            // GO_IPFS_PATH should point to the location of the go-ipfs binary
+            let go_ipfs_path = env::vars()
+                .find(|(key, _val)| key == "GO_IPFS_PATH")
+                .expect("the GO_IPFS_PATH environment variable was not found")
+                .1;
 
-        let mut tmp_dir = env::temp_dir();
-        let mut rng = rand::thread_rng();
-        tmp_dir.push(&format!("ipfs_test_{}", rng.gen::<u64>()));
-        let _ = fs::create_dir(&tmp_dir);
+            let mut tmp_dir = env::temp_dir();
+            let mut rng = rand::thread_rng();
+            tmp_dir.push(&format!("ipfs_test_{}", rng.gen::<u64>()));
+            let _ = fs::create_dir(&tmp_dir);
 
-        Command::new(&go_ipfs_path)
-            .env("IPFS_PATH", &tmp_dir)
-            .arg("init")
-            .arg("-p")
-            .arg("test")
-            .arg("--bits")
-            .arg("2048")
-            .stdout(Stdio::null())
-            .status()
-            .unwrap();
+            Command::new(&go_ipfs_path)
+                .env("IPFS_PATH", &tmp_dir)
+                .arg("init")
+                .arg("-p")
+                .arg("test")
+                .arg("--bits")
+                .arg("2048")
+                .stdout(Stdio::null())
+                .status()
+                .unwrap();
 
-        let daemon = Command::new(&go_ipfs_path)
-            .env("IPFS_PATH", &tmp_dir)
-            .arg("daemon")
-            .stdout(Stdio::null())
-            .spawn()
-            .unwrap();
+            let daemon = Command::new(&go_ipfs_path)
+                .env("IPFS_PATH", &tmp_dir)
+                .arg("daemon")
+                .stdout(Stdio::null())
+                .spawn()
+                .unwrap();
 
-        // give the go-ipfs daemon a little bit of time to start
-        thread::sleep(Duration::from_secs(1));
+            // give the go-ipfs daemon a little bit of time to start
+            thread::sleep(Duration::from_secs(1));
 
-        let go_id = Command::new(&go_ipfs_path)
-            .env("IPFS_PATH", &tmp_dir)
-            .arg("id")
-            .output()
-            .unwrap()
-            .stdout;
+            let go_id = Command::new(&go_ipfs_path)
+                .env("IPFS_PATH", &tmp_dir)
+                .arg("id")
+                .output()
+                .unwrap()
+                .stdout;
 
-        let go_id_stdout = String::from_utf8_lossy(&go_id);
-        let go_id: GoNodeId = serde_json::de::from_str(&go_id_stdout).unwrap();
+            let go_id_stdout = String::from_utf8_lossy(&go_id);
+            let go_id: GoNodeId = serde_json::de::from_str(&go_id_stdout).unwrap();
 
-        let id = go_id.id.parse().unwrap();
-        let addrs = go_id
-            .addresses
-            .into_iter()
-            .map(|a| a.parse().unwrap())
-            .collect();
+            let id = go_id.id.parse().unwrap();
+            let addrs = go_id
+                .addresses
+                .into_iter()
+                .map(|a| a.parse().unwrap())
+                .collect();
 
-        ForeignNode {
-            dir: tmp_dir,
-            daemon,
-            id,
-            addrs,
+            ForeignNode {
+                dir: tmp_dir,
+                daemon,
+                id,
+                addrs,
+            }
+        }
+    }
+
+    impl Drop for ForeignNode {
+        fn drop(&mut self) {
+            let _ = self.daemon.kill();
+            let _ = fs::remove_dir_all(&self.dir);
         }
     }
 }
 
 #[cfg(not(feature = "test_go_interop"))]
-pub struct ForeignNode;
-
-#[cfg(feature = "test_go_interop")]
-impl Drop for ForeignNode {
-    fn drop(&mut self) {
-        let _ = self.daemon.kill();
-        let _ = fs::remove_dir_all(&self.dir);
-    }
+pub mod none {
+    pub struct ForeignNode;
 }

--- a/tests/common/interop_go.rs
+++ b/tests/common/interop_go.rs
@@ -1,10 +1,10 @@
-#[cfg(feature = "test_dht_with_go")]
+#[cfg(feature = "test_go_interop")]
 use rand::prelude::*;
-#[cfg(feature = "test_dht_with_go")]
+#[cfg(feature = "test_go_interop")]
 use serde::Deserialize;
-#[cfg(feature = "test_dht_with_go")]
+#[cfg(feature = "test_go_interop")]
 use std::time::Duration;
-#[cfg(feature = "test_dht_with_go")]
+#[cfg(feature = "test_go_interop")]
 use std::{
     env, fs,
     path::PathBuf,
@@ -12,7 +12,7 @@ use std::{
     thread,
 };
 
-#[cfg(feature = "test_dht_with_go")]
+#[cfg(feature = "test_go_interop")]
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "PascalCase")]
 pub struct GoNodeId {
@@ -27,7 +27,7 @@ pub struct GoNodeId {
     protocol_version: String,
 }
 
-#[cfg(feature = "test_dht_with_go")]
+#[cfg(feature = "test_go_interop")]
 pub struct GoIpfsNode {
     daemon: Child,
     pub id: GoNodeId,
@@ -35,8 +35,8 @@ pub struct GoIpfsNode {
 }
 
 impl GoIpfsNode {
-    #[cfg(feature = "test_dht_with_go")]
-    pub fn new() -> GoIpfsNode {
+    #[cfg(feature = "test_go_interop")]
+    fn new() -> GoIpfsNode {
         // GO_IPFS_PATH should point to the location of the go-ipfs binary
         let go_ipfs_path = env::vars()
             .find(|(key, _val)| key == "GO_IPFS_PATH")
@@ -87,10 +87,10 @@ impl GoIpfsNode {
     }
 }
 
-#[cfg(not(feature = "test_dht_with_go"))]
+#[cfg(not(feature = "test_go_interop"))]
 pub struct GoIpfsNode;
 
-#[cfg(feature = "test_dht_with_go")]
+#[cfg(feature = "test_go_interop")]
 impl Drop for GoIpfsNode {
     fn drop(&mut self) {
         let _ = self.daemon.kill();

--- a/tests/common/interop_go.rs
+++ b/tests/common/interop_go.rs
@@ -1,0 +1,99 @@
+#[cfg(feature = "test_dht_with_go")]
+use rand::prelude::*;
+#[cfg(feature = "test_dht_with_go")]
+use serde::Deserialize;
+#[cfg(feature = "test_dht_with_go")]
+use std::time::Duration;
+#[cfg(feature = "test_dht_with_go")]
+use std::{
+    env, fs,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    thread,
+};
+
+#[cfg(feature = "test_dht_with_go")]
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+pub struct GoNodeId {
+    #[serde(rename = "ID")]
+    pub id: String,
+    #[serde(skip)]
+    pub public_key: String,
+    pub addresses: Vec<String>,
+    #[serde(skip)]
+    agent_version: String,
+    #[serde(skip)]
+    protocol_version: String,
+}
+
+#[cfg(feature = "test_dht_with_go")]
+pub struct GoIpfsNode {
+    daemon: Child,
+    pub id: GoNodeId,
+    dir: PathBuf,
+}
+
+impl GoIpfsNode {
+    #[cfg(feature = "test_dht_with_go")]
+    pub fn new() -> GoIpfsNode {
+        // GO_IPFS_PATH should point to the location of the go-ipfs binary
+        let go_ipfs_path = env::vars()
+            .find(|(key, _val)| key == "GO_IPFS_PATH")
+            .expect("the GO_IPFS_PATH environment variable was not found")
+            .1;
+
+        let mut tmp_dir = env::temp_dir();
+        let mut rng = rand::thread_rng();
+        tmp_dir.push(&format!("ipfs_test_{}", rng.gen::<u64>()));
+        let _ = fs::create_dir(&tmp_dir);
+
+        Command::new(&go_ipfs_path)
+            .env("IPFS_PATH", &tmp_dir)
+            .arg("init")
+            .arg("-p")
+            .arg("test")
+            .arg("--bits")
+            .arg("2048")
+            .stdout(Stdio::null())
+            .status()
+            .unwrap();
+
+        let go_daemon = Command::new(&go_ipfs_path)
+            .env("IPFS_PATH", &tmp_dir)
+            .arg("daemon")
+            .stdout(Stdio::null())
+            .spawn()
+            .unwrap();
+
+        // give the go-ipfs daemon a little bit of time to start
+        thread::sleep(Duration::from_secs(1));
+
+        let go_id = Command::new(&go_ipfs_path)
+            .env("IPFS_PATH", &tmp_dir)
+            .arg("id")
+            .output()
+            .unwrap()
+            .stdout;
+
+        let go_id_stdout = String::from_utf8_lossy(&go_id);
+        let go_id: GoNodeId = serde_json::de::from_str(&go_id_stdout).unwrap();
+
+        GoIpfsNode {
+            daemon: go_daemon,
+            id: go_id,
+            dir: tmp_dir,
+        }
+    }
+}
+
+#[cfg(not(feature = "test_dht_with_go"))]
+pub struct GoIpfsNode;
+
+#[cfg(feature = "test_dht_with_go")]
+impl Drop for GoIpfsNode {
+    fn drop(&mut self) {
+        let _ = self.daemon.kill();
+        let _ = fs::remove_dir_all(&self.dir);
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,1 +1,1 @@
-pub mod interop_go;
+pub mod interop;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,1 @@
+pub mod interop_go;

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -5,10 +5,8 @@ use tokio::time::timeout;
 
 #[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
 mod common;
-#[cfg(feature = "test_go_interop")]
-use common::interop::go::ForeignNode;
-#[cfg(feature = "test_js_interop")]
-use common::interop::js::ForeignNode;
+#[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
+use common::interop::ForeignNode;
 
 // Make sure two instances of ipfs can be connected by `Multiaddr`.
 #[tokio::test(max_threads = 1)]

--- a/tests/connect_two.rs
+++ b/tests/connect_two.rs
@@ -3,11 +3,22 @@ use libp2p::{multiaddr::Protocol, Multiaddr};
 use std::time::Duration;
 use tokio::time::timeout;
 
+#[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
+mod common;
+#[cfg(feature = "test_go_interop")]
+use common::interop::go::ForeignNode;
+#[cfg(feature = "test_js_interop")]
+use common::interop::js::ForeignNode;
+
 // Make sure two instances of ipfs can be connected by `Multiaddr`.
 #[tokio::test(max_threads = 1)]
 async fn connect_two_nodes_by_addr() {
     let node_a = Node::new("a").await;
+
+    #[cfg(all(not(feature = "test_go_interop"), not(feature = "test_js_interop")))]
     let node_b = Node::new("b").await;
+    #[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
+    let node_b = ForeignNode::new();
 
     let (_, mut b_addrs) = node_b.identity().await.unwrap();
     let b_addr = b_addrs.pop().unwrap();

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -38,7 +38,7 @@ async fn find_peer_local() {
 }
 
 // starts the specified number of rust IPFS nodes connected in a chain.
-#[cfg(not(feature = "test_dht_with_go"))]
+#[cfg(not(feature = "test_go_interop"))]
 async fn start_nodes_in_chain(
     count: usize,
 ) -> (Vec<Node>, Vec<(PeerId, Multiaddr)>, Option<GoIpfsNode>) {
@@ -84,12 +84,12 @@ async fn start_nodes_in_chain(
     (nodes, ids_and_addrs, None)
 }
 
-// most of the setup is the same as in the not(feature = "test_dht_with_go") case, with
+// most of the setup is the same as in the not(feature = "test_go_interop") case, with
 // the addition of a go-ipfs node in the middle of the chain; the first half of the chain
 // learns about the next peer, the go-ipfs node being the last one, and the second half
 // learns about the previous peer, the go-ipfs node being the first one; a visualization:
 // r[0] > r[1] > .. > go < .. < r[count - 3] < r[count - 2]
-#[cfg(feature = "test_dht_with_go")]
+#[cfg(feature = "test_go_interop")]
 async fn start_nodes_in_chain(
     count: usize,
 ) -> (Vec<Node>, Vec<(PeerId, Multiaddr)>, Option<GoIpfsNode>) {

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -7,7 +7,7 @@ use tokio::time::timeout;
 use std::{convert::TryInto, time::Duration};
 
 mod common;
-use common::interop_go::GoIpfsNode;
+use common::interop::ForeignNode;
 
 fn strip_peer_id(addr: Multiaddr) -> Multiaddr {
     let MultiaddrWithPeerId { multiaddr, .. } = addr.try_into().unwrap();
@@ -41,7 +41,7 @@ async fn find_peer_local() {
 #[cfg(not(feature = "test_go_interop"))]
 async fn start_nodes_in_chain(
     count: usize,
-) -> (Vec<Node>, Vec<(PeerId, Multiaddr)>, Option<GoIpfsNode>) {
+) -> (Vec<Node>, Vec<(PeerId, Multiaddr)>, Option<ForeignNode>) {
     // fire up count nodes and register their PeerIds and
     // Multiaddrs (without the PeerId) for add_peer purposes
     let mut nodes = Vec::with_capacity(count);
@@ -92,8 +92,8 @@ async fn start_nodes_in_chain(
 #[cfg(feature = "test_go_interop")]
 async fn start_nodes_in_chain(
     count: usize,
-) -> (Vec<Node>, Vec<(PeerId, Multiaddr)>, Option<GoIpfsNode>) {
-    let go_node = GoIpfsNode::new();
+) -> (Vec<Node>, Vec<(PeerId, Multiaddr)>, Option<ForeignNode>) {
+    let go_node = ForeignNode::new();
 
     let mut nodes = Vec::with_capacity(count - 1);
     let mut ids_and_addrs = Vec::with_capacity(count - 1);
@@ -109,8 +109,8 @@ async fn start_nodes_in_chain(
         ids_and_addrs.push((id, addr));
     }
 
-    let go_peer_id = go_node.id.id.parse::<PeerId>().unwrap();
-    let go_addr = strip_peer_id(go_node.id.addresses[0].parse::<Multiaddr>().unwrap());
+    let go_peer_id = go_node.id.clone();
+    let go_addr = strip_peer_id(go_node.addrs[0].clone());
 
     // skip the last index again, as there is a go node without one bound to it
     for i in 0..(count - 1) {

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -7,12 +7,7 @@ use tokio::time::timeout;
 use std::{convert::TryInto, time::Duration};
 
 mod common;
-#[cfg(feature = "test_go_interop")]
-use common::interop::go::ForeignNode;
-#[cfg(feature = "test_js_interop")]
-use common::interop::js::ForeignNode;
-#[cfg(all(not(feature = "test_go_interop"), not(feature = "test_js_interop")))]
-use common::interop::none::ForeignNode;
+use common::interop::ForeignNode;
 
 fn strip_peer_id(addr: Multiaddr) -> Multiaddr {
     let MultiaddrWithPeerId { multiaddr, .. } = addr.try_into().unwrap();

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -7,7 +7,10 @@ use tokio::time::timeout;
 use std::{convert::TryInto, time::Duration};
 
 mod common;
-use common::interop::ForeignNode;
+#[cfg(feature = "test_go_interop")]
+use common::interop::go::ForeignNode;
+#[cfg(not(feature = "test_go_interop"))]
+use common::interop::none::ForeignNode;
 
 fn strip_peer_id(addr: Multiaddr) -> Multiaddr {
     let MultiaddrWithPeerId { multiaddr, .. } = addr.try_into().unwrap();


### PR DESCRIPTION
Initially this PR only added `go-ipfs` interop DHT tests to the Linux CI run. Even if that functionality was a tiny amount of code, I might have gotten lost in the moment and gone a bit too far with extending this PR to also introduce a `jsipfs` interop functionality :sweat_smile: - I can split it out if that's desirable.

In any case, the individual commits describe specific changes; the diff seems big, but it's mostly moving stuff around, as almost all of the `go-ipfs` interop code is compatible with `jsipfs`. The `jsipfs` interop tests are not run in the CI yet.