### PR TITLE
fix(http): change default ipfs path to .rust-ipfs

### DIFF
--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
         .or_else(|| {
             std::env::var_os("HOME").map(|tilde| {
                 let mut path = PathBuf::from(tilde);
-                path.push(".ipfs");
+                path.push(".rust-ipfs");
                 path
             })
         });


### PR DESCRIPTION
This PR changes the default `IPFS_PATH` from `.ipfs` to `.rust-ipfs` as mentioned in #402. 

I _think_ this is all that's needed? 
