### PR TITLE
Fix gha deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,10 +163,11 @@ jobs:
 
     - name: Upload crashes (macos)
       uses: actions/upload-artifact@v2
-      if: matrix.platform.host == 'macos-latest' && ${{ always() }}
+      if: ${{ always() }}
       with:
         name: macos.crashes
         path: /cores
+        if-no-files-found: ignore
 
   lint-rust:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
         vcpkgGitCommitId: 'ffa41582f78478812c836a6e8ce315fb27431182'  # ok for openssl-sys v0.9.58
 
     - name: Install rust toolchain
-      uses: hecrj/setup-rust-action@v1
+      uses: hecrj/setup-rust-action@v1.3.4
       with:
         rust-version: ${{ matrix.toolchain.rust }}
         targets: ${{ matrix.platform.target }}
@@ -182,7 +182,7 @@ jobs:
         key: lint-cargo-${{ hashFiles('Cargo.lock') }}
 
     - name: Install rust toolchain
-      uses: hecrj/setup-rust-action@v1
+      uses: hecrj/setup-rust-action@v1.3.4
       with:
         rust-version: stable
         components: clippy, rustfmt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         tar -xf go_ipfs.tar.gz
 
     - name: Install dependencies windows (openssl)
-      uses: lukka/run-vcpkg@v3.3
+      uses: lukka/run-vcpkg@v4.1
       id: windows-runvcpkg
       if: matrix.platform.host == 'windows-latest'
       with:

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -172,13 +172,11 @@ pub enum PinMode {
 
 impl<B: Borrow<Cid>> PartialEq<PinMode> for PinKind<B> {
     fn eq(&self, other: &PinMode) -> bool {
-        match (self, other) {
+        matches!((self, other),
             (PinKind::IndirectFrom(_), PinMode::Indirect)
             | (PinKind::Direct, PinMode::Direct)
             | (PinKind::Recursive(_), PinMode::Recursive)
-            | (PinKind::RecursiveIntention, PinMode::Recursive) => true,
-            _ => false,
-        }
+            | (PinKind::RecursiveIntention, PinMode::Recursive))
     }
 }
 


### PR DESCRIPTION
In this PR:

 - Fixes #407 
 - "no artifacts found" nagging for missing core files
 - 1.47 clippy warning

Github had [a security issue and will be deprecating some functionality](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). I learned this from the easy-to-miss workflow warnings.