### PR TITLE
Move the README example, remove the nightly feature and CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,26 +192,6 @@ jobs:
     - name: cargo clippy
       run: cargo clippy --all-targets --workspace -- -D warnings
 
-  readme-doctest:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout sources
-      uses: actions/checkout@v2
-
-    - name: Cache cargo folder
-      uses: actions/cache@v2
-      with:
-        path: ~/.cargo
-        key: readme-doctest-${{ hashFiles('Cargo.lock') }}
-
-    - name: Install rust toolchain
-      uses: hecrj/setup-rust-action@v1
-      with:
-        rust-version: nightly
-
-    - name: cargo test --features nightly
-      run: cargo test --features nightly
-
   # adapted from https://github.com/taiki-e/pin-project/blob/5878410863f5f25e21f7cba97b035501749850f9/.github/workflows/ci.yml#L136-L167
   ci-success:
       # this is read by bors
@@ -220,7 +200,6 @@ jobs:
       needs:
         - ci-matrix
         - lint-rust
-        - readme-doctest
       runs-on: ubuntu-latest
       steps:
         - name: Mark the job as a success
@@ -233,7 +212,6 @@ jobs:
       needs:
         - ci-matrix
         - lint-rust
-        - readme-doctest
       runs-on: ubuntu-latest
       steps:
         - name: Mark the job as failure

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 
 [features]
 default = []
-nightly = []
 test_go_interop = []
 test_js_interop = []
 

--- a/README.md
+++ b/README.md
@@ -66,42 +66,10 @@ You will then find the binaries inside of the project root's `/target/debug` fol
 _Note: binaries available via `cargo install` is coming soon._
 
 ## Getting started
-```rust,no_run
-use tokio::task;
-use futures::join;
-use ipfs::{make_ipld, Ipfs, IpfsPath, Ipld, Types, UninitializedIpfs};
 
-#[tokio::main]
-async fn main() {
-    tracing_subscriber::fmt::init();
-
-    // Start daemon and initialize repo
-    let (ipfs, fut): (Ipfs<Types>, _) = UninitializedIpfs::default().await.start().await.unwrap();
-    task::spawn(fut);
-
-    // Create a DAG
-    let f1 = ipfs.put_dag(make_ipld!("block1"));
-    let f2 = ipfs.put_dag(make_ipld!("block2"));
-    let (res1, res2) = join!(f1, f2);
-    let root = make_ipld!([res1.unwrap(), res2.unwrap()]);
-    let cid = ipfs.put_dag(root).await.unwrap();
-    let path = IpfsPath::from(cid);
-
-    // Query the DAG
-    let path1 = path.sub_path("0").unwrap();
-    let path2 = path.sub_path("1").unwrap();
-    let f1 = ipfs.get_dag(path1);
-    let f2 = ipfs.get_dag(path2);
-    let (res1, res2) = join!(f1, f2);
-    println!("Received block with contents: {:?}", res1.unwrap());
-    println!("Received block with contents: {:?}", res2.unwrap());
-
-    // Exit
-    ipfs.exit_daemon();
-}
-```
-
-More usage examples coming soon :+1:
+We recommend to browse the [examples](https://github.com/rs-ipfs/rust-ipfs/tree/master/examples) and
+[tests](https://github.com/rs-ipfs/rust-ipfs/tree/master/tests) in order to see how to use Rust-IPFS
+in different scenarios.
 
 ## Roadmap
 

--- a/examples/dag_creation.rs
+++ b/examples/dag_creation.rs
@@ -1,0 +1,32 @@
+use futures::join;
+use ipfs::{make_ipld, Ipfs, IpfsPath, Types, UninitializedIpfs};
+use tokio::task;
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    // Initialize the repo and start a daemon
+    let (ipfs, fut): (Ipfs<Types>, _) = UninitializedIpfs::default().await.start().await.unwrap();
+    task::spawn(fut);
+
+    // Create a DAG
+    let f1 = ipfs.put_dag(make_ipld!("block1"));
+    let f2 = ipfs.put_dag(make_ipld!("block2"));
+    let (res1, res2) = join!(f1, f2);
+    let root = make_ipld!([res1.unwrap(), res2.unwrap()]);
+    let cid = ipfs.put_dag(root).await.unwrap();
+    let path = IpfsPath::from(cid);
+
+    // Query the DAG
+    let path1 = path.sub_path("0").unwrap();
+    let path2 = path.sub_path("1").unwrap();
+    let f1 = ipfs.get_dag(path1);
+    let f2 = ipfs.get_dag(path2);
+    let (res1, res2) = join!(f1, f2);
+    println!("Received block with contents: {:?}", res1.unwrap());
+    println!("Received block with contents: {:?}", res2.unwrap());
+
+    // Exit
+    ipfs.exit_daemon().await;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! IPFS node implementation
 //#![deny(missing_docs)]
-#![cfg_attr(feature = "nightly", feature(external_doc))]
-#![cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 
 mod config;
 pub mod dag;


### PR DESCRIPTION
Moving the code example from the README to the `examples` simplifies our CI setup and makes one of the runs redundant.