### PR TITLE
Prepare 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next
 
+# 0.2.1
+
 * fix: restore_bootstrappers doesn't enable content discovery [#406]
 
 [#406]: https://github.com/rs-ipfs/rust-ipfs/pull/406

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1185,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "ipfs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ name = "ipfs"
 readme = "README.md"
 repository = "https://github.com/rs-ipfs/rust-ipfs"
 description = "IPFS node implementation"
-version = "0.2.0"
+version = "0.2.1"
 
 [features]
 default = []

--- a/examples/fetch_and_cat.rs
+++ b/examples/fetch_and_cat.rs
@@ -9,15 +9,6 @@ use tokio::io::AsyncWriteExt;
 async fn main() {
     tracing_subscriber::fmt::init();
 
-    // This example attempts to fetch a CID provided at command line. It is expected to be used by
-    // either:
-    //
-    //  - connecting another ipfs peer to it
-    //  - be given the other peers address as the last argument
-    //
-    // The other connecting or connected peer must be providing the requested CID or this will hang
-    // forever.
-
     let (bootstrappers, path, target) = match parse_options() {
         Ok(Some(tuple)) => tuple,
         Ok(None) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,12 @@
 //! [interface-ipfs-core]: https://www.npmjs.com/package/interface-ipfs-core
 //! [go-ipfs]: https://github.com/ipfs/go-ipfs/
 //! [js-ipfs]: https://github.com/ipfs/js-ipfs/
+// We are not done yet, but uncommenting this makes it easier to hunt down for missing docs.
 //#![deny(missing_docs)]
+//
+// This isn't recognized in stable yet, but we should disregard any nags on these to keep making
+// the docs better.
+//#![allow(private_intra_doc_links)]
 
 pub mod config;
 pub mod dag;


### PR DESCRIPTION
Tracked in #413. This turned out a bit misc PR with the comment removal from fetch_and_cat and all that.
