### PR TITLE
chore: add missing Cargo.toml metadata

### DIFF
--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -1,8 +1,11 @@
 [package]
 authors = ["Rust-IPFS contributors"]
+description = "Bitswap protocol implementation used in ipfs"
 edition = "2018"
 name = "ipfs-bitswap"
 version = "0.1.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/rs-ipfs/rust-ipfs"
 
 [build-dependencies]
 prost-build = { default-features = false, version = "0.6" }


### PR DESCRIPTION
whoops.

This PR adds the necessary metadata bitswap/Cargo.toml, so that I can publish it.