### PR TITLE
Refresh docs

### DIFF
--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -26,6 +26,7 @@ use std::{
     },
 };
 
+/// Event used to communicate with the swarm or the higher level behaviour.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BitswapEvent {
     ReceivedBlock(PeerId, Block),
@@ -33,6 +34,7 @@ pub enum BitswapEvent {
     ReceivedCancel(PeerId, Cid),
 }
 
+/// Bitswap statistics.
 #[derive(Debug, Default)]
 pub struct Stats {
     pub sent_blocks: AtomicU64,

--- a/bitswap/src/block.rs
+++ b/bitswap/src/block.rs
@@ -1,8 +1,14 @@
 use cid::Cid;
 
+/// An Ipfs block consisting of a [`Cid`] and the bytes of the block.
+///
+/// Note: At the moment the equality is based on [`Cid`] equality, which is based on the triple
+/// `(cid::Version, cid::Codec, multihash)`.
 #[derive(Clone, Debug)]
 pub struct Block {
+    /// The content identifier for this block
     pub cid: Cid,
+    /// The data of this block
     pub data: Box<[u8]>,
 }
 
@@ -11,6 +17,7 @@ impl PartialEq for Block {
         self.cid.hash() == other.cid.hash()
     }
 }
+
 impl Eq for Block {}
 
 impl Block {

--- a/http/README.md
+++ b/http/README.md
@@ -6,6 +6,10 @@ functionality but mostly in the aim of testing the `rust-ipfs` via:
  * [conformance](../conformance)
  * [interop](https://github.com/rs-ipfs/interop/)
 
+The vision for this crate is to eventually provide warp filters and async
+methods suitable to providing the Ipfs HTTP API in other applications as well
+instead of having to write application specific debug and introspection APIs.
+
 HTTP specs:
 
  * https://docs.ipfs.io/reference/http/api/

--- a/http/README.md
+++ b/http/README.md
@@ -1,14 +1,14 @@
 # ipfs-http crate
 
-HTTP api on top of ipfs crate. The end binary has some rudimentary ipfs CLI
+HTTP api on top of `ipfs` crate. The end binary has some rudimentary ipfs CLI
 functionality but mostly in the aim of testing the `rust-ipfs` via:
 
- * [ipfs-rust-conformance](https://github.com/rs-ipfs/ipfs-rust-conformance)
+ * [conformance](../conformance)
  * [interop](https://github.com/rs-ipfs/interop/)
 
 HTTP specs:
 
- * https://docs.ipfs.io/reference/api/http/
+ * https://docs.ipfs.io/reference/http/api/
 
 Status: Pre-alpha, most of the functionality is missing or `501 Not
 Implemented`. See the repository level README for more information.

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -1,4 +1,4 @@
-//! go-ipfs compatible configuration file handling or at least setup.
+//! go-ipfs compatible configuration file handling and setup.
 
 use parity_multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -1,3 +1,8 @@
+//! `ipfs-http` http API implementation.
+//!
+//! This crate is most useful as a binary used first and foremost for compatibility testing against
+//! other ipfs implementations.
+
 #[macro_use]
 extern crate tracing;
 

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -1,3 +1,7 @@
+//! Implementation of `/api/v0` HTTP endpoints.
+//!
+//! See https://docs.ipfs.io/reference/http/api/ for more information.
+
 use ipfs::{Ipfs, IpfsTypes};
 use warp::{query, Filter};
 

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -1,3 +1,5 @@
+//! `ipfs.dag` interface implementation around [`Ipfs`].
+
 use crate::error::Error;
 use crate::ipld::{decode_ipld, encode_ipld, Ipld};
 use crate::path::{IpfsPath, SlashedPath};

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -854,7 +854,7 @@ mod tests {
         // FIXME: validate that go-ipfs still does this
         let equiv_paths = vec![
             prefix.sub_path("0/0").unwrap(),
-            prefix.into_sub_path("0/./0").unwrap(),
+            prefix.sub_path("0/./0").unwrap(),
         ];
 
         for p in equiv_paths {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Crate wide errors.
+//! Crate-wide errors.
 //!
 //! The error handling in `ipfs` is subject to change in the future.
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-///! IPFS crate wide errors.
-///!
-///! The error handling in `ipfs` is subject to change in the future.
+//! Crate wide errors.
+//!
+//! The error handling in `ipfs` is subject to change in the future.
 
 /// Just re-export anyhow for now.
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,17 @@
+///! IPFS crate wide errors.
+///!
+///! The error handling in `ipfs` is subject to change in the future.
+
+/// Just re-export anyhow for now.
+///
+/// # Stability
+///
+/// Very likely to change in the future.
 pub use anyhow::Error;
 
+/// A try conversion failed.
+///
+/// # Stability
+///
+/// Very likely to change in the future.
 pub struct TryError;

--- a/src/ipld/ipld_macro.rs
+++ b/src/ipld/ipld_macro.rs
@@ -1,3 +1,5 @@
+/// Easy to use nested [`crate::ipld::Ipld`] creation with syntax similar to
+/// [`serde_json::json`](https://docs.rs/serde_json/1.0/serde_json/macro.json.html) macro.
 #[macro_export(local_inner_macros)]
 macro_rules! make_ipld {
     // Hide distracting implementation details from the generated rustdoc.

--- a/src/ipld/mod.rs
+++ b/src/ipld/mod.rs
@@ -1,7 +1,9 @@
-// This code was adapted from https://github.com/ipfs-rust/rust-ipld, and most of
-// its code is the same as at revision b2286c53c13f3eeec2a3766387f2926838e8e4c9;
-// it used to be a direct dependency, but recent updates to cid and multihash crates
-// made it incompatible with them.
+//! IPLD dag-json, dag-cbor and some dag-pb functionality.
+//!
+//! This code was adapted from https://github.com/ipfs-rust/rust-ipld, and most of
+//! its code is the same as at revision b2286c53c13f3eeec2a3766387f2926838e8e4c9;
+//! it used to be a direct dependency, but recent updates to cid and multihash crates
+//! made it incompatible with them.
 
 pub mod dag_cbor;
 pub mod dag_json;

--- a/src/ipns/mod.rs
+++ b/src/ipns/mod.rs
@@ -1,3 +1,5 @@
+//! IPNS functionality around [`Ipfs`].
+
 use crate::error::Error;
 use crate::path::{IpfsPath, PathRoot};
 use crate::repo::RepoTypes;
@@ -5,6 +7,7 @@ use crate::Ipfs;
 
 mod dnslink;
 
+/// IPNS facade around [`Ipns`].
 #[derive(Clone, Debug)]
 pub struct Ipns<Types: RepoTypes> {
     ipfs: Ipfs<Types>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,20 @@
 //! IPFS node implementation
+//!
+//! [Ipfs](https://ipfs.io) is a peer-to-peer system with content addressed functionality. The main
+//! entry point for users of this crate is the [`Ipfs`] facade, which allows access to most of the
+//! implemented functionality.
+//!
+//! This crate passes a lot of the [interface-ipfs-core] test suite; most of that functionality is
+//! in `ipfs-http` crate. The crate has some interoperability with the [go-ipfs] and [js-ipfs]
+//! implementations.
+//!
+//! `ipfs` is an early alpha level crate: APIs and their implementation are subject to change in
+//! any upcoming release at least for now. The aim of the crate is to become a library-first
+//! production ready implementation of an Ipfs node.
+//!
+//! [interface-ipfs-core]: https://www.npmjs.com/package/interface-ipfs-core
+//! [go-ipfs]: https://github.com/ipfs/go-ipfs/
+//! [js-ipfs]: https://github.com/ipfs/js-ipfs/
 //#![deny(missing_docs)]
 
 mod config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,9 +249,9 @@ impl<Types: IpfsTypes> Clone for Ipfs<Types> {
     }
 }
 
-/// Ipfs struct creates a new IPFS node and is the main entry point
-/// for interacting with IPFS.
+/// The internal shared implementation of [`Ipfs`].
 #[derive(Debug)]
+#[doc(hidden)]
 pub struct IpfsInner<Types: IpfsTypes> {
     pub span: Span,
     repo: Repo<Types>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub use self::{
     path::IpfsPath,
     repo::{PinKind, PinMode, RepoTypes},
 };
-pub use bitswap::{Block, Stats};
+pub use bitswap::Block;
 pub use cid::Cid;
 pub use libp2p::{
     core::{
@@ -1586,15 +1586,24 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
     }
 }
 
+/// Bitswap statistics
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BitswapStats {
+    /// The number of IPFS blocks sent to other peers
     pub blocks_sent: u64,
+    /// The number of bytes sent in IPFS blocks to other peers
     pub data_sent: u64,
+    /// The number of IPFS blocks received from other peers
     pub blocks_received: u64,
+    /// The number of bytes received in IPFS blocks from other peers
     pub data_received: u64,
+    /// Duplicate blocks received (the block had already been received previously)
     pub dup_blks_received: u64,
+    /// The number of bytes in duplicate blocks received
     pub dup_data_received: u64,
+    /// The current peers
     pub peers: Vec<PeerId>,
+    /// The wantlist of the local node
     pub wantlist: Vec<(Cid, bitswap::Priority)>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,9 +68,7 @@ pub use self::{
 pub use bitswap::Block;
 pub use cid::Cid;
 pub use libp2p::{
-    core::{
-        connection::ListenerId, multiaddr::Protocol, ConnectedPoint, Multiaddr, PeerId, PublicKey,
-    },
+    core::{connection::ListenerId, multiaddr::Protocol, Multiaddr, PeerId, PublicKey},
     identity::Keypair,
     kad::{record::Key, Quorum},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -806,7 +806,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         .await
     }
 
-    /// Forcefully unsubscribes a previously made [`SubscriptionStream`], which could also be
+    /// Forcibly unsubscribes a previously made [`SubscriptionStream`], which could also be
     /// unsubscribed by dropping the stream.
     ///
     /// Returns true if unsubscription was successful
@@ -857,7 +857,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
         .await
     }
 
-    /// Returns the known wantlist for the local node when `peer` is `None` or the given `peer`
+    /// Returns the known wantlist for the local node when the `peer` is `None` or the wantlist of the given `peer`
     pub async fn bitswap_wantlist(
         &self,
         peer: Option<PeerId>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -730,7 +730,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
 
     /// Subscribes to a given topic. Can be done at most once without unsubscribing in the between.
     /// The subscription can be unsubscribed by dropping the stream or calling
-    /// [`pubsub_unsubscribe`].
+    /// [`Ipfs::pubsub_unsubscribe`].
     pub async fn pubsub_subscribe(&self, topic: String) -> Result<SubscriptionStream, Error> {
         async move {
             let (tx, rx) = oneshot_channel();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,7 @@ pub use self::{
     path::IpfsPath,
     repo::{PinKind, PinMode, RepoTypes},
 };
-pub use bitswap::{BitswapEvent, Block, Stats};
+pub use bitswap::{Block, Stats};
 pub use cid::Cid;
 pub use libp2p::{
     core::{

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -169,8 +169,10 @@ impl Pubsub {
         }
     }
 
-    /// Unsubscribes from a topic.
-    /// Returns true if an existing subscription was dropped
+    /// Unsubscribes from a topic. Unsubscription is usually done through dropping the
+    /// SubscriptionStream.
+    ///
+    /// Returns true if an existing subscription was dropped, false otherwise
     pub fn unsubscribe(&mut self, topic: impl Into<String>) -> bool {
         let topic = Topic::new(topic);
         if self.streams.remove(&topic).is_some() {

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,11 +5,8 @@ use libp2p::PeerId;
 use std::fmt;
 use std::str::FromStr;
 
-// TODO: it might be useful to split this into CidPath and IpnsPath, then have Ipns resolve through
-// latter into CidPath (recursively) and have dag.rs support only CidPath. Keep IpfsPath as a
-// common abstraction which can be either.
-/// Abstraction over Ipfs paths, which are used to target sub-trees
-/// or sub-documents on top of content addressable ([`Cid`]) trees.
+/// Abstraction over Ipfs paths, which are used to target sub-trees or sub-documents on top of
+/// content addressable ([`Cid`]) trees.
 ///
 /// In addition to being based on content addressing, IpfsPaths provide adaptation from other Ipfs
 /// (related) functionality which can be resolved to a [`Cid`] such as IPNS. IpfsPaths have similar
@@ -30,6 +27,9 @@ use std::str::FromStr;
 /// [Multiaddr]: https://github.com/multiformats/multiaddr
 /// [IPNS]: https://github.com/ipfs/specs/blob/master/IPNS.md
 /// [DNSLINK]: https://dnslink.io/
+// TODO: it might be useful to split this into CidPath and IpnsPath, then have Ipns resolve through
+// latter into CidPath (recursively) and have dag.rs support only CidPath. Keep IpfsPath as a
+// common abstraction which can be either.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct IpfsPath {
     root: PathRoot,
@@ -58,7 +58,6 @@ impl FromStr for IpfsPath {
                     None => PathRoot::Dns(key.to_string()),
                 },
                 _ => {
-                    //todo!("empty: {:?}, root: {:?}, key: {:?}", empty, root_type, key);
                     return Err(IpfsPathError::InvalidPath(string.to_owned()).into());
                 }
             }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,5 +1,4 @@
 use crate::error::{Error, TryError};
-use crate::ipld::Ipld;
 use cid::Cid;
 use core::convert::{TryFrom, TryInto};
 use libp2p::PeerId;

--- a/src/path.rs
+++ b/src/path.rs
@@ -266,39 +266,10 @@ impl fmt::Debug for PathRoot {
 }
 
 impl PathRoot {
-    pub fn is_ipld(&self) -> bool {
-        matches!(self, PathRoot::Ipld(_))
-    }
-
-    pub fn is_ipns(&self) -> bool {
-        matches!(self, PathRoot::Ipns(_))
-    }
-
     pub fn cid(&self) -> Option<&Cid> {
         match self {
             PathRoot::Ipld(cid) => Some(cid),
             _ => None,
-        }
-    }
-
-    pub fn peer_id(&self) -> Option<&PeerId> {
-        match self {
-            PathRoot::Ipns(peer_id) => Some(peer_id),
-            _ => None,
-        }
-    }
-
-    pub fn to_bytes(&self) -> Vec<u8> {
-        self.into()
-    }
-}
-
-impl Into<Vec<u8>> for &PathRoot {
-    fn into(self) -> Vec<u8> {
-        match self {
-            PathRoot::Ipld(cid) => cid.to_bytes(),
-            PathRoot::Ipns(peer_id) => peer_id.as_bytes().to_vec(),
-            PathRoot::Dns(domain) => domain.as_bytes().to_vec(),
         }
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,3 +1,5 @@
+//! [`IpfsPath`] related functionality for content addressed paths with links.
+
 use crate::error::{Error, TryError};
 use cid::Cid;
 use core::convert::{TryFrom, TryInto};

--- a/src/path.rs
+++ b/src/path.rs
@@ -8,7 +8,8 @@ use std::fmt;
 use std::str::FromStr;
 
 /// Abstraction over Ipfs paths, which are used to target sub-trees or sub-documents on top of
-/// content addressable ([`Cid`]) trees.
+/// content addressable ([`Cid`]) trees. The most common use case is to specify a file under an
+/// unixfs tree from underneath a [`Cid`] forest.
 ///
 /// In addition to being based on content addressing, IpfsPaths provide adaptation from other Ipfs
 /// (related) functionality which can be resolved to a [`Cid`] such as IPNS. IpfsPaths have similar

--- a/src/path.rs
+++ b/src/path.rs
@@ -84,24 +84,17 @@ impl IpfsPath {
         &self.root
     }
 
-    pub fn set_root(&mut self, root: PathRoot) {
-        self.root = root;
-    }
-
-    pub fn push_str(&mut self, string: &str) -> Result<(), Error> {
+    pub(crate) fn push_str(&mut self, string: &str) -> Result<(), Error> {
         self.path.push_path(string)?;
         Ok(())
     }
 
-    pub fn sub_path(&self, string: &str) -> Result<Self, Error> {
+    /// Returns a new [`IpfsPath`] with the given path segments appended, or an error, if a segment is
+    /// invalid.
+    pub fn sub_path(&self, segments: &str) -> Result<Self, Error> {
         let mut path = self.to_owned();
-        path.push_str(string)?;
+        path.push_str(segments)?;
         Ok(path)
-    }
-
-    pub fn into_sub_path(mut self, string: &str) -> Result<Self, Error> {
-        self.push_str(string)?;
-        Ok(self)
     }
 
     /// Returns an iterator over the path segments following the root

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -1,3 +1,5 @@
+//! `refs` or the references of dag-pb and other supported IPLD formats functionality.
+
 use crate::ipld::{decode_ipld, Ipld};
 use crate::{Block, Ipfs, IpfsTypes};
 use async_stream::stream;

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -11,7 +11,7 @@ use std::fmt;
 /// Represents a single link in an IPLD tree encountered during a `refs` walk.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Edge {
-    /// Source document which links to [`destination`]
+    /// Source document which links to [`Edge::destination`]
     pub source: Cid,
     /// The destination document
     pub destination: Cid,

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -22,12 +22,12 @@ mod paths;
 use paths::{block_path, filestem_to_block_cid, filestem_to_pin_cid, pin_path};
 
 /// FsDataStore which uses the filesystem as a lockable key-value store. Maintains a similar to
-/// blockstore sharded two level storage. Direct have empty files, recursive pins record all of
+/// [`FsBlockStore`] sharded two level storage. Direct have empty files, recursive pins record all of
 /// their indirect descendants. Pin files are separated by their file extensions.
 ///
-/// When modifying, single write lock is used.
+/// When modifying, single lock is used.
 ///
-/// For the PinStore implementation, please see `fs/pinstore.rs`.
+/// For the [`PinStore`] implementation, please see `fs/pinstore.rs`.
 #[derive(Debug)]
 pub struct FsDataStore {
     /// The base directory under which we have a sharded directory structure, and the individual

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -27,7 +27,7 @@ use paths::{block_path, filestem_to_block_cid, filestem_to_pin_cid, pin_path};
 ///
 /// When modifying, single lock is used.
 ///
-/// For the [`PinStore`] implementation, please see `fs/pinstore.rs`.
+/// For the [`crate::repo::PinStore`] implementation see `fs/pinstore.rs`.
 #[derive(Debug)]
 pub struct FsDataStore {
     /// The base directory under which we have a sharded directory structure, and the individual

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -1,4 +1,7 @@
-//! Persistent fs backed repo
+//! Persistent fs backed repo.
+//!
+//! Consists of [`FsDataStore`] and [`FsBlockStore`].
+
 use crate::error::Error;
 use async_trait::async_trait;
 use std::path::PathBuf;

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -20,7 +20,7 @@ type ArcMutexMap<A, B> = Arc<Mutex<HashMap<A, B>>>;
 
 /// File system backed block store.
 ///
-/// For information on path mangling, please see [`block_path`] and [`filestem_to_block_cid`].
+/// For information on path mangling, please see `block_path` and `filestem_to_block_cid`.
 #[derive(Debug)]
 pub struct FsBlockStore {
     /// The base directory under which we have a sharded directory structure, and the individual

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -1,4 +1,4 @@
-//! IPFS repo
+//! Storage implementation(s) backing the [`crate::Ipfs`].
 use crate::error::Error;
 use crate::p2p::KadResult;
 use crate::path::IpfsPath;

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -259,7 +259,7 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
     }
 
     /// Shutdowns the repo, cancelling any pending subscriptions; Likely going away after some
-    /// refactoring, see notes on [`Ipfs::exit_daemon`].
+    /// refactoring, see notes on [`crate::Ipfs::exit_daemon`].
     pub fn shutdown(&self) {
         self.subscriptions.shutdown();
     }

--- a/src/unixfs/mod.rs
+++ b/src/unixfs/mod.rs
@@ -1,3 +1,8 @@
+//! Adaptation for `ipfs-unixfs` crate functionality on top of [`crate::Ipfs`].
+//!
+//! Adding files and directory structures is supported but not exposed via an API. See examples and
+//! `ipfs-http`.
+
 pub use ipfs_unixfs as ll;
 
 mod cat;


### PR DESCRIPTION
Adds at least top level documentation for many types, hides some unnecessary re-exports, removes warnings from nightly rustdoc on bad links, and so on.

Cc: #197 (this leaves us with 185 errors)