### PR TITLE
fix restore_bootstrappers doesn't enable content discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+* fix: restore_bootstrappers doesn't enable content discovery [#406]
+
+[#406]: https://github.com/rs-ipfs/rust-ipfs/pull/406
+
 # 0.2.0
 
 First real release, with big changes and feature improvements. Started tracking

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -26,7 +26,7 @@ async fn main() {
             );
             eprintln!();
             eprintln!(
-                "Example will try to find the file by the given IPFS_PATH and print it's contents to stdout."
+                "Example will try to find the file by the given IPFS_PATH and print its contents to stdout."
             );
             eprintln!();
             eprintln!("The example has three modes in the order of precedence:");
@@ -37,7 +37,7 @@ async fn main() {
                 "2. When IPFS_PATH and MULTIADDR are given, connect to MULTIADDR to get the file"
             );
             eprintln!(
-                "3. When only IPFS_PATH is given, await to be connected by another ipfs node"
+                "3. When only IPFS_PATH is given, wait to be connected to by another ipfs node"
             );
             exit(0);
         }

--- a/http/src/v0/bootstrap.rs
+++ b/http/src/v0/bootstrap.rs
@@ -48,7 +48,7 @@ pub struct BootstrapAddQuery {
     timeout: Option<StringSerialized<humantime::Duration>>,
 }
 
-// optionally timedout wrapper around [`Ipfs::restore_bootstrappers`] with stringified errors, used
+// optionally timed-out wrapper around [`Ipfs::restore_bootstrappers`] with stringified errors, used
 // in both bootstrap_add_query and bootstrap_restore_query
 async fn restore_helper<T: IpfsTypes>(
     ipfs: Ipfs<T>,
@@ -83,7 +83,7 @@ async fn bootstrap_add_query<T: IpfsTypes>(
             .map_err(StringError::from)?
             .to_string()]
     } else if default == Some(true) {
-        // HTTP api documents the ?default=true as the deprecated way
+        // HTTP api documents `?default=true` as deprecated
         let _ = restore_helper(ipfs, &timeout).await?;
 
         // return a list of all known bootstrap nodes as js-ipfs does
@@ -116,7 +116,7 @@ pub struct BootstrapClearQuery {
     timeout: Option<StringSerialized<humantime::Duration>>,
 }
 
-// optionally timeouted wrapper over [`Ipfs::clear_bootstrappers`] used in both
+// optionally timed-out wrapper over [`Ipfs::clear_bootstrappers`] used in both
 // `bootstrap_clear_query` and `bootstrap_rm_query`.
 async fn clear_helper<T: IpfsTypes>(
     ipfs: Ipfs<T>,
@@ -204,7 +204,7 @@ async fn bootstrap_restore_query<T: IpfsTypes>(
 ) -> Result<impl Reply, Rejection> {
     let _ = restore_helper(ipfs, &query.timeout).await?;
 
-    // similar to add?default=true return a list of all bootstrap nodes, not only the added ones
+    // similar to add?default=true; returns a list of all bootstrap nodes, not only the added ones
     let peers = ipfs::config::BOOTSTRAP_NODES.to_vec();
     let response = Response { peers };
 

--- a/http/src/v0/bootstrap.rs
+++ b/http/src/v0/bootstrap.rs
@@ -48,7 +48,8 @@ pub struct BootstrapAddQuery {
     timeout: Option<StringSerialized<humantime::Duration>>,
 }
 
-// used in both bootstrap_add_query and bootstrap_restore_query
+// optionally timedout wrapper around [`Ipfs::restore_bootstrappers`] with stringified errors, used
+// in both bootstrap_add_query and bootstrap_restore_query
 async fn restore_helper<T: IpfsTypes>(
     ipfs: Ipfs<T>,
     timeout: &Option<StringSerialized<humantime::Duration>>,
@@ -101,6 +102,7 @@ async fn bootstrap_add_query<T: IpfsTypes>(
     Ok(warp::reply::json(&response))
 }
 
+/// https://docs.ipfs.io/reference/http/api/#api-v0-bootstrap-add
 pub fn bootstrap_add<T: IpfsTypes>(
     ipfs: &Ipfs<T>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
@@ -114,7 +116,8 @@ pub struct BootstrapClearQuery {
     timeout: Option<StringSerialized<humantime::Duration>>,
 }
 
-// used in both bootstrap_clear_query and bootstrap_rm_query
+// optionally timeouted wrapper over [`Ipfs::clear_bootstrappers`] used in both
+// `bootstrap_clear_query` and `bootstrap_rm_query`.
 async fn clear_helper<T: IpfsTypes>(
     ipfs: Ipfs<T>,
     timeout: &Option<StringSerialized<humantime::Duration>>,
@@ -208,6 +211,8 @@ async fn bootstrap_restore_query<T: IpfsTypes>(
     Ok(warp::reply::json(&response))
 }
 
+/// https://docs.ipfs.io/reference/http/api/#api-v0-bootstrap-add-default, similar functionality
+/// also available via /bootstrap/add?default=true through [`bootstrap_add`].
 pub fn bootstrap_restore<T: IpfsTypes>(
     ipfs: &Ipfs<T>,
 ) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,19 @@
 //! Static configuration (the bootstrap node(s)).
 
+/// The supported bootstrap nodes (/dnsaddr is not yet supported).
+// FIXME: it would be nice to parse these into MultiaddrWithPeerId with const fn.
 pub const BOOTSTRAP_NODES: &[&str] =
     &["/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"];
+
+#[cfg(test)]
+mod tests {
+    use crate::p2p::MultiaddrWithPeerId;
+
+    #[test]
+    fn bootstrap_nodes_are_multiaddr_with_peerid() {
+        super::BOOTSTRAP_NODES
+            .iter()
+            .try_for_each(|s| s.parse::<MultiaddrWithPeerId>().map(|_| ()))
+            .unwrap();
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 //! Static configuration (the bootstrap node(s)).
 
-/// The supported bootstrap nodes (/dnsaddr is not yet supported).
+/// The supported bootstrap nodes (/dnsaddr is not yet supported). This will be updated to contain
+/// the latest known supported IPFS bootstrap peers.
 // FIXME: it would be nice to parse these into MultiaddrWithPeerId with const fn.
 pub const BOOTSTRAP_NODES: &[&str] =
     &["/ip4/104.131.131.82/tcp/4001/p2p/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1113,6 +1113,8 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     }
 
     /// Extend the list of used bootstrapper nodes with an additional address.
+    /// Return value cannot be used to determine if the `addr` was a new bootstrapper, subject to
+    /// change.
     pub async fn add_bootstrapper(&self, addr: MultiaddrWithPeerId) -> Result<Multiaddr, Error> {
         async move {
             let (tx, rx) = oneshot_channel();
@@ -1129,6 +1131,8 @@ impl<Types: IpfsTypes> Ipfs<Types> {
     }
 
     /// Remove an address from the currently used list of bootstrapper nodes.
+    /// Return value cannot be used to determine if the `addr` was an actual bootstrapper, subject to
+    /// change.
     pub async fn remove_bootstrapper(&self, addr: MultiaddrWithPeerId) -> Result<Multiaddr, Error> {
         async move {
             let (tx, rx) = oneshot_channel();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! [js-ipfs]: https://github.com/ipfs/js-ipfs/
 //#![deny(missing_docs)]
 
-mod config;
+pub mod config;
 pub mod dag;
 pub mod error;
 #[macro_use]

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -623,11 +623,13 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     ) -> Result<Multiaddr, anyhow::Error> {
         let ret = addr.clone().into();
         self.swarm.bootstrappers.remove(&addr);
+        // FIXME: why not kademlia.remove_address?
         Ok(ret)
     }
 
     pub fn clear_bootstrappers(&mut self) -> Vec<Multiaddr> {
         self.swarm.bootstrappers.drain().map(|a| a.into()).collect()
+        // FIXME: why not kademlia.remove_address?
     }
 
     pub fn restore_bootstrappers(&mut self) -> Result<Vec<Multiaddr>, anyhow::Error> {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -643,14 +643,17 @@ impl<Types: IpfsTypes> Behaviour<Types> {
                 let MultiaddrWithPeerId {
                     multiaddr: ma,
                     peer_id,
-                } = addr;
+                } = addr.clone();
 
                 // this is intentionally the multiaddr without peerid turned into plain multiaddr:
                 // libp2p cannot dial addresses which include peerids.
                 let ma: Multiaddr = ma.into();
 
                 self.kademlia.add_address(&peer_id, ma.clone());
-                ret.push(ma);
+
+                // report with the peerid
+                let reported: Multiaddr = addr.into();
+                ret.push(reported);
             }
         }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -636,13 +636,17 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         let mut ret = Vec::new();
 
         for addr in BOOTSTRAP_NODES {
-            let addr = addr.parse::<MultiaddrWithPeerId>().unwrap();
+            let addr = addr
+                .parse::<MultiaddrWithPeerId>()
+                .expect("see test bootstrap_nodes_are_multiaddr_with_peerid");
             if self.swarm.bootstrappers.insert(addr.clone()) {
                 let MultiaddrWithPeerId {
                     multiaddr: ma,
                     peer_id,
                 } = addr;
 
+                // this is intentionally the multiaddr without peerid turned into plain multiaddr:
+                // libp2p cannot dial addresses which include peerids.
                 let ma: Multiaddr = ma.into();
 
                 self.kademlia.add_address(&peer_id, ma.clone());

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -607,12 +607,13 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         addr: MultiaddrWithPeerId,
     ) -> Result<Multiaddr, anyhow::Error> {
         let ret = addr.clone().into();
-        self.swarm.bootstrappers.insert(addr.clone());
-        let MultiaddrWithPeerId {
-            multiaddr: _,
-            peer_id,
-        } = addr.clone();
-        self.kademlia.add_address(&peer_id, addr.into());
+        if self.swarm.bootstrappers.insert(addr.clone()) {
+            let MultiaddrWithPeerId {
+                multiaddr: ma,
+                peer_id,
+            } = addr.clone();
+            self.kademlia.add_address(&peer_id, ma.into());
+        }
         Ok(ret)
     }
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -611,7 +611,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
             let MultiaddrWithPeerId {
                 multiaddr: ma,
                 peer_id,
-            } = addr.clone();
+            } = addr;
             self.kademlia.add_address(&peer_id, ma.into());
         }
         Ok(ret)

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -1,6 +1,6 @@
 use cid::{Cid, Codec};
 use ipfs::{p2p::MultiaddrWithPeerId, Block, Node};
-use libp2p::{kad::Quorum, multiaddr::Protocol, Multiaddr, PeerId};
+use libp2p::{kad::Quorum, multiaddr::Protocol, Multiaddr};
 use multihash::Sha2_256;
 use tokio::time::timeout;
 
@@ -139,20 +139,9 @@ async fn dht_get_closest_peers() {
 #[ignore = "targets an actual bootstrapper, so random failures can happen"]
 #[tokio::test(max_threads = 1)]
 async fn dht_popular_content_discovery() {
-    let (bootstrapper_id, bootstrapper_addr): (PeerId, Multiaddr) = (
-        "QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
-            .parse()
-            .unwrap(),
-        "/ip4/104.131.131.82/tcp/4001".parse().unwrap(),
-    );
-
     let peer = Node::new("a").await;
 
-    // connect it to one of the well-known bootstrappers
-    assert!(peer
-        .add_peer(bootstrapper_id, bootstrapper_addr)
-        .await
-        .is_ok());
+    peer.restore_bootstrappers().await.unwrap();
 
     // the Cid of the IPFS logo
     let cid: Cid = "bafkreicncneocapbypwwe3gl47bzvr3pkpxmmobzn7zr2iaz67df4kjeiq"


### PR DESCRIPTION
Fixes #405 and also:

- makes sure ipfs.restore_bootstrappers is used in the `dht_popular_content_discovery` test
- adds a test case making sure we can parse all config::BOOTSTRAP_NODES
- ~adds some FIXMEs we couldn't decide yet on the other /bootstrap impl~ handled
- expose ipfs::config to allow http to access ipfs::config::BOOTSTRAP_NODES to enable the http api semantics
- keep exposing the delta semantics in ipfs.restore_bootstrappers
- use ipfs.restore_bootstrappers in examples/fetch_and_cat.rs via new `--default-bootstrappers` option/mode
- add tracing to *_bootstrapper methods