### PR TITLE
Improve /add interop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,7 @@ dependencies = [
  "percent-encoding",
  "prost",
  "prost-build",
+ "rand 0.7.3",
  "serde",
  "serde_json",
  "structopt",

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -40,4 +40,5 @@ warp = { default-features = false, version = "0.2" }
 
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }
+rand = { default-features = false, version = "0.7" }
 tempfile = { default-features = false, version = "3.1" }

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -376,10 +376,11 @@ impl<D: fmt::Display> serde::Serialize for Quoted<D> {
 #[cfg(test)]
 mod tests {
     use crate::v0::root_files::add;
+    use ipfs::Node;
 
     #[tokio::test(max_threads = 1)]
     async fn add_single_block_file() {
-        let ipfs = tokio_ipfs().await;
+        let ipfs = Node::new("0").await;
 
         // this is from interface-ipfs-core, pretty much simplest add a buffer test case
         // but the body content is from the pubsub test case I copied this from
@@ -406,17 +407,5 @@ mod tests {
             body,
             "{\"Hash\":\"Qma4hjFTnCasJ8PVp3mZbZK5g2vGDT4LByLJ7m8ciyRFZP\",\"Name\":\"testfile.txt\",\"Size\":\"20\"}\r\n"
         );
-    }
-
-    async fn tokio_ipfs() -> ipfs::Ipfs<ipfs::TestTypes> {
-        let options = ipfs::IpfsOptions::inmemory_with_generated_keys();
-        let (ipfs, fut) = ipfs::UninitializedIpfs::new(options, None)
-            .await
-            .start()
-            .await
-            .unwrap();
-
-        tokio::spawn(fut);
-        ipfs
     }
 }


### PR DESCRIPTION
I browsed the `go-ipfs` and `js-ipfs` codebases in search for some nice `/add` test cases so that we could verify that our logic, e.g. wrt. the headers and field names, is compatible; I haven't found much :sweat_smile:, but based on the one `js-ipfs` test case I found I relaxed the `/add` restrictions a little bit.

Not sure if this is the right approach and if I'm seeing the whole picture, so I'm marking this as a draft.