### PR TITLE
Enabling pinned blocks test

### DIFF
--- a/conformance/test/index.js
+++ b/conformance/test/index.js
@@ -67,7 +67,6 @@ tests.dag.put(factory)
 tests.block(factory, {
   skip: [
     // both are pinning related
-    'should error when removing pinned blocks',
     'should put a buffer, using options'
   ]
 })


### PR DESCRIPTION
This PR un-skips one conformance test that works now that we have pinning. This brings our number up by one! :firecracker: 