### PR TITLE
fix: unhandled panics in the fs blockstore

### DIFF
--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -183,7 +183,7 @@ impl BlockStore for FsBlockStore {
         let cid = block.cid;
         let data = block.data;
 
-        let inner_span = span.clone();
+        let inner_span = debug_span!(parent: &span, "blocking");
 
         async move {
             // why synchronize here? because when we lose the race we cant know if there was someone
@@ -212,11 +212,8 @@ impl BlockStore for FsBlockStore {
             // create this in case the winner is dropped while awaiting
             let cleanup = RemoveOnDrop(self.writes.clone(), Some(RepoCid(cid.to_owned())));
 
-            let span = tracing::Span::current();
-
             // launch a blocking task for the filesystem mutation.
             let je = tokio::task::spawn_blocking(move || {
-                let _entered = span.enter();
                 // pick winning writer with filesystem and create_new; this error will be the 1st
                 // nested level
 

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -318,9 +318,13 @@ impl BlockStore for FsBlockStore {
                         Ok((cid.to_owned(), BlockPut::Existed))
                     }
                 }
+                Err(e) if e.is_cancelled() => {
+                    trace!("runtime is shutting down: {}", e);
+                    Err(e.into())
+                }
                 Err(e) => {
-                    // blocking task panicked or the runtime is going down, but we don't know
-                    // if the thread has stopped or not (like not)
+                    // as of writing this, we didn't have panicking inside the task
+                    error!("blocking put task panicked or something else: {}", e);
                     Err(e.into())
                 }
             }

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -37,12 +37,26 @@ pub struct FsBlockStore {
     written_bytes: AtomicU64,
 }
 
+/// Helper is used to remove our key from `FsBlockStore::writes`. It is quite inefficient, some
+/// kind of reference counting would be great.
+///
+/// [`Drop`] is used to clean up the so that it is _safer_ to drop the future returned by
+/// `FsBlockStore::put`.
+///
+/// Without reference counting, there is a race condition with repeat multiple
+/// concurrent writers and dropping; this might lead into the first ones dropping the latter
+/// concurrent writes key.
 struct RemoveOnDrop<K: Eq + Hash, V>(ArcMutexMap<K, V>, Option<K>);
 
 impl<K: Eq + Hash, V> Drop for RemoveOnDrop<K, V> {
     fn drop(&mut self) {
         if let Some(key) = self.1.take() {
             let mut g = self.0.lock().unwrap();
+            // FIXME: there should be something here to make sure the value is of expected
+            // "generation", not to remove any future channels. Or then, we could just use the
+            // tokio::sync::broadcast::Sender::receiver_count here to make sure we only remove an
+            // unused Sender. This would however wreak havoc on the FsBlockStore::put long match in
+            // the end, which has match arms which assume all of the senders have gone away.
             g.remove(&key);
         }
     }


### PR DESCRIPTION
Fixes #386 -- at least there are no more unhandled panics, seems that the blockstore is still racy but I am not sure how to fix it right now. I am not 100% what caused those panics but I suspect it was related to having multiple broadcast::Sender's alive in the blocking task queue trying to send to receivers which were already dropped because the outer async context was dropped.

In addition there are even more comments, minor comment adjustments, minor splitting to comment less but more clear code.

First commit is the fix.