### PR TITLE
Improve multi-node tests

### DIFF
--- a/src/dag.rs
+++ b/src/dag.rs
@@ -596,7 +596,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn test_resolve_root_cid() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data = make_ipld!([1, 2, 3]);
         let cid = dag.put(data.clone(), Codec::DagCBOR).await.unwrap();
@@ -606,7 +606,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn test_resolve_array_elem() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data = make_ipld!([1, 2, 3]);
         let cid = dag.put(data.clone(), Codec::DagCBOR).await.unwrap();
@@ -619,7 +619,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn test_resolve_nested_array_elem() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data = make_ipld!([1, [2], 3,]);
         let cid = dag.put(data, Codec::DagCBOR).await.unwrap();
@@ -632,7 +632,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn test_resolve_object_elem() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data = make_ipld!({
             "key": false,
@@ -647,7 +647,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn test_resolve_cid_elem() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let data1 = make_ipld!([1]);
         let cid1 = dag.put(data1, Codec::DagCBOR).await.unwrap();
@@ -841,7 +841,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn resolve_through_link() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let ipld = make_ipld!([1]);
         let cid1 = dag.put(ipld, Codec::DagCBOR).await.unwrap();
@@ -870,7 +870,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn fail_resolving_first_segment() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let ipld = make_ipld!([1]);
         let cid1 = dag.put(ipld, Codec::DagCBOR).await.unwrap();
@@ -886,7 +886,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn fail_resolving_last_segment() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
         let ipld = make_ipld!([1]);
         let cid1 = dag.put(ipld, Codec::DagCBOR).await.unwrap();
@@ -902,7 +902,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn fail_resolving_through_file() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
 
         let mut adder = ipfs_unixfs::file::adder::FileAdder::default();
         let (mut blocks, _) = adder.push(b"foobar\n");
@@ -934,7 +934,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn fail_resolving_through_dir() {
-        let Node { ipfs, bg_task: _bt } = Node::new("test_node").await;
+        let Node { ipfs, .. } = Node::new("test_node").await;
 
         let mut adder = ipfs_unixfs::file::adder::FileAdder::default();
         let (mut blocks, _) = adder.push(b"foobar\n");

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -369,7 +369,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn all_refs_from_root() {
-        let Node { ipfs, bg_task: _bt } = preloaded_testing_ipfs().await;
+        let Node { ipfs, .. } = preloaded_testing_ipfs().await;
 
         let (root, dag0, unixfs0, dag1, unixfs1) = (
             // this is the dag with content: [dag0, unixfs0, dag1, unixfs1]
@@ -416,7 +416,7 @@ mod tests {
 
     #[tokio::test(max_threads = 1)]
     async fn all_unique_refs_from_root() {
-        let Node { ipfs, bg_task: _bt } = preloaded_testing_ipfs().await;
+        let Node { ipfs, .. } = preloaded_testing_ipfs().await;
 
         let (root, dag0, unixfs0, dag1, unixfs1) = (
             // this is the dag with content: [dag0, unixfs0, dag1, unixfs1]

--- a/tests/bitswap_cleanup.rs
+++ b/tests/bitswap_cleanup.rs
@@ -1,39 +1,33 @@
-use ipfs::Node;
+use std::time::Duration;
 use tokio::time;
 
-async fn wait(millis: u64) {
-    time::delay_for(std::time::Duration::from_millis(millis)).await;
-}
+mod common;
+use common::{spawn_connected_nodes, Topology};
 
 // Ensure that the Bitswap object doesn't leak.
 #[tokio::test(max_threads = 1)]
 async fn check_bitswap_cleanups() {
-    // create a few nodes
-    let node_a = Node::new("a").await;
-    let node_b = Node::new("b").await;
-    let node_c = Node::new("c").await;
+    // create a few nodes and connect the first one to others
+    let mut nodes = spawn_connected_nodes(3, Topology::Star).await;
 
-    // connect node a to node b...
-    let (_, mut b_addrs) = node_b.identity().await.unwrap();
-    node_a.connect(b_addrs.pop().unwrap()).await.unwrap();
-    let bitswap_peers = node_a.get_bitswap_peers().await.unwrap();
-    assert_eq!(bitswap_peers.len(), 1);
-
-    // ...and to node c
-    let (_, mut c_addrs) = node_c.identity().await.unwrap();
-    node_a.connect(c_addrs.pop().unwrap()).await.unwrap();
-    let bitswap_peers = node_a.get_bitswap_peers().await.unwrap();
+    let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
     assert_eq!(bitswap_peers.len(), 2);
 
-    // node b says goodbye; check the number of bitswap peers
-    node_b.shutdown().await;
-    wait(200).await;
-    let bitswap_peers = node_a.get_bitswap_peers().await.unwrap();
+    // last node says goodbye; check the number of bitswap peers
+    if let Some(node) = nodes.pop() {
+        node.shutdown().await;
+        time::delay_for(Duration::from_millis(200)).await;
+    }
+
+    let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
     assert_eq!(bitswap_peers.len(), 1);
 
-    // node c says goodbye; check the number of bitswap peers
-    node_c.shutdown().await;
-    wait(200).await;
-    let bitswap_peers = node_a.get_bitswap_peers().await.unwrap();
+    // another node says goodbye; check the number of bitswap peers
+    if let Some(node) = nodes.pop() {
+        node.shutdown().await;
+        time::delay_for(Duration::from_millis(200)).await;
+    }
+
+    let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
     assert!(bitswap_peers.is_empty());
 }

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -2,6 +2,7 @@
 pub use common::ForeignNode;
 
 #[cfg(all(not(feature = "test_go_interop"), not(feature = "test_js_interop")))]
+#[allow(dead_code)]
 pub struct ForeignNode;
 
 #[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,12 +2,18 @@ pub mod interop;
 
 use ipfs::Node;
 
+/// The way in which nodes are connected to each other; to be used with spawn_connected_nodes.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Topology {
+    /// a > b > c
     Line,
+    /// a > b > c > a
     Ring,
+    /// a <> b <> c <> a
     Mesh,
+    /// a > b, a > c
+    Star,
 }
 
 #[allow(dead_code)]
@@ -19,25 +25,33 @@ pub async fn spawn_connected_nodes(count: usize, topology: Topology) -> Vec<Node
         nodes.push(node);
     }
 
-    if topology != Topology::Mesh {
-        for i in 0..(count - 1) {
-            nodes[i]
-                .connect(nodes[i + 1].addrs[0].clone())
-                .await
-                .unwrap();
+    match topology {
+        Topology::Line | Topology::Ring => {
+            for i in 0..(count - 1) {
+                nodes[i]
+                    .connect(nodes[i + 1].addrs[0].clone())
+                    .await
+                    .unwrap();
+            }
+            if topology == Topology::Ring {
+                nodes[count - 1]
+                    .connect(nodes[0].addrs[0].clone())
+                    .await
+                    .unwrap();
+            }
         }
-        if topology == Topology::Ring {
-            nodes[count - 1]
-                .connect(nodes[0].addrs[0].clone())
-                .await
-                .unwrap();
-        }
-    } else {
-        for i in 0..count {
-            for (j, peer) in nodes.iter().enumerate() {
-                if i != j {
-                    nodes[i].connect(peer.addrs[0].clone()).await.unwrap();
+        Topology::Mesh => {
+            for i in 0..count {
+                for (j, peer) in nodes.iter().enumerate() {
+                    if i != j {
+                        nodes[i].connect(peer.addrs[0].clone()).await.unwrap();
+                    }
                 }
+            }
+        }
+        Topology::Star => {
+            for node in nodes.iter().skip(1) {
+                nodes[0].connect(node.addrs[0].clone()).await.unwrap();
             }
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,1 +1,21 @@
 pub mod interop;
+
+use ipfs::{Node, PeerId};
+
+#[allow(dead_code)]
+pub async fn two_connected_nodes() -> ((Node, PeerId), (Node, PeerId)) {
+    let a = Node::new("a").await;
+    let b = Node::new("b").await;
+
+    let (a_pk, _) = a.identity().await.unwrap();
+    let a_id = a_pk.into_peer_id();
+
+    let (b_pk, mut addrs) = b.identity().await.unwrap();
+    let b_id = b_pk.into_peer_id();
+
+    a.connect(addrs.pop().expect("b must have address to connect to"))
+        .await
+        .unwrap();
+
+    ((a, a_id), (b, b_id))
+}

--- a/tests/exchange_block.rs
+++ b/tests/exchange_block.rs
@@ -1,8 +1,11 @@
 use cid::{Cid, Codec};
-use ipfs::{Block, Node};
+use ipfs::Block;
 use multihash::Sha2_256;
 use std::time::Duration;
 use tokio::time::timeout;
+
+mod common;
+use common::two_connected_nodes;
 
 #[tokio::test(max_threads = 1)]
 async fn exchange_block() {
@@ -11,14 +14,7 @@ async fn exchange_block() {
     let data = b"hello block\n".to_vec().into_boxed_slice();
     let cid = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
 
-    let a = Node::new("a").await;
-    let b = Node::new("b").await;
-
-    let (_, mut addrs) = b.identity().await.unwrap();
-
-    a.connect(addrs.pop().expect("b must have address to connect to"))
-        .await
-        .unwrap();
+    let ((a, _), (b, _)) = two_connected_nodes().await;
 
     a.put_block(Block {
         cid: cid.clone(),

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -1,8 +1,11 @@
 use futures::future::pending;
 use futures::stream::StreamExt;
-use ipfs::{Node, PeerId};
+use ipfs::Node;
 use std::time::Duration;
 use tokio::time::timeout;
+
+mod common;
+use common::two_connected_nodes;
 
 #[tokio::test(max_threads = 1)]
 async fn subscribe_only_once() {
@@ -130,21 +133,4 @@ async fn publish_between_two_nodes() {
     }
 
     assert!(disappeared, "timed out before a saw b's unsubscription");
-}
-
-async fn two_connected_nodes() -> ((Node, PeerId), (Node, PeerId)) {
-    let a = Node::new("a").await;
-    let b = Node::new("b").await;
-
-    let (a_pk, _) = a.identity().await.unwrap();
-    let a_id = a_pk.into_peer_id();
-
-    let (b_pk, mut addrs) = b.identity().await.unwrap();
-    let b_id = b_pk.into_peer_id();
-
-    a.connect(addrs.pop().expect("b must have address to connect to"))
-        .await
-        .unwrap();
-
-    ((a, a_id), (b, b_id))
 }


### PR DESCRIPTION
This PR improves our multi-node testing capabilities by:
- introducing a `spawn_connected_nodes` function and the related `Topology` object, allowing us to automate the creation of various test scenarios
- adds the `PeerId` and listening addresses to the `Node` object used in tests, to remove the need for calling `.identity()` every time a node is created

These new functionalities are not used everywhere yet and can probably be improved further, but it's a good starting point.