### PR TITLE
ipfs-unixfs: update changelog, bump version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1265,7 +1265,7 @@ dependencies = [
 
 [[package]]
 name = "ipfs-unixfs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cid",
  "criterion",

--- a/unixfs/CHANGELOG.md
+++ b/unixfs/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.2.0
+
+Minor version bump due to ipfs 0.2.0 release.
+
+* Clippy future-proofing [#316]
+* Use core and alloc crates instead of std [#331]
+* `crate::dagpb::wrap_node_data`, part of [#332]
+* minor doc fix for `crate::dir::ResolveError::UnexpectedType`, part of [#332]
+
+[#316]: https://github.com/rs-ipfs/rust-ipfs/pull/316
+[#331]: https://github.com/rs-ipfs/rust-ipfs/pull/331
+[#332]: https://github.com/rs-ipfs/rust-ipfs/pull/332
+
 # 0.1.0
 
 Minor version bump due to many new features and broken API.

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 name = "ipfs-unixfs"
 readme = "README.md"
 repository = "https://github.com/rs-ipfs/rust-ipfs"
-version = "0.1.0"
+version = "0.2.0"
 
 [features]
 default = ["filetime"]


### PR DESCRIPTION
Updates the changelog and bumps the version to 0.2.0. I'll tag and release after merging.