### PR TITLE
fix: restore bootstrappers from static list, update the bootstrapper list

### DIFF
--- a/conformance/patches/bootstrap.patch
+++ b/conformance/patches/bootstrap.patch
@@ -5,7 +5,7 @@
 
        const peers = res.Peers
 -      expect(peers).to.have.property('length').that.is.gt(1)
-+      expect(peers).to.have.property('length').that.is.eq(0)
++      expect(peers).to.have.property('length').that.is.gt(0)
      })
 
      it('should return a list of all peers removed when all option is passed', async () => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,17 +7,8 @@ use std::fs;
 use std::path::Path;
 use thiserror::Error;
 
-const BOOTSTRAP_NODES: &[&str] = &[
-    "/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ",
-    "/ip4/104.236.179.241/tcp/4001/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
-    "/ip4/104.236.76.40/tcp/4001/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
-    "/ip4/128.199.219.111/tcp/4001/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
-    "/ip4/178.62.158.247/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-    "/ip6/2400:6180:0:d0::151:6001/tcp/4001/p2p/QmSoLSafTMBsPKadTEgaXctDQVcqN88CNLHXMkTNwMKPnu",
-    "/ip6/2604:a880:1:20::203:d001/tcp/4001/p2p/QmSoLPppuBtQSGwKDZT2M73ULpjvfd3aZ6ha4oFGL1KrGM",
-    "/ip6/2604:a880:800:10::4a:5001/tcp/4001/p2p/QmSoLV4Bbm51jM9C4gDYZQ9Cy3U6aXMJDAbzgu2fzaDs64",
-    "/ip6/2a03:b0c0:0:1010::23:1001/tcp/4001/p2p/QmSoLer265NRgSp2LA3dPaeykiS1J6DifTC88f5uVQKNAd",
-];
+const BOOTSTRAP_NODES: &[&str] =
+    &["/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"];
 
 /// See test cases for examples how to write such file.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::Path;
 use thiserror::Error;
 
-const BOOTSTRAP_NODES: &[&str] =
+pub const BOOTSTRAP_NODES: &[&str] =
     &["/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"];
 
 /// See test cases for examples how to write such file.


### PR DESCRIPTION
Alters the `BOOTSTRAP_NODES` list to contain only the currently working addresses and changes the behavior of `Swarm::remove_bootstrappers` to not use the config file, but rather the aforementioned in-memory list.

Cc https://github.com/rs-ipfs/rust-ipfs/issues/356