### PR TITLE
Full /bootstrap support

### DIFF
--- a/conformance/patches/bootstrap.patch
+++ b/conformance/patches/bootstrap.patch
@@ -1,0 +1,11 @@
+--- node_modules/interface-ipfs-core/src/bootstrap/reset.js
++++ node_modules/interface-ipfs-core/src/bootstrap/reset.js
+@@ -34,7 +34,7 @@ module.exports = (common, options) => {
+       const res = await ipfs.bootstrap.reset()
+
+       const peers = res.Peers
+-      expect(peers).to.have.property('length').that.is.gt(1)
++      expect(peers).to.have.property('length').that.is.eq(0)
+     })
+
+     it('should return a list of all peers removed when all option is passed', async () => {

--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -147,17 +147,7 @@ tests.pin.rm(factory, {
   ]
 })
 
-tests.bootstrap(factory, {
-  skip: [
-    // need to figure out the inner workings of clear()
-    'should prevent duplicate inserts of bootstrap peers',
-    'should return a list containing the peer removed when called with a valid arg (ip4)',
-    // need to figure out the inner workings of reset()
-    'should return a list of all peers removed when all option is passed',
-    'should return a list of bootstrap peers when resetting the bootstrap nodes',
-    'should return a list of all peers removed when all option is passed',
-  ]
-})
+tests.bootstrap(factory);
 
 // tests.name(factory)
 // tests.namePubsub(factory)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,7 +298,7 @@ enum IpfsEvent {
     AddBootstrapper(MultiaddrWithPeerId, Channel<Multiaddr>),
     RemoveBootstrapper(MultiaddrWithPeerId, Channel<Multiaddr>),
     ClearBootstrappers(OneshotSender<Vec<Multiaddr>>),
-    RestoreBootstrappers(OneshotSender<Vec<Multiaddr>>),
+    RestoreBootstrappers(Channel<Vec<Multiaddr>>),
     Exit,
 }
 
@@ -1149,7 +1149,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
                 .send(IpfsEvent::ClearBootstrappers(tx))
                 .await?;
 
-            Ok(rx.await?).map_err(|e: String| anyhow!(e))
+            Ok(rx.await?)
         }
         .instrument(self.span.clone())
         .await
@@ -1166,7 +1166,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
                 .send(IpfsEvent::RestoreBootstrappers(tx))
                 .await?;
 
-            Ok(rx.await?).map_err(|e: String| anyhow!(e))
+            rx.await?
         }
         .instrument(self.span.clone())
         .await

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -17,7 +17,7 @@ use libp2p::swarm::toggle::Toggle;
 use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourEventProcess};
 use libp2p::NetworkBehaviour;
 use multibase::Base;
-use std::{convert::TryInto, sync::Arc};
+use std::{collections::HashSet, convert::TryInto, env, fs::File, path::PathBuf, sync::Arc};
 use tokio::task;
 
 /// Behaviour type.
@@ -594,10 +594,11 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     }
 
     pub fn restore_bootstrappers(&mut self) -> Result<Vec<Multiaddr>, anyhow::Error> {
-        let config_location = format!("{}/config", std::env::var("IPFS_PATH")?);
-        let mut config_reader = std::fs::File::open(config_location)?;
+        let mut config_location = PathBuf::from(env::var("IPFS_PATH")?);
+        config_location.push("config");
+        let mut config_reader = File::open(config_location)?;
         let config_file: serde_json::Value = serde_json::from_reader(&mut config_reader)?;
-        let mut ret = std::collections::HashSet::new();
+        let mut ret = HashSet::new();
 
         if let Some(addrs) = config_file
             .as_object()

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -593,10 +593,10 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         self.swarm.bootstrappers.drain().map(|a| a.into()).collect()
     }
 
-    pub fn restore_bootstrappers(&mut self) -> Vec<Multiaddr> {
-        let config_location = std::env::var("IPFS_PATH").expect("always expected to be set");
-        let mut config_reader = std::fs::File::open(config_location).expect("the config is there");
-        let config_file: serde_json::Value = serde_json::from_reader(&mut config_reader).unwrap();
+    pub fn restore_bootstrappers(&mut self) -> Result<Vec<Multiaddr>, anyhow::Error> {
+        let config_location = format!("{}/config", std::env::var("IPFS_PATH")?);
+        let mut config_reader = std::fs::File::open(config_location)?;
+        let config_file: serde_json::Value = serde_json::from_reader(&mut config_reader)?;
         let mut ret = std::collections::HashSet::new();
 
         if let Some(addrs) = config_file
@@ -620,7 +620,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
             }
         }
 
-        ret.into_iter().collect()
+        Ok(ret.into_iter().collect())
     }
 }
 


### PR DESCRIPTION
~~Builds on https://github.com/rs-ipfs/rust-ipfs/pull/371, only the last 6 commits are new.~~

Fixes the remaining 5 `bootstrap` conformance tests, bringing our overall score past 200 passing :muscle::
```
201 passing (52s)
48 pending
```

As usual, the commits describe specific changes; most are pretty self-explanatory, with the exception of the new patch:
```
-      expect(peers).to.have.property('length').that.is.gt(1)
+      expect(peers).to.have.property('length').that.is.eq(0)
```
The reason behind that one is that our HTTP test node only carries `Identity` config information - there is no `Bootstrap` key available in the config file, so the number of default bootstrapper addresses is `0`.

~~Blocked by https://github.com/rs-ipfs/rust-ipfs/pull/371.~~