### PR TITLE
Fix 2 issues triggered with the dht_popular_content_discovery test

### DIFF
--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -112,7 +112,7 @@ impl TryFrom<Multiaddr> for MultiaddrWithPeerId {
             // is unexpected; it is hard to trigger, hence this debug-only assertion so we might be
             // able to catch it sometime during tests
             debug_assert!(
-                matches!(multiaddr.iter().last(), Some(Protocol::P2p(_))),
+                matches!(multiaddr.iter().last(), Some(Protocol::P2p(_)) | Some(Protocol::P2pCircuit)),
                 "unexpected Multiaddr format: {}",
                 multiaddr
             );
@@ -120,7 +120,7 @@ impl TryFrom<Multiaddr> for MultiaddrWithPeerId {
             let multiaddr = MultiaddrWithoutPeerId(
                 multiaddr
                     .into_iter()
-                    .filter(|p| !matches!(p, Protocol::P2p(_)))
+                    .filter(|p| !matches!(p, Protocol::P2p(_) | Protocol::P2pCircuit))
                     .collect(),
             );
             let peer_id =

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -471,7 +471,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     // FIXME: it would be best if get_providers is called only in case the already connected
     // peers don't have it
     pub fn want_block(&mut self, cid: Cid) {
-        let key = cid.to_bytes();
+        let key = cid.hash().as_bytes().to_owned();
         self.kademlia.get_providers(key.into());
         self.bitswap.want_block(cid, 1);
     }


### PR DESCRIPTION
This is an `#[ignore]`d test due to it using the global network, but it's a practical debugging tool regardless; this time it helped fix 2 issues:
- the handling of `Multiaddr`s ending with `/p2p-circuit`
- searching for `Block` providers using the full `Cid` instead of just the `Multiaddr` (we've noticed this before, but it got lost in the TODOs :stuck_out_tongue:)