### PR TITLE
feat: repo locking with fs2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Next
 
+* feat: introduce repo locking [#429]
 * ci: update go-ipfs to `0.7.0` for interop tests [#428]
 * refactor(http): introduce `Config` as the facade for configuration [#423]
 * feat(http): create `Profile` abstraction [#421]
 
+[#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
 [#423]: https://github.com/rs-ipfs/rust-ipfs/pull/423
 [#421]: https://github.com/rs-ipfs/rust-ipfs/pull/421

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,6 +766,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1198,6 +1208,7 @@ dependencies = [
  "domain",
  "domain-resolv",
  "either",
+ "fs2",
  "futures",
  "hex-literal",
  "ipconfig",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { default-features = false, features = ["fs", "rt-threaded", "stream", "
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = ["std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }
+fs2 = "0.4.3"
 
 [target.'cfg(windows)'.dependencies]
 # required for DNS resolution

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = ["std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }
 fs2 = "0.4.3"
+tempfile = "3.1.0"
 
 [target.'cfg(windows)'.dependencies]
 # required for DNS resolution
@@ -54,7 +55,6 @@ hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
 tokio = { default-features = false, features = ["io-std"], version = "0.2" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
-tempfile = "3.1.0"
 
 [workspace]
 members = [ "bitswap", "http", "unixfs" ]

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -18,7 +18,7 @@ enum Options {
         #[structopt(long)]
         bits: NonZeroU16,
         /// List of configuration profiles to apply. Currently only the `Test` and `Default`
-        /// profiles are supported.  
+        /// profiles are supported.
         ///
         /// `Test` uses ephemeral ports (necessary for conformance tests), `Default` uses `4004`.
         #[structopt(long, use_delimiter = true)]
@@ -143,6 +143,7 @@ fn main() {
             span: None,
         };
 
+        // TODO: handle errors more gracefully.
         let (ipfs, task): (Ipfs<ipfs::Types>, _) = UninitializedIpfs::new(opts)
             .start()
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use tracing_futures::Instrument;
 use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet},
-    fmt,
+    env, fmt,
     future::Future,
     ops::{Deref, DerefMut, Range},
     path::PathBuf,
@@ -104,6 +104,7 @@ pub struct Types;
 impl RepoTypes for Types {
     type TBlockStore = repo::fs::FsBlockStore;
     type TDataStore = repo::fs::FsDataStore;
+    type TLock = repo::fs::FsLock;
 }
 
 /// In-memory testing configuration used in tests.
@@ -112,6 +113,7 @@ pub struct TestTypes;
 impl RepoTypes for TestTypes {
     type TBlockStore = repo::mem::MemBlockStore;
     type TDataStore = repo::mem::MemDataStore;
+    type TLock = repo::mem::MemLock;
 }
 
 /// Ipfs node options used to configure the node to be created with [`UninitializedIpfs`].
@@ -177,12 +179,8 @@ impl IpfsOptions {
     ///
     /// Also used from examples.
     pub fn inmemory_with_generated_keys() -> Self {
-        use tempfile::TempDir;
-
-        let tempdir = TempDir::new().expect("tempdir creation failed").into_path();
-
         Self {
-            ipfs_path: tempdir,
+            ipfs_path: env::temp_dir(),
             keypair: Keypair::generate_ed25519(),
             mdns: Default::default(),
             bootstrap: Default::default(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ use tracing_futures::Instrument;
 use std::{
     borrow::Borrow,
     collections::{HashMap, HashSet},
-    env, fmt,
+    fmt,
     future::Future,
     ops::{Deref, DerefMut, Range},
     path::PathBuf,
@@ -177,8 +177,12 @@ impl IpfsOptions {
     ///
     /// Also used from examples.
     pub fn inmemory_with_generated_keys() -> Self {
+        use tempfile::TempDir;
+
+        let tempdir = TempDir::new().expect("tempdir creation failed").into_path();
+
         Self {
-            ipfs_path: env::temp_dir(),
+            ipfs_path: tempdir,
             keypair: Keypair::generate_ed25519(),
             mdns: Default::default(),
             bootstrap: Default::default(),

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -4,6 +4,7 @@
 
 use crate::error::Error;
 use async_trait::async_trait;
+use std::fs::File;
 use std::path::PathBuf;
 use std::sync::{atomic::AtomicU64, Arc};
 use tokio::sync::Semaphore;
@@ -88,9 +89,6 @@ impl DataStore for FsDataStore {
     }
 }
 
-use fs2::FileExt;
-use std::fs::File;
-
 #[derive(Debug)]
 pub struct FsLock {
     file: Option<File>,
@@ -114,6 +112,7 @@ impl Lock for FsLock {
     }
 
     fn try_exclusive(&mut self) -> Result<(), LockError> {
+        use fs2::FileExt;
         use std::fs::OpenOptions;
 
         let file = OpenOptions::new()

--- a/src/repo/fs.rs
+++ b/src/repo/fs.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use std::sync::{atomic::AtomicU64, Arc};
 use tokio::sync::Semaphore;
 
-use super::{BlockRm, BlockRmError, Column, DataStore, Lock, RepoCid};
+use super::{BlockRm, BlockRmError, Column, DataStore, Lock, LockError, RepoCid};
 
 /// The PinStore implementation for FsDataStore
 mod pinstore;
@@ -113,15 +113,14 @@ impl Lock for FsLock {
         }
     }
 
-    fn try_exclusive(&mut self) -> Result<(), Error> {
+    fn try_exclusive(&mut self) -> Result<(), LockError> {
         use std::fs::OpenOptions;
 
         let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
-            .open(&self.path)
-            .unwrap();
+            .open(&self.path)?;
 
         file.try_lock_exclusive()?;
 

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -1,6 +1,8 @@
 //! Volatile memory backed repo
 use crate::error::Error;
-use crate::repo::{BlockPut, BlockStore, Column, DataStore, Lock, PinKind, PinMode, PinStore};
+use crate::repo::{
+    BlockPut, BlockStore, Column, DataStore, Lock, LockError, PinKind, PinMode, PinStore,
+};
 use crate::Block;
 use async_trait::async_trait;
 use cid::Cid;
@@ -657,7 +659,7 @@ impl Lock for MemLock {
         Self
     }
 
-    fn try_exclusive(&mut self) -> Result<(), Error> {
+    fn try_exclusive(&mut self) -> Result<(), LockError> {
         Ok(())
     }
 }

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -1,6 +1,6 @@
 //! Volatile memory backed repo
 use crate::error::Error;
-use crate::repo::{BlockPut, BlockStore, Column, DataStore, PinKind, PinMode, PinStore};
+use crate::repo::{BlockPut, BlockStore, Column, DataStore, Lock, PinKind, PinMode, PinStore};
 use crate::Block;
 use async_trait::async_trait;
 use cid::Cid;
@@ -646,6 +646,17 @@ pub enum PinUpdateError {
     // go-ipfs prepends the ipfspath here
     #[error("is pinned recursively")]
     CannotUnpinDirectOnRecursivelyPinned,
+}
+
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct MemLock;
+
+impl Lock for MemLock {
+    fn new(_path: &Path) -> std::io::Result<Self> {
+        Ok(Self)
+    }
 }
 
 #[cfg(test)]

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -648,14 +648,17 @@ pub enum PinUpdateError {
     CannotUnpinDirectOnRecursivelyPinned,
 }
 
-use std::path::Path;
-
+// Used for in memory repos, currently not implementing any true locking.
 #[derive(Debug)]
 pub struct MemLock;
 
 impl Lock for MemLock {
-    fn new(_path: &Path) -> std::io::Result<Self> {
-        Ok(Self)
+    fn new(_path: PathBuf) -> Self {
+        Self
+    }
+
+    fn try_exclusive(&mut self) -> Result<(), Error> {
+        Ok(())
     }
 }
 

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -117,7 +117,6 @@ pub trait DataStore: PinStore + Debug + Send + Sync + Unpin + 'static {
     async fn wipe(&self);
 }
 
-#[async_trait]
 pub trait Lock: Debug + Send + Sync {
     fn new(path: &Path) -> std::io::Result<Self>
     where

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -254,7 +254,7 @@ impl Lock {
             .open(path)
             .unwrap();
 
-        FileExt::try_lock_exclusive(&file).unwrap();
+        FileExt::try_lock_exclusive(&file).expect("repo lock creation failed");
 
         Ok(Lock { file })
     }


### PR DESCRIPTION
supersedes #426 and resolves #243. 

This implements repo locking with fs2. The only concern for this crate is that it is poorly maintained but the functionality we need seems stable enough for now. 

Certain tests are currently failing, notably because multiple nodes are being created with the same repo (dag tests for instance). Not sure what the solution to this will be...

Update: running tests with `--test-threads=1` passes all unit tests. The integration tests fail (I think because multiple nodes are being spun up with the same repo). 

Update 2: all green, making sure test nodes use a different temp dir for the repo fixed the tests.