### PR TITLE
Improved interop test functionalities, prepare a simple pubsub interop test

### DIFF
--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -11,14 +11,13 @@ pub mod common {
     use libp2p::{core::PublicKey, Multiaddr, PeerId};
     use rand::prelude::*;
     use serde::Deserialize;
-    use std::time::Duration;
     use std::{
         env, fs,
         path::PathBuf,
         process::{Child, Command, Stdio},
-        thread,
     };
 
+    #[derive(Debug)]
     pub struct ForeignNode {
         pub dir: PathBuf,
         pub daemon: Child,
@@ -26,17 +25,21 @@ pub mod common {
         pub pk: PublicKey,
         pub addrs: Vec<Multiaddr>,
         pub binary_path: String,
+        pub api_port: u16,
     }
 
     impl ForeignNode {
         #[allow(dead_code)]
         pub fn new() -> ForeignNode {
+            use std::{io::Read, net::SocketAddr, str};
+
             // this environment variable should point to the location of the foreign ipfs binary
             #[cfg(feature = "test_go_interop")]
             const ENV_IPFS_PATH: &str = "GO_IPFS_PATH";
             #[cfg(feature = "test_js_interop")]
             const ENV_IPFS_PATH: &str = "JS_IPFS_PATH";
 
+            // obtain the path of the foreign ipfs binary from an environment variable
             let binary_path = env::vars()
                 .find(|(key, _val)| key == ENV_IPFS_PATH)
                 .unwrap_or_else(|| {
@@ -44,11 +47,13 @@ pub mod common {
                 })
                 .1;
 
+            // create the temporary directory for the repo etc
             let mut tmp_dir = env::temp_dir();
             let mut rng = rand::thread_rng();
             tmp_dir.push(&format!("ipfs_test_{}", rng.gen::<u64>()));
             let _ = fs::create_dir(&tmp_dir);
 
+            // initialize the node and assign the temporary directory to it
             Command::new(&binary_path)
                 .env("IPFS_PATH", &tmp_dir)
                 .arg("init")
@@ -60,16 +65,39 @@ pub mod common {
                 .status()
                 .unwrap();
 
-            let daemon = Command::new(&binary_path)
+            // start the ipfs daemon
+            let mut daemon = Command::new(&binary_path)
                 .env("IPFS_PATH", &tmp_dir)
                 .arg("daemon")
-                .stdout(Stdio::null())
+                .stdout(Stdio::piped())
                 .spawn()
                 .unwrap();
 
-            // give the daemon a little bit of time to start
-            thread::sleep(Duration::from_secs(1));
+            // read the stdout of the spawned daemon...
+            let mut buf = vec![0; 2048];
+            let mut index = 0;
+            if let Some(ref mut stdout) = daemon.stdout {
+                while let Ok(read) = stdout.read(&mut buf[index..]) {
+                    index += read;
+                    if str::from_utf8(&buf).unwrap().contains("Daemon is ready") {
+                        break;
+                    }
+                }
+            }
 
+            // ...so that the randomly assigned API port can be registered
+            let mut api_port = None;
+            for line in str::from_utf8(&buf).unwrap().lines() {
+                if line.contains("webui") {
+                    let addr = line.rsplitn(2, ' ').next().unwrap();
+                    let addr = addr.strip_prefix("http://").unwrap();
+                    let addr: SocketAddr = addr.rsplitn(2, '/').nth(1).unwrap().parse().unwrap();
+                    api_port = Some(addr.port());
+                }
+            }
+            let api_port = api_port.unwrap();
+
+            // run /id in order to register the PeerId, PublicKey and Multiaddrs assigned to the node
             let node_id = Command::new(&binary_path)
                 .env("IPFS_PATH", &tmp_dir)
                 .arg("id")
@@ -98,6 +126,7 @@ pub mod common {
                 pk,
                 addrs: addresses,
                 binary_path,
+                api_port,
             }
         }
 

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -65,10 +65,15 @@ pub mod common {
                 .status()
                 .unwrap();
 
+            #[cfg(feature = "test_go_interop")]
+            let daemon_args = &["daemon", "--enable-pubsub-experiment"];
+            #[cfg(feature = "test_js_interop")]
+            let daemon_args = &["daemon"];
+
             // start the ipfs daemon
             let mut daemon = Command::new(&binary_path)
                 .env("IPFS_PATH", &tmp_dir)
-                .arg("daemon")
+                .args(daemon_args)
                 .stdout(Stdio::piped())
                 .spawn()
                 .unwrap();

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -19,12 +19,6 @@ pub mod common {
         thread,
     };
 
-    // this environment variable should point to the location of the foreign ipfs binary
-    #[cfg(feature = "test_go_interop")]
-    pub const ENV_IPFS_PATH: &str = "GO_IPFS_PATH";
-    #[cfg(feature = "test_js_interop")]
-    pub const ENV_IPFS_PATH: &str = "JS_IPFS_PATH";
-
     pub struct ForeignNode {
         pub dir: PathBuf,
         pub daemon: Child,
@@ -34,7 +28,14 @@ pub mod common {
     }
 
     impl ForeignNode {
+        #[allow(dead_code)]
         pub fn new() -> ForeignNode {
+            // this environment variable should point to the location of the foreign ipfs binary
+            #[cfg(feature = "test_go_interop")]
+            const ENV_IPFS_PATH: &str = "GO_IPFS_PATH";
+            #[cfg(feature = "test_js_interop")]
+            const ENV_IPFS_PATH: &str = "JS_IPFS_PATH";
+
             let binary_path = env::vars()
                 .find(|(key, _val)| key == ENV_IPFS_PATH)
                 .unwrap_or_else(|| {

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -134,6 +134,21 @@ pub mod common {
         pub async fn identity(&self) -> Result<(PublicKey, Vec<Multiaddr>), anyhow::Error> {
             Ok((self.pk.clone(), self.addrs.clone()))
         }
+
+        #[allow(dead_code)]
+        pub async fn api_call(&self, call: &str) -> String {
+            let bytes = Command::new("curl")
+                .arg("-X")
+                .arg("POST")
+                .arg(&format!(
+                    "http://127.0.0.1:{}/api/v0/{}",
+                    self.api_port, call
+                ))
+                .output()
+                .unwrap()
+                .stdout;
+            String::from_utf8(bytes).unwrap()
+        }
     }
 
     impl Drop for ForeignNode {

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -25,6 +25,7 @@ pub mod common {
         pub id: PeerId,
         pub pk: PublicKey,
         pub addrs: Vec<Multiaddr>,
+        pub binary_path: String,
     }
 
     impl ForeignNode {
@@ -96,6 +97,7 @@ pub mod common {
                 id,
                 pk,
                 addrs: addresses,
+                binary_path,
             }
         }
 


### PR DESCRIPTION
Builds on https://github.com/rs-ipfs/rust-ipfs/pull/368, only the `test: ...` commits are new.

Extends the interop test functionalities so that arbitrary HTTP API calls can be made for the foreign nodes; I attempted to use them in order to introduce a `pubsub` interop test, but it doesn't work yet. Since the underlying issue might cause the PR to grow, I'd prefer to merge it as-is, with the new `pubsub` interop test currently `#[ignore]`d.

Blocked by https://github.com/rs-ipfs/rust-ipfs/pull/368.