### PR TITLE
Update to go-ipfs 0.7.0 (used in interop tests) 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     - name: Download go-ipfs on Linux
       if: matrix.platform.host == 'ubuntu-latest'
       run: |
-        curl -L https://github.com/ipfs/go-ipfs/releases/download/v0.6.0/go-ipfs_v0.6.0_linux-amd64.tar.gz --output go_ipfs.tar.gz
+        curl -L https://github.com/ipfs/go-ipfs/releases/download/v0.7.0/go-ipfs_v0.7.0_linux-amd64.tar.gz --output go_ipfs.tar.gz
         tar -xf go_ipfs.tar.gz
 
     - name: Install dependencies windows (openssl)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Next
 
+* ci: update go-ipfs to `0.7.0` for interop tests [#428]
 * refactor(http): introduce `Config` as the facade for configuration [#423]
 * feat(http): create `Profile` abstraction [#421]
 
+[#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
 [#423]: https://github.com/rs-ipfs/rust-ipfs/pull/423
 [#421]: https://github.com/rs-ipfs/rust-ipfs/pull/421
 

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -59,8 +59,6 @@ pub mod common {
                 .arg("init")
                 .arg("-p")
                 .arg("test")
-                .arg("--bits")
-                .arg("2048")
                 .stdout(Stdio::null())
                 .status()
                 .unwrap();


### PR DESCRIPTION
We were using `0.6.0`, this upgrades to `0.7.0`. 

I also removed the `--bits` option as `0.7` uses `ed25519` by default. 