### PR TITLE
Add the list of supported libp2p protocols to /id

### DIFF
--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -60,7 +60,7 @@ async fn main() {
     if let Some(target) = target {
         ipfs.connect(target).await.unwrap();
     } else {
-        let (_, addresses) = ipfs.identity().await.unwrap();
+        let (_, addresses, _) = ipfs.identity().await.unwrap();
         assert!(!addresses.is_empty(), "Zero listening addresses");
 
         eprintln!("Please connect an ipfs node having {} to:\n", path);

--- a/examples/ipfs_bitswap_test.rs
+++ b/examples/ipfs_bitswap_test.rs
@@ -24,7 +24,7 @@ async fn main() {
     let data = b"block-want\n".to_vec().into_boxed_slice();
     let wanted = Cid::new_v1(Codec::Raw, Sha2_256::digest(&data));
 
-    let (public_key, addresses) = ipfs.identity().await.unwrap();
+    let (public_key, addresses, _) = ipfs.identity().await.unwrap();
     assert!(!addresses.is_empty(), "Zero listening addresses");
 
     eprintln!("Please connect an ipfs node having {} to:\n", wanted);

--- a/http/src/v0/id.rs
+++ b/http/src/v0/id.rs
@@ -38,7 +38,7 @@ async fn identity_query<T: IpfsTypes>(
     }
 
     match ipfs.identity().await {
-        Ok((public_key, addresses)) => {
+        Ok((public_key, addresses, protocols)) => {
             let peer_id = public_key.clone().into_peer_id();
             let id = peer_id.to_string();
             let public_key = Base64Pad.encode(public_key.into_protobuf_encoding());
@@ -51,6 +51,7 @@ async fn identity_query<T: IpfsTypes>(
                 addresses,
                 agent_version: "rust-ipfs/0.1.0",
                 protocol_version: "ipfs/0.1.0",
+                protocols,
             };
 
             Ok(warp::reply::json(&response))
@@ -82,4 +83,6 @@ struct Response {
     agent_version: &'static str,
     // Multiaddr alike ipfs/0.1.0 ... not sure if there are plans to bump this anytime soon
     protocol_version: &'static str,
+    // the list of supported libp2p protocols
+    protocols: Vec<String>,
 }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -623,6 +623,14 @@ impl<Types: IpfsTypes> Behaviour<Types> {
 
         Ok(ret.into_iter().collect())
     }
+
+    pub fn protocols(&self) -> Vec<String> {
+        self.swarm
+            .protocols
+            .iter()
+            .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+            .collect()
+    }
 }
 
 /// Create a IPFS behaviour with the IPFS bootstrap nodes.

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -46,6 +46,7 @@ pub struct SwarmApi {
     roundtrip_times: HashMap<PeerId, Duration>,
     connected_peers: HashMap<PeerId, Vec<MultiaddrWithoutPeerId>>,
     pub(crate) bootstrappers: HashSet<MultiaddrWithPeerId>,
+    pub(crate) protocols: Vec<Vec<u8>>,
 }
 
 impl SwarmApi {
@@ -242,8 +243,12 @@ impl NetworkBehaviour for SwarmApi {
     fn poll(
         &mut self,
         _: &mut Context,
-        _: &mut impl PollParameters,
+        params: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction> {
+        if params.supported_protocols().len() != self.protocols.len() {
+            self.protocols = params.supported_protocols().collect();
+        }
+
         if let Some(event) = self.events.pop_front() {
             Poll::Ready(event)
         } else {

--- a/tests/listening_addresses.rs
+++ b/tests/listening_addresses.rs
@@ -128,7 +128,7 @@ async fn pre_configured_listening_addrs() {
     opts.listening_addrs.push(addr.clone());
     let ipfs = Node::with_options(opts).await;
 
-    let (_id, addrs) = ipfs.identity().await.unwrap();
+    let (_id, addrs, _) = ipfs.identity().await.unwrap();
     let addrs: Vec<MultiaddrWithoutPeerId> = addrs
         .into_iter()
         .map(|addr| MultiaddrWithPeerId::try_from(addr).unwrap().multiaddr)


### PR DESCRIPTION
Following the changes in [`go-ipfs`](https://github.com/ipfs/go-ipfs/pull/7409) and [`js-ipfs`](https://github.com/ipfs/js-ipfs/pull/3250) (and already required in the upstream conformance tests), this PR adds the quite useful list of supported `libp2p` protocols to the JSON returned by `/id`.

Since I'm not sure about the resulting small API changes and the way the protocols get populated (which was WAY harder than anticipated), I'm marking it as a draft.