### PR TITLE
feat(http): create Profile abstraction to allow port choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Next
 
-* fix(http): create `Profile` abstraction [#421]
+* feat(http): create `Profile` abstraction [#421]
 
 [#421]: https://github.com/rs-ipfs/rust-ipfs/pull/421
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+* fix(http): create `Profile` abstraction [#421]
+
+[#421]: https://github.com/rs-ipfs/rust-ipfs/pull/421
+
 # 0.2.1
 
 * fix: restore_bootstrappers doesn't enable content discovery [#406]

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -1,9 +1,8 @@
 //! go-ipfs compatible configuration file handling and setup.
 
-use parity_multiaddr::Multiaddr;
+use parity_multiaddr::{multiaddr, Multiaddr};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
-use std::net::SocketAddr;
 use std::num::NonZeroU16;
 use std::path::Path;
 use std::str::FromStr;
@@ -87,8 +86,8 @@ fn create(
     use std::io::BufWriter;
 
     let api_addr = match profiles[0] {
-        Profile::Test => "127.0.0.1:0",
-        Profile::Default => "127.0.0.1:4004",
+        Profile::Test => multiaddr!(Ip4([127, 0, 0, 1]), Tcp(0u16)),
+        Profile::Default => multiaddr!(Ip4([127, 0, 0, 1]), Tcp(4004u16)),
     };
 
     let bits = bits.get();
@@ -143,7 +142,7 @@ fn create(
         },
         addresses: Addresses {
             swarm: vec!["/ip4/127.0.0.1/tcp/0".parse().unwrap()],
-            api: api_addr.parse().unwrap(),
+            api: api_addr,
         },
     };
 
@@ -173,7 +172,7 @@ pub enum LoadingError {
 /// Returns only the keypair and listening addresses or [`LoadingError`] but this should be
 /// extended to contain the bootstrap nodes at least later when we need to support those for
 /// testing purposes.
-pub fn load(config: File) -> Result<(ipfs::Keypair, Vec<Multiaddr>, SocketAddr), LoadingError> {
+pub fn load(config: File) -> Result<(ipfs::Keypair, Vec<Multiaddr>, Multiaddr), LoadingError> {
     use std::io::BufReader;
 
     let CompatibleConfigFile {
@@ -272,7 +271,7 @@ struct CompatibleConfigFile {
 struct Addresses {
     swarm: Vec<Multiaddr>,
     #[serde(rename = "API")]
-    api: SocketAddr,
+    api: Multiaddr,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -86,7 +86,7 @@ fn create(
     use prost::Message;
     use std::io::BufWriter;
 
-    let api_addrs = match profiles[0] {
+    let api_addr = match profiles[0] {
         Profile::Test => "127.0.0.1:0",
         Profile::Default => "127.0.0.1:4004",
     };
@@ -143,7 +143,7 @@ fn create(
         },
         addresses: Addresses {
             swarm: vec!["/ip4/127.0.0.1/tcp/0".parse().unwrap()],
-            api: api_addrs.parse().unwrap(),
+            api: api_addr.parse().unwrap(),
         },
     };
 

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -64,10 +64,6 @@ pub fn initialize(
     // This check is done here to avoid an empty config file being created in the case of an
     // unsupported input.
     if profiles.len() != 1 {
-        // profiles are expected to be (comma separated) "test" as there are no bootstrap peer
-        // handling yet. the conformance test cases seem to init `go-ipfs` in this profile where
-        // it does not have any bootstrap nodes, and multi node tests later call swarm apis to
-        // dial the nodes together.
         unimplemented!("Multiple profiles are currently unsupported!");
     }
 
@@ -275,6 +271,7 @@ struct CompatibleConfigFile {
 #[serde(rename_all = "PascalCase")]
 struct Addresses {
     swarm: Vec<Multiaddr>,
+    #[serde(rename = "API")]
     api: SocketAddr,
 }
 

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -19,7 +19,7 @@ enum Options {
         /// List of configuration profiles to apply. Currently only the `Test` and `Default`
         /// profiles are supported.  
         ///
-        /// `Test` uses ephemeral ports, `Default` uses `4004`.
+        /// `Test` uses ephemeral ports (necessary for conformance tests), `Default` uses `4004`.
         #[structopt(long, use_delimiter = true)]
         profile: Vec<config::Profile>,
     },
@@ -157,11 +157,6 @@ fn main() {
 
         let api_link_file = home.join("api");
 
-        // If the port is specified, use that to start the server, if it isn't use ephemeral ports,
-        // i.e.:
-        //
-        // port => port
-        // none => 0
         let (addr, server) = serve(&ipfs, api_listening_addrs);
 
         // shutdown future will handle signalling the exit

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -62,7 +62,7 @@ fn main() {
 
     let config_path = home.join("config");
 
-    let (keypair, listening_addrs, api_listening_addrs) = match opts {
+    let (keypair, listening_addrs, api_listening_addr) = match opts {
         Options::Init { bits, profile } => {
             println!("initializing IPFS node at {:?}", home);
 
@@ -157,7 +157,7 @@ fn main() {
 
         let api_link_file = home.join("api");
 
-        let (addr, server) = serve(&ipfs, api_listening_addrs);
+        let (addr, server) = serve(&ipfs, api_listening_addr);
 
         // shutdown future will handle signalling the exit
         drop(ipfs);
@@ -189,7 +189,7 @@ fn main() {
 
 fn serve<Types: IpfsTypes>(
     ipfs: &Ipfs<Types>,
-    listening_addrs: std::net::SocketAddr,
+    listening_addr: std::net::SocketAddr,
 ) -> (std::net::SocketAddr, impl std::future::Future<Output = ()>) {
     use tokio::stream::StreamExt;
     use warp::Filter;
@@ -200,7 +200,7 @@ fn serve<Types: IpfsTypes>(
 
     let ipfs = ipfs.clone();
 
-    warp::serve(routes).bind_with_graceful_shutdown(listening_addrs, async move {
+    warp::serve(routes).bind_with_graceful_shutdown(listening_addr, async move {
         shutdown_rx.next().await;
         info!("Shutdown trigger received; starting shutdown");
         ipfs.exit_daemon().await;

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -16,9 +16,12 @@ enum Options {
         /// Generated key length
         #[structopt(long)]
         bits: NonZeroU16,
-        /// List of configuration profiles to apply
-        #[structopt(long)]
-        profile: config::Profile,
+        /// List of configuration profiles to apply. Currently only the `Test` and `Default`
+        /// profiles are supported.  
+        ///
+        /// `Test` uses ephemeral ports, `Default` uses `4004`.
+        #[structopt(long, use_delimiter = true)]
+        profile: Vec<config::Profile>,
     },
     /// Start the IPFS node in the foreground (not detaching from parent process).
     Daemon,
@@ -201,8 +204,6 @@ fn serve<Types: IpfsTypes>(
     let routes = routes.with(warp::log(env!("CARGO_PKG_NAME")));
 
     let ipfs = ipfs.clone();
-
-    println!("SOCKET_ADDR: {:?}", listening_addrs);
 
     warp::serve(routes).bind_with_graceful_shutdown(listening_addrs, async move {
         shutdown_rx.next().await;


### PR DESCRIPTION
This PR introduces a `Profile` abstraction to allow the customisation of port selection as discussed in #402.

Two profiles are supported: 
- `Test` for use with conformance tests (ephemeral port selection)
- `Default` serves on `4004`