### PR TITLE
Finish Block subscriptions only if a subscription had been created

### DIFF
--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -290,14 +290,15 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
     pub async fn put_block(&self, block: Block) -> Result<(Cid, BlockPut), Error> {
         let cid = block.cid.clone();
         let (_cid, res) = self.block_store.put(block.clone()).await?;
-        self.subscriptions
-            .finish_subscription(cid.clone().into(), Ok(block));
 
         // FIXME: this doesn't cause actual DHT providing yet, only some
         // bitswap housekeeping; RepoEvent::ProvideBlock should probably
         // be renamed to ::NewBlock and we might want to not ignore the
         // channel errors when we actually start providing on the DHT
         if let BlockPut::NewBlock = res {
+            self.subscriptions
+                .finish_subscription(cid.clone().into(), Ok(block));
+
             // sending only fails if no one is listening anymore
             // and that is okay with us.
             let (tx, rx) = oneshot::channel();


### PR DESCRIPTION
I've found this issue while doing runs of the usually `#[ignore]`d tests, namely with the `bitswap_stress_test`. In `debug` builds it would trigger a `debug_assert` that verifies that we don't finish non-existent subscriptions (which in itself is not a big deal, but it is undesirable).

The reason was that a call to `get_block` that doesn't find the `Block` in the local repo creates a subscription for that `Block` (but _not_ if it was found), while `put_block` always finished a subscription for the `Block`, even if it had already existed in the repo. The solution was to just move `finish_subscription` under the `if let BlockPut::NewBlock = res` block, meaning that it's triggered only if the block that was put was new to the repo.