### PR TITLE
Configurable listening addrs

### DIFF
--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -137,7 +137,8 @@ fn main() {
     let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
-        let opts: IpfsOptions = IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None);
+        let opts: IpfsOptions =
+            IpfsOptions::new(home.clone(), keypair, Vec::new(), false, None, Vec::new());
 
         let (ipfs, task): (Ipfs<ipfs::Types>, _) = UninitializedIpfs::new(opts, None)
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1203,7 +1203,7 @@ impl<TRepoTypes: RepoTypes> IpfsFuture<TRepoTypes> {
                 > 0
         {
             if let Some(sender) = ret {
-                let _ = sender.send(Err(format_err!("Cannot start listening to unspecified address when there are pending specified addresses awaiting")));
+                let _ = sender.send(Err(format_err!("Cannot start listening to an unspecified address when there are pending specified addresses")));
             }
             return;
         }
@@ -1211,7 +1211,7 @@ impl<TRepoTypes: RepoTypes> IpfsFuture<TRepoTypes> {
         match self.listening_addresses.entry(addr) {
             Entry::Occupied(oe) => {
                 if let Some(sender) = ret {
-                    let _ = sender.send(Err(format_err!("Already adding a possibly ephemeral multiaddr, wait first one to resolve before adding next: {}", oe.key())));
+                    let _ = sender.send(Err(format_err!("Already adding a possibly ephemeral Multiaddr; wait for the first one to resolve before adding others: {}", oe.key())));
                 }
             }
             Entry::Vacant(ve) => match Swarm::listen_on(&mut self.swarm, ve.key().to_owned()) {


### PR DESCRIPTION
This PR allows us to specify the desired listening address(es) of the node. For now, these addresses are just additions to the current randomly assigned listening address, as I'm not sure what to pick as the default; once we know this, the only change needed (besides the default listening addresses being put in the config) is to remove the following line from `p2p::create_swarm`:
```
// Listen on all interfaces and whatever port the OS assigns
Swarm::listen_on(&mut swarm, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
```
Another question is how to handle a situation where one/all of the supplied addresses can't be listened on:
- refuse to start?
- assign a random different address?
- only log errors if at least one works?

This is currently unresolved, but since the PR preserves the current behavior, this is a concern that needs to be handled in the aforementioned later follow-up.

Cc https://github.com/rs-ipfs/rust-ipfs/issues/173.