### PR TITLE
Update libp2p and tokio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
 dependencies = [
  "block-cipher",
- "byteorder 1.3.4",
+ "byteorder",
  "opaque-debug 0.3.0",
 ]
 
@@ -134,9 +134,12 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f46ca51dca4837f1520754d1c8c36636356b81553d928dc9c177025369a06e"
+checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "atty"
@@ -180,7 +183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
 dependencies = [
  "byte-tools",
- "byteorder 1.3.4",
+ "byteorder",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
  "opaque-debug 0.2.3",
@@ -216,7 +219,7 @@ checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding 0.1.5",
  "byte-tools",
- "byteorder 1.3.4",
+ "byteorder",
  "generic-array 0.12.3",
 ]
 
@@ -256,9 +259,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
@@ -286,12 +289,6 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-
-[[package]]
-name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
@@ -301,12 +298,6 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cast"
@@ -385,15 +376,6 @@ dependencies = [
  "bitflags",
  "textwrap",
  "unicode-width",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -550,25 +532,13 @@ dependencies = [
 
 [[package]]
 name = "cuckoofilter"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd43f7cfaffe0a386636a10baea2ee05cc50df3b77bea4a456c9572a939bf1f"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
 dependencies = [
- "byteorder 0.5.3",
- "rand 0.3.23",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-dependencies = [
- "byteorder 1.3.4",
- "digest 0.8.1",
- "rand_core 0.5.1",
- "subtle 2.3.0",
- "zeroize",
+ "byteorder",
+ "fnv",
+ "rand",
 ]
 
 [[package]]
@@ -577,9 +547,9 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "digest 0.9.0",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle 2.3.0",
  "zeroize",
 ]
@@ -656,7 +626,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "quick-error",
 ]
 
@@ -667,7 +637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc2157cca35ae62d3d6281d876cc1b3f0f71a3409fe4b7c8d8790b441e9bc2b"
 dependencies = [
  "bytes",
- "rand 0.7.3",
+ "rand",
  "smallvec",
 ]
 
@@ -680,9 +650,9 @@ dependencies = [
  "bytes",
  "domain",
  "futures",
- "rand 0.7.3",
+ "rand",
  "smallvec",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -706,9 +676,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek 3.0.0",
+ "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sha2 0.9.1",
  "zeroize",
@@ -764,12 +734,6 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -882,7 +846,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 0.4.26",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -898,14 +862,8 @@ dependencies = [
  "bytes",
  "futures",
  "memchr",
- "pin-project",
+ "pin-project 0.4.26",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -924,28 +882,6 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "get_if_addrs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-dependencies = [
- "gcc",
- "libc",
 ]
 
 [[package]]
@@ -982,7 +918,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tracing",
 ]
@@ -1124,9 +1060,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 0.4.26",
  "socket2",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "want",
@@ -1141,6 +1077,27 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+dependencies = [
+ "if-addrs-sys",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "if-addrs-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1191,7 +1148,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "byteorder 1.3.4",
+ "byteorder",
  "bytes",
  "cid",
  "dirs",
@@ -1208,13 +1165,13 @@ dependencies = [
  "multihash",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand",
  "serde",
  "serde_json",
  "sha2 0.9.1",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1234,7 +1191,7 @@ dependencies = [
  "prost",
  "prost-build",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "unsigned-varint 0.3.3",
 ]
@@ -1266,7 +1223,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1360,9 +1317,9 @@ checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
 name = "libp2p"
-version = "0.28.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f5a4604c1a40d75651da141dfde29ad15329f537a779528803297d2220274"
+checksum = "e3c2b4c99f8798be90746fc226acf95d3e6cff0655883634cc30dab1f64f438b"
 dependencies = [
  "atomic",
  "bytes",
@@ -1383,17 +1340,17 @@ dependencies = [
  "libp2p-yamux",
  "multihash",
  "parity-multiaddr",
- "parking_lot 0.10.2",
- "pin-project",
+ "parking_lot",
+ "pin-project 1.0.1",
  "smallvec",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.22.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f13ba8c7df0768af2eb391696d562c7de88cc3a35122531aaa6a7d77754d25"
+checksum = "1b8186060d6bd415e4e928e6cb44c4fe7e7a7dd53437bd936ce7e5f421e45a51"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1408,17 +1365,17 @@ dependencies = [
  "multihash",
  "multistream-select",
  "parity-multiaddr",
- "parking_lot 0.10.2",
- "pin-project",
+ "parking_lot",
+ "pin-project 1.0.1",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand",
  "ring",
  "rw-stream-sink",
- "sha2 0.8.2",
+ "sha2 0.9.1",
  "smallvec",
  "thiserror",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "void",
  "zeroize",
 ]
@@ -1435,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf319822e08dd65c8e060d2354e9f952895bbc433f5706c75ed010c152aee5e"
+checksum = "0baeff71fb5cb1fe1604f74a712a44b66a8c5900f4022411a1d550f09d6bb776"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1446,26 +1403,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a9acb43a3e4a4e413e0c4abe0fa49308df7c6335c88534757b647199cb8a51"
+checksum = "db0f925a45f310b678e70faf71a10023b829d02eb9cc2628a63de928936f3ade"
 dependencies = [
  "cuckoofilter",
  "fnv",
  "futures",
  "libp2p-core",
  "libp2p-swarm",
+ "log",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand",
  "smallvec",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56396ee63aa9164eacf40c2c5d2bda8c4133c2f57e1b0425d51d3a4e362583b1"
+checksum = "e074124669840484de564901d47f2d0892e73f6d8ee7c37e9c2644af1b217bf4"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1479,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7fa9047f8b8f544278a35c2d9d45d3b2c1785f2d86d4e1629d6edf97be3955"
+checksum = "78a2653b2e3254a3bbeb66bfc3f0dca7d6cba6aa2a96791db114003dec1b5394"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1495,20 +1453,20 @@ dependencies = [
  "multihash",
  "prost",
  "prost-build",
- "rand 0.7.3",
- "sha2 0.8.2",
+ "rand",
+ "sha2 0.9.1",
  "smallvec",
  "uint",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3173b5a6b2f690c29ae07798d85b9441a131ac76ddae9015ef22905b623d0c69"
+checksum = "786b068098794322239f8f04df88a52daeb7863b2e77501c4d85d32e0a8f2d26"
 dependencies = [
  "data-encoding",
  "dns-parser",
@@ -1519,77 +1477,79 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "net2",
- "rand 0.7.3",
+ "rand",
  "smallvec",
- "tokio",
+ "tokio 0.3.3",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a73a799cc8410b36e40b8f4c4b6babbcb9efd3727111bf517876e4acfa612d3"
+checksum = "ed764eab613a8fb6b7dcf6c796f55a06fef2270e528329903e25cd3311b99663"
 dependencies = [
  "bytes",
- "fnv",
  "futures",
  "futures_codec",
  "libp2p-core",
  "log",
- "parking_lot 0.10.2",
- "unsigned-varint 0.4.0",
+ "nohash-hasher",
+ "parking_lot",
+ "rand",
+ "smallvec",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef6c490042f549fb1025f2892dfe6083d97a77558f450c1feebe748ca9eb15a"
+checksum = "fb441fb015ec16690099c5d910fcba271d357763b3dcb784db7b27bbb0b68372"
 dependencies = [
  "bytes",
- "curve25519-dalek 2.1.0",
+ "curve25519-dalek",
  "futures",
  "lazy_static",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
- "rand 0.7.3",
- "sha2 0.8.2",
+ "rand",
+ "sha2 0.9.1",
  "snow",
  "static_assertions",
- "x25519-dalek 0.6.0",
+ "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad063c21dfcea4518ac9e8bd4119d33a5b26c41e674f602f41f05617a368a5c8"
+checksum = "82e5c50936cfdbe96a514e8992f304fa44cd3a681b6f779505f1ae62b3474705"
 dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand 0.7.3",
+ "rand",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193e444210132237b81b755ec7fe53f1c4bd2f53cf719729b94c0c72eb6eaa1"
+checksum = "565f0e06674b4033c978471e4083d5aaa8e03cef0719a0ec0905aaeaad39a919"
 dependencies = [
  "either",
  "futures",
  "libp2p-core",
  "log",
- "rand 0.7.3",
+ "rand",
  "smallvec",
  "void",
  "wasm-timer",
@@ -1597,29 +1557,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f42ec130d7a37a7e47bf4398026b7ad9185c08ed26972e2720f8b94112796f"
+checksum = "33f3dce259c0d3127af5167f45c275b6c047320efdd0e40fde947482487af0a3"
 dependencies = [
  "futures",
  "futures-timer",
- "get_if_addrs",
+ "if-addrs",
  "ipnet",
  "libp2p-core",
  "log",
  "socket2",
- "tokio",
+ "tokio 0.3.3",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781d9b9f043dcdabc40640807125368596b849fd4d96cdca2dcf052fdf6f33fd"
+checksum = "1a0798cbb58535162c40858493d09af06eac42a26e4966e58de0df701f559348"
 dependencies = [
  "futures",
  "libp2p-core",
- "parking_lot 0.11.0",
+ "parking_lot",
  "thiserror",
  "yamux",
 ]
@@ -1634,19 +1594,10 @@ dependencies = [
  "crunchy",
  "digest 0.8.1",
  "hmac-drbg",
- "rand 0.7.3",
+ "rand",
  "sha2 0.8.2",
  "subtle 2.3.0",
  "typenum",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
 ]
 
 [[package]]
@@ -1732,10 +1683,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.5",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1751,6 +1715,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mpart-async"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,7 +1736,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.7.3",
+ "rand",
  "thiserror",
  "twoway",
 ]
@@ -1801,16 +1775,16 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9157e87afbc2ef0d84cc0345423d715f445edde00141c93721c162de35a05e5"
+checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
 dependencies = [
  "bytes",
  "futures",
  "log",
- "pin-project",
+ "pin-project 1.0.1",
  "smallvec",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
@@ -1829,6 +1803,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "num-integer"
@@ -1912,30 +1895,20 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2165a93382a93de55868dcbfa11e4a8f99676a9164eee6a2b4a9479ad319c257"
+checksum = "43244a26dc1ddd3097216bb12eaa6cf8a07b060c72718d9ebd60fd297d6401df"
 dependencies = [
  "arrayref",
  "bs58",
- "byteorder 1.3.4",
+ "byteorder",
  "data-encoding",
  "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "url",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -1945,22 +1918,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
 dependencies = [
  "instant",
- "lock_api 0.4.1",
- "parking_lot_core 0.8.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if",
- "cloudabi 0.0.3",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1970,7 +1929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
  "cfg-if",
- "cloudabi 0.1.0",
+ "cloudabi",
  "instant",
  "libc",
  "redox_syscall",
@@ -2000,7 +1959,16 @@ version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.26",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee41d838744f60d959d7074e3afb6b35c7456d0f61cad38a24e35e6553f73841"
+dependencies = [
+ "pin-project-internal 1.0.1",
 ]
 
 [[package]]
@@ -2008,6 +1976,17 @@ name = "pin-project-internal"
 version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a4ffa594b66bff340084d4081df649a7dc049ac8d7fc458d8e628bfbbb2f86"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2177,7 +2156,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e489d4a83c17ea69b0291630229b5d4c92a94a3bf0165f7f72f506e94cda8b4b"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
 ]
 
 [[package]]
@@ -2191,29 +2170,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2221,7 +2177,7 @@ dependencies = [
  "getrandom",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
+ "rand_core",
  "rand_hc",
 ]
 
@@ -2232,23 +2188,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2265,7 +2206,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -2291,15 +2232,6 @@ dependencies = [
  "crossbeam-utils",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2334,7 +2266,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "regex-syntax",
 ]
 
@@ -2402,7 +2334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
  "futures",
- "pin-project",
+ "pin-project 0.4.26",
  "static_assertions",
 ]
 
@@ -2599,13 +2531,13 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand",
+ "rand_core",
  "ring",
  "rustc_version",
  "sha2 0.9.1",
  "subtle 2.3.0",
- "x25519-dalek 1.1.0",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -2680,9 +2612,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "cc371affeffc477f42a221a1e4297aedcea33d47d19b61455588bd9d8f6b19ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2720,7 +2652,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if",
  "libc",
- "rand 0.7.3",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2803,11 +2735,24 @@ dependencies = [
  "iovec",
  "lazy_static",
  "memchr",
- "mio",
+ "mio 0.6.22",
  "num_cpus",
  "pin-project-lite",
  "slab",
  "tokio-macros",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
+dependencies = [
+ "autocfg",
+ "lazy_static",
+ "libc",
+ "mio 0.7.5",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2832,7 +2777,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -2870,7 +2815,7 @@ checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
  "futures",
  "futures-task",
- "pin-project",
+ "pin-project 0.4.26",
  "tracing",
 ]
 
@@ -2929,7 +2874,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "crunchy",
  "rustc-hex",
  "static_assertions",
@@ -3004,19 +2949,13 @@ checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
+checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 dependencies = [
  "bytes",
  "futures_codec",
 ]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "untrusted"
@@ -3104,12 +3043,12 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "pin-project",
+ "pin-project 0.4.26",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -3202,7 +3141,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.11.0",
+ "parking_lot",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3298,23 +3237,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
-dependencies = [
- "curve25519-dalek 2.1.0",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
- "curve25519-dalek 3.0.0",
- "rand_core 0.5.1",
+ "curve25519-dalek",
+ "rand_core",
  "zeroize",
 ]
 
@@ -3327,8 +3255,8 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.0",
- "rand 0.7.3",
+ "parking_lot",
+ "rand",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
 
 [[package]]
 name = "arrayref"
@@ -77,9 +77,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "asn1_der"
@@ -160,9 +160,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base-x"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
@@ -178,22 +178,20 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
+checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
- "byte-tools",
- "byteorder",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -202,9 +200,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9e07352b829279624ceb7c64adb4f585dacdb81d35cafae81139ccd617cf44"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -265,9 +263,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -306,12 +304,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
-
-[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,15 +314,21 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "f1770ced377336a88a67c473594ccc14eca6f4559217c34f64aac8f83d641b40"
 
 [[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chacha20"
@@ -400,6 +398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_fn"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c478836e029dcef17fb47c89023448c64f781a046e0300e257ad8225ae59afab"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,36 +453,35 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
- "crossbeam-utils",
- "maybe-uninit",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils",
- "maybe-uninit",
+ "crossbeam-utils 0.8.0",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
+checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
 dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
+ "cfg-if 1.0.0",
+ "const_fn",
+ "crossbeam-utils 0.8.0",
  "lazy_static",
- "maybe-uninit",
  "memoffset",
  "scopeguard",
 ]
@@ -490,7 +493,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
+ "lazy_static",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "const_fn",
  "lazy_static",
 ]
 
@@ -522,9 +537,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+checksum = "fc4666154fd004af3fd6f1da2e81a96fd5a81927fe8ddb6ecc79e2aa6e138b54"
 dependencies = [
  "bstr",
  "csv-core",
@@ -568,29 +583,27 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6489dde5128f5ab2f71f88f8807a237cecf08d96dc7ca4be64e0730dc7d961"
+checksum = "0a94feec3d2ba66c0b6621bca8bc6f68415b1e5c69af3586fdd0af9fd9f29b17"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2d6daefd5f1d4b74a891a5d2ab7dccba028d423107c074232a0c5dc0d40a9e"
+checksum = "f0f83e699727abca3c56e187945f303389590305ab2f0185ea445aa66e8d5f2a"
 dependencies = [
  "data-encoding",
- "proc-macro-hack",
  "syn",
 ]
 
@@ -649,7 +662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc2157cca35ae62d3d6281d876cc1b3f0f71a3409fe4b7c8d8790b441e9bc2b"
 dependencies = [
  "bytes 0.5.6",
- "rand 0.7.3",
+ "rand",
  "smallvec",
 ]
 
@@ -664,7 +677,7 @@ dependencies = [
  "futures",
  "rand",
  "smallvec",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -675,9 +688,9 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 
 [[package]]
 name = "ed25519"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dfc993ea376e864fe29a4099a61ca0bb994c6d7745a61bf60ddb3d64e05237"
+checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
 dependencies = [
  "signature",
 ]
@@ -692,7 +705,7 @@ dependencies = [
  "ed25519",
  "rand",
  "serde",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "zeroize",
 ]
 
@@ -710,11 +723,11 @@ checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "filetime"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+checksum = "0c122a393ea57648015bf06fbd3d372378992e86b9ff5a7a497b076a28c79efe"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -748,6 +761,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,9 +788,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8e3078b7b2a8a671cb7a3d17b4760e4181ea243227776ba83fd043b4ca034e"
+checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -780,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
+checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -790,15 +813,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
+checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc709ca1da6f66143b8c9bec8e6260181869893714e9b5a490b169b0414144ab"
+checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -808,15 +831,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
+checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
+checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -826,15 +849,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
+checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
+checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
 dependencies = [
  "once_cell",
 ]
@@ -847,9 +870,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
+checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -858,7 +881,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 0.4.26",
+ "pin-project 1.0.1",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -874,7 +897,20 @@ dependencies = [
  "bytes 0.5.6",
  "futures",
  "memchr",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
+]
+
+[[package]]
+name = "generator"
+version = "0.6.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
+dependencies = [
+ "cc",
+ "libc",
+ "log",
+ "rustc_version",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -902,7 +938,7 @@ version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -918,9 +954,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -930,9 +966,10 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1058,9 +1095,9 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.13.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "f6ad767baac13b44d4529fcf58ba2cd0995e36e7b435bc5b039de6f47e880dbf"
 dependencies = [
  "bytes 0.5.6",
  "futures-channel",
@@ -1072,9 +1109,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.26",
+ "pin-project 1.0.1",
  "socket2",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tower-service",
  "tracing",
  "want",
@@ -1124,11 +1161,11 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+checksum = "cb1fc4429a33e1f80d41dc9fea4d108a88bec1de8053878898ae448a0b52f613"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1160,7 +1197,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "byteorder 1.3.4",
+ "byteorder",
  "bytes 0.5.6",
  "cid",
  "dirs",
@@ -1180,7 +1217,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "tempfile",
  "thiserror",
  "tokio 0.3.3",
@@ -1256,7 +1293,7 @@ dependencies = [
  "multibase",
  "multihash",
  "quick-protobuf",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "tar",
 ]
 
@@ -1323,9 +1360,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.79"
+version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
+checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
 
 [[package]]
 name = "libp2p"
@@ -1384,7 +1421,7 @@ dependencies = [
  "rand",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.5.1",
@@ -1466,7 +1503,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "smallvec",
  "uint",
  "unsigned-varint 0.5.1",
@@ -1491,7 +1528,7 @@ dependencies = [
  "net2",
  "rand",
  "smallvec",
- "tokio 0.2.22",
+ "tokio 0.3.3",
  "void",
  "wasm-timer",
 ]
@@ -1503,7 +1540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed764eab613a8fb6b7dcf6c796f55a06fef2270e528329903e25cd3311b99663"
 dependencies = [
  "bytes 0.5.6",
- "fnv",
  "futures",
  "futures_codec",
  "libp2p-core",
@@ -1522,7 +1558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb441fb015ec16690099c5d910fcba271d357763b3dcb784db7b27bbb0b68372"
 dependencies = [
  "bytes 0.5.6",
- "curve25519-dalek 2.1.0",
+ "curve25519-dalek",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -1530,7 +1566,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -1581,7 +1617,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "socket2",
- "tokio 0.2.22",
+ "tokio 0.3.3",
 ]
 
 [[package]]
@@ -1628,7 +1664,20 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "loom"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
+dependencies = [
+ "cfg-if 0.1.10",
+ "generator",
+ "scoped-tls",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1647,16 +1696,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -1689,7 +1732,7 @@ version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "fuchsia-zircon",
  "fuchsia-zircon-sys",
  "iovec",
@@ -1704,13 +1747,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8962c171f57fcfffa53f4df1bb15ec4c8cf26a7569459c9ceb62d94aab0d9584"
+checksum = "f33bc887064ef1fd66020c9adfc45bb9f33d75a42096c81e7c56c65b75dd1a8b"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.5",
+ "miow 0.3.6",
  "ntapi",
  "winapi 0.3.9",
 ]
@@ -1729,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07b88fb9795d4d36d62a012dfbf49a8f5cf12751f36d31a9dbe66d528e58979e"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
  "winapi 0.3.9",
@@ -1739,16 +1782,17 @@ dependencies = [
 
 [[package]]
 name = "mpart-async"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea338ffba87fdaaea364b314301ead2ee38e584a7a7b06e881ca101a2a059d0f"
+checksum = "5e07b32f6b568132fa4b990cff3ff0728780bf4c62c57cf193c84b4d765868ce"
 dependencies = [
- "anyhow",
  "bytes 0.5.6",
- "futures",
+ "futures-core",
+ "futures-util",
  "http",
  "httparse",
  "log",
+ "pin-project 0.4.27",
  "rand",
  "thiserror",
  "twoway",
@@ -1774,8 +1818,8 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "digest 0.9.0",
- "sha-1 0.9.1",
- "sha2 0.9.1",
+ "sha-1 0.9.2",
+ "sha2 0.9.2",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
@@ -1806,7 +1850,7 @@ version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
 ]
@@ -1828,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1838,9 +1882,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -1857,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
+checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "oorandom"
@@ -1886,7 +1930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
 dependencies = [
  "bitflags",
- "cfg-if",
+ "cfg-if 0.1.10",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1941,7 +1985,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "instant",
  "libc",
@@ -1968,11 +2012,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
- "pin-project-internal 0.4.26",
+ "pin-project-internal 0.4.27",
 ]
 
 [[package]]
@@ -1986,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2008,9 +2052,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-utils"
@@ -2020,9 +2064,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
@@ -2051,15 +2095,15 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "universal-hash",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-error"
@@ -2087,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2224,9 +2268,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -2236,13 +2280,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils",
+ "crossbeam-utils 0.8.0",
  "lazy_static",
  "num_cpus",
 ]
@@ -2266,9 +2310,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
 dependencies = [
  "regex-syntax",
 ]
@@ -2285,9 +2329,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
 
 [[package]]
 name = "remove_dir_all"
@@ -2322,7 +2366,7 @@ dependencies = [
  "base64",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils",
+ "crossbeam-utils 0.7.2",
 ]
 
 [[package]]
@@ -2347,7 +2391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
  "futures",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "static_assertions",
 ]
 
@@ -2395,9 +2439,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
 dependencies = [
  "serde_derive",
 ]
@@ -2414,9 +2458,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2425,9 +2469,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
 dependencies = [
  "itoa",
  "ryu",
@@ -2460,12 +2504,12 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -2485,12 +2529,12 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpuid-bool",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
@@ -2510,11 +2554,12 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.0.9"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
 dependencies = [
  "lazy_static",
+ "loom",
 ]
 
 [[package]]
@@ -2548,18 +2593,18 @@ dependencies = [
  "rand_core",
  "ring",
  "rustc_version",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "subtle 2.3.0",
  "x25519-dalek",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "7fd8b795c389288baa5f355489c65e71fd48a02104600d15c4cfbc561e9e429d"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
  "winapi 0.3.9",
@@ -2589,9 +2634,9 @@ dependencies = [
 
 [[package]]
 name = "structopt"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
+checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2600,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
+checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2663,7 +2708,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "rand",
  "redox_syscall",
@@ -2682,18 +2727,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2732,15 +2777,24 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "b78a366903f506d2ad52ca8dc552102ffdd3e937ba8a227f024dc1d1eae28575"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
+checksum = "a6d7ad61edd59bfcc7e80dababf0f4aed2e6d5e0ba1659356ae889752dfc12ff"
 dependencies = [
  "bytes 0.5.6",
  "fnv",
@@ -2748,10 +2802,10 @@ dependencies = [
  "iovec",
  "lazy_static",
  "memchr",
- "mio",
+ "mio 0.6.22",
  "pin-project-lite",
  "slab",
- "tokio-macros 0.2.5",
+ "tokio-macros 0.2.6",
 ]
 
 [[package]]
@@ -2761,17 +2815,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ca08accbcb46f11fd8d2d1c6158c348b7888009a1f39260bcad66f6a454250"
 dependencies = [
  "autocfg",
+ "bytes 0.6.0",
+ "futures-core",
  "lazy_static",
  "libc",
- "mio 0.7.5",
+ "memchr",
+ "mio 0.7.6",
+ "num_cpus",
  "pin-project-lite",
+ "slab",
+ "tokio-macros 0.3.1",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
+checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2800,7 +2860,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
- "tokio 0.2.22",
+ "tokio 0.2.23",
 ]
 
 [[package]]
@@ -2815,10 +2875,22 @@ version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2838,7 +2910,7 @@ checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
  "futures",
  "futures-task",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tracing",
 ]
 
@@ -2855,9 +2927,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -2865,6 +2937,7 @@ dependencies = [
  "regex",
  "sharded-slab",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2929,18 +3002,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "b7f98e67a4d84f730d343392f9bfff7d21e3fca562b9cb7a43b768350beeddc6"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
 
 [[package]]
 name = "unicode-width"
@@ -2988,10 +3061,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -3066,12 +3140,12 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.22",
+ "tokio 0.2.23",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -3096,7 +3170,7 @@ version = "0.2.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "wasm-bindgen-macro",
 ]
 
@@ -3121,7 +3195,7 @@ version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "js-sys",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
+name = "c_linked_list"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,8 +648,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc2157cca35ae62d3d6281d876cc1b3f0f71a3409fe4b7c8d8790b441e9bc2b"
 dependencies = [
- "bytes",
- "rand",
+ "bytes 0.5.6",
+ "rand 0.7.3",
  "smallvec",
 ]
 
@@ -647,7 +659,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836b2fbda90bc12569223077c1fa0a62a8eee8b78f4e5d82a8f20b20ca1ccf0f"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "domain",
  "futures",
  "rand",
@@ -859,7 +871,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "memchr",
  "pin-project 0.4.26",
@@ -910,7 +922,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -943,7 +955,7 @@ checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
  "base64",
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "headers-core",
  "http",
  "mime",
@@ -1011,7 +1023,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -1022,7 +1034,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -1050,7 +1062,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1148,8 +1160,8 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "byteorder",
- "bytes",
+ "byteorder 1.3.4",
+ "bytes 0.5.6",
  "cid",
  "dirs",
  "domain",
@@ -1171,7 +1183,7 @@ dependencies = [
  "sha2 0.9.1",
  "tempfile",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.3.3",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1191,7 +1203,7 @@ dependencies = [
  "prost",
  "prost-build",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.3.3",
  "tracing",
  "unsigned-varint 0.3.3",
 ]
@@ -1202,7 +1214,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "bytes",
+ "bytes 0.5.6",
  "cid",
  "futures",
  "hex-literal",
@@ -1223,7 +1235,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.3.3",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1322,7 +1334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c2b4c99f8798be90746fc226acf95d3e6cff0655883634cc30dab1f64f438b"
 dependencies = [
  "atomic",
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -1442,7 +1454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78a2653b2e3254a3bbeb66bfc3f0dca7d6cba6aa2a96791db114003dec1b5394"
 dependencies = [
  "arrayvec",
- "bytes",
+ "bytes 0.5.6",
  "either",
  "fnv",
  "futures",
@@ -1479,7 +1491,7 @@ dependencies = [
  "net2",
  "rand",
  "smallvec",
- "tokio 0.3.3",
+ "tokio 0.2.22",
  "void",
  "wasm-timer",
 ]
@@ -1490,7 +1502,8 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed764eab613a8fb6b7dcf6c796f55a06fef2270e528329903e25cd3311b99663"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
+ "fnv",
  "futures",
  "futures_codec",
  "libp2p-core",
@@ -1508,8 +1521,8 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb441fb015ec16690099c5d910fcba271d357763b3dcb784db7b27bbb0b68372"
 dependencies = [
- "bytes",
- "curve25519-dalek",
+ "bytes 0.5.6",
+ "curve25519-dalek 2.1.0",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -1568,7 +1581,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "socket2",
- "tokio 0.3.3",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -1731,7 +1744,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea338ffba87fdaaea364b314301ead2ee38e584a7a7b06e881ca101a2a059d0f"
 dependencies = [
  "anyhow",
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "http",
  "httparse",
@@ -1779,7 +1792,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "log",
  "pin-project 1.0.1",
@@ -2099,7 +2112,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "prost-derive",
 ]
 
@@ -2109,7 +2122,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "heck",
  "itertools 0.8.2",
  "log",
@@ -2140,7 +2153,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "prost",
 ]
 
@@ -2729,17 +2742,16 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "memchr",
- "mio 0.6.22",
- "num_cpus",
+ "mio",
  "pin-project-lite",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.5",
 ]
 
 [[package]]
@@ -2767,12 +2779,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-macros"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d30fdbb5dc2d8f91049691aa1a9d4d4ae422a21c334ce8936e5886d30c5c45"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -2953,7 +2976,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures_codec",
 ]
 
@@ -3035,7 +3058,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "headers",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rand = { default-features = false, version = "0.7" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, features = ["fs", "rt-threaded", "stream", "sync", "blocking"], version = "0.2" }
+tokio = { default-features = false, features = ["fs", "macros", "rt-multi-thread", "stream", "sync"], version = "0.3" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = ["std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }
@@ -51,7 +51,7 @@ prost-build = { default-features = false, version = "0.6" }
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
-tokio = { default-features = false, features = ["io-std"], version = "0.2" }
+tokio = { default-features = false, features = ["io-std", "io-util"], version = "0.3" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
 tempfile = "3.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ prost-build = { default-features = false, version = "0.6" }
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
-tokio = { default-features = false, features = ["io-std", "io-util"], version = "0.3" }
+tokio = { default-features = false, features = ["io-std", "io-util", "time"], version = "0.3" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
 tempfile = "3.1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ domain-resolv = { default-features = false, version = "0.5" }
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mdns-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.28" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mdns-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.30" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -19,6 +19,6 @@ libp2p-swarm = { default-features = false, version = "0.24" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, version = "0.2" }
+tokio = { default-features = false, version = "0.3" }
 tracing = { default-features = false, version = "0.1" }
 unsigned-varint = { default-features = false, version = "0.3" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -14,8 +14,8 @@ prost-build = { default-features = false, version = "0.6" }
 cid = { default-features = false, version = "0.5" }
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
-libp2p-core = { default-features = false, version = "0.22" }
-libp2p-swarm = { default-features = false, version = "0.22" }
+libp2p-core = { default-features = false, version = "0.24" }
+libp2p-swarm = { default-features = false, version = "0.24" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }
 thiserror = { default-features = false, version = "1.0" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = { default-features = false, version = "1.0" }
 structopt = { default-features = false, version = "0.3" }
 tar = { default-features = false, version = "0.4" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, version = "0.2" }
+tokio = { default-features = false, features = ["time"], version = "0.3" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "env-filter"], version = "0.2" }
 url = { default-features = false, version = "2.1" }

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -18,7 +18,7 @@ enum Options {
         #[structopt(long)]
         bits: NonZeroU16,
         /// List of configuration profiles to apply. Currently only the `Test` and `Default`
-        /// profiles are supported.  
+        /// profiles are supported.
         ///
         /// `Test` uses ephemeral ports (necessary for conformance tests), `Default` uses `4004`.
         #[structopt(long, use_delimiter = true)]
@@ -130,7 +130,7 @@ fn main() {
     // TODO: sigterm should initiate graceful shutdown, second time should shutdown right now
     // NOTE: sigkill ... well surely it will stop the process right away
 
-    let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
+    let rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
         let opts = IpfsOptions {

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -155,7 +155,7 @@ pub fn routes<T: IpfsTypes>(
 }
 
 pub(crate) async fn handle_shutdown(
-    mut tx: tokio::sync::mpsc::Sender<()>,
+    tx: tokio::sync::mpsc::Sender<()>,
 ) -> Result<impl warp::Reply, std::convert::Infallible> {
     Ok(match tx.send(()).await {
         Ok(_) => warp::http::StatusCode::OK,
@@ -185,7 +185,7 @@ mod tests {
         routes(&ipfs, shutdown_tx)
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn not_found_as_plaintext() {
         let routes = testing_routes().await;
         let resp = warp::test::request()
@@ -199,7 +199,7 @@ mod tests {
         assert_eq!(resp.body(), "404 page not found");
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn invalid_peer_id_as_messageresponse() {
         let routes = testing_routes().await;
         let resp = warp::test::request()

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -536,7 +536,7 @@ mod tests {
         })
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn url_hacked_args() {
         let response = request()
             .path("/pubsub/pub?arg=some_channel&arg=foobar")
@@ -546,7 +546,7 @@ mod tests {
         assert_eq!(body, r#"{"message":"foobar","topic":"some_channel"}"#);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn message_in_body() {
         let response = request()
             .path("/pubsub/pub?arg=some_channel")

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -216,7 +216,7 @@ mod tests {
     use std::collections::HashSet;
     use std::convert::TryFrom;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_inner_local() {
         let filter = local(&*preloaded_testing_ipfs().await);
 
@@ -263,7 +263,7 @@ mod tests {
         assert!(diff.is_empty(), "{:?}", diff);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn refs_with_path() {
         let ipfs = preloaded_testing_ipfs().await;
 

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -303,7 +303,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn very_long_file_and_symlink_names() {
         let ipfs = Node::new("test_node").await;
 
@@ -359,7 +359,7 @@ mod tests {
         assert_eq!(found, expected);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_multiblock_file() {
         let ipfs = Node::new("test_node").await;
 

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -377,7 +377,7 @@ impl<D: fmt::Display> serde::Serialize for Quoted<D> {
 mod tests {
     use crate::v0::root_files::add;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn add_single_block_file() {
         let ipfs = tokio_ipfs().await;
 

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -106,7 +106,7 @@ fn add_stream<St, E>(
 ) -> impl Stream<Item = Result<Bytes, AddError>> + Send + 'static
 where
     St: Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
-    E: Into<anyhow::Error> + Send + 'static,
+    E: Into<anyhow::Error> + Send + Sync + 'static + std::error::Error,
 {
     async_stream::try_stream! {
 

--- a/http/src/v0/support/timeout.rs
+++ b/http/src/v0/support/timeout.rs
@@ -5,7 +5,7 @@
 use futures::future::{Either, Map};
 use std::future::Future;
 use std::time::Duration;
-use tokio::time::{timeout, Elapsed, Timeout};
+use tokio::time::{error::Elapsed, timeout, Timeout};
 
 pub type MaybeTimeout<F> =
     Either<Timeout<F>, Map<F, fn(<F as Future>::Output) -> Result<<F as Future>::Output, Elapsed>>>;

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -595,7 +595,7 @@ mod tests {
     use super::*;
     use crate::{make_ipld, Node};
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_root_cid() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -605,7 +605,7 @@ mod tests {
         assert_eq!(res, data);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_array_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -618,7 +618,7 @@ mod tests {
         assert_eq!(res, make_ipld!(2));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_nested_array_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -631,7 +631,7 @@ mod tests {
         assert_eq!(res, make_ipld!(2));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_object_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -646,7 +646,7 @@ mod tests {
         assert_eq!(res, make_ipld!(false));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_cid_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -840,7 +840,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn resolve_through_link() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -869,7 +869,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolving_first_segment() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -885,7 +885,7 @@ mod tests {
         assert_eq!(e.to_string(), format!("no link named \"1\" under {}", cid2));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolving_last_segment() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -901,7 +901,7 @@ mod tests {
         assert_eq!(e.to_string(), format!("no link named \"a\" under {}", cid1));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolving_through_file() {
         let Node { ipfs, .. } = Node::new("test_node").await;
 
@@ -933,7 +933,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolving_through_dir() {
         let Node { ipfs, .. } = Node::new("test_node").await;
 

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -120,14 +120,14 @@ pub async fn resolve(domain: &str) -> Result<IpfsPath, Error> {
 mod tests {
     use super::*;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn test_resolve1() {
         let res = resolve("ipfs.io").await.unwrap().to_string();
         assert_eq!(res, "/ipns/website.ipfs.io");
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn test_resolve2() {
         let res = resolve("website.ipfs.io").await.unwrap().to_string();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1732,7 +1732,7 @@ mod tests {
     use crate::make_ipld;
     use multihash::Sha2_256;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_put_and_get_block() {
         let ipfs = Node::new("test_node").await;
 
@@ -1745,7 +1745,7 @@ mod tests {
         assert_eq!(block, new_block);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_put_and_get_dag() {
         let ipfs = Node::new("test_node").await;
 
@@ -1755,7 +1755,7 @@ mod tests {
         assert_eq!(data, new_data);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_pin_and_unpin() {
         let ipfs = Node::new("test_node").await;
 

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -267,7 +267,7 @@ mod tests {
     use libp2p::{multiaddr::Protocol, multihash::Multihash, swarm::Swarm};
     use std::convert::TryInto;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn swarm_api() {
         let (peer1_id, trans) = mk_transport();
         let mut swarm1 = Swarm::new(trans, SwarmApi::default(), peer1_id.clone());

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,19 +1,19 @@
 use libp2p::core::muxing::StreamMuxerBox;
-use libp2p::core::transport::boxed::Boxed;
 use libp2p::core::transport::upgrade::Version;
+use libp2p::core::transport::Boxed;
 use libp2p::core::upgrade::SelectUpgrade;
 use libp2p::dns::DnsConfig;
 use libp2p::identity;
 use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseConfig};
 use libp2p::tcp::TokioTcpConfig;
-use libp2p::yamux::Config as YamuxConfig;
+use libp2p::yamux::YamuxConfig;
 use libp2p::{PeerId, Transport};
 use std::io::{self, Error, ErrorKind};
 use std::time::Duration;
 
 /// Transport type.
-pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox), Error>;
+pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
 /// Builds the transport that serves as a common ground for all connections.
 ///

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(links, ["african.txt", "americas.txt", "australian.txt",]);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn all_refs_from_root() {
         let Node { ipfs, .. } = preloaded_testing_ipfs().await;
 
@@ -416,7 +416,7 @@ mod tests {
         assert_edges(&expected, all_edges.as_slice());
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn all_unique_refs_from_root() {
         let Node { ipfs, .. } = preloaded_testing_ipfs().await;
 

--- a/src/repo/common_tests.rs
+++ b/src/repo/common_tests.rs
@@ -56,7 +56,7 @@ macro_rules! pinstore_interface_tests {
             use std::collections::HashMap;
             use std::convert::TryFrom;
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn pin_direct_twice_is_good() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -70,7 +70,7 @@ macro_rules! pinstore_interface_tests {
                 assert_eq!(repo.is_pinned(&empty).await.unwrap(), true);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn cannot_recursively_unpin_unpinned() {
                 let repo = DSTestContext::with($factory).await;
                 // root/nested/deeper: QmX5S2xLu32K6WxWnyLeChQFbDHy79ULV9feJYH2Hy9bgp
@@ -89,7 +89,7 @@ macro_rules! pinstore_interface_tests {
                 assert_eq!(e.to_string(), "not pinned or pinned indirectly");
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn cannot_unpin_indirect() {
                 let repo = DSTestContext::with($factory).await;
                 // root/nested/deeper: QmX5S2xLu32K6WxWnyLeChQFbDHy79ULV9feJYH2Hy9bgp
@@ -132,7 +132,7 @@ macro_rules! pinstore_interface_tests {
                 assert_eq!(e.to_string(), "not pinned or pinned indirectly");
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn can_pin_direct_as_recursive() {
                 // the other way around doesn't work
                 let repo = DSTestContext::with($factory).await;
@@ -170,7 +170,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn pin_recursive_pins_all_blocks() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -203,7 +203,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn indirect_can_be_pinned_directly() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -243,7 +243,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn direct_and_indirect_when_parent_unpinned() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -293,7 +293,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(one.is_empty(), "{:?}", one);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn cannot_pin_recursively_pinned_directly() {
                 // this is a bit of odd as other ops are additive
                 let repo = DSTestContext::with($factory).await;

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -93,9 +93,9 @@ impl FsBlockStore {
 
         match rx.recv().await {
             Ok(Ok(())) => WriteCompletion::KnownGood,
-            Err(broadcast::RecvError::Closed) => WriteCompletion::NotObserved,
+            Err(broadcast::error::RecvError::Closed) => WriteCompletion::NotObserved,
             Ok(Err(_)) => WriteCompletion::KnownBad,
-            Err(broadcast::RecvError::Lagged(_)) => {
+            Err(broadcast::error::RecvError::Lagged(_)) => {
                 unreachable!("sending at most one message to the channel with capacity of one")
             }
         }
@@ -298,12 +298,12 @@ impl BlockStore for FsBlockStore {
                             trace!("synchronized with writer, write outcome: {:?}", message);
                             message
                         }
-                        Err(broadcast::RecvError::Closed) => {
+                        Err(broadcast::error::RecvError::Closed) => {
                             // there was never any write intention by any party, and we may have just
                             // closed the last sender above, or we were late for the one message.
                             Ok(())
                         }
-                        Err(broadcast::RecvError::Lagged(_)) => {
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
                             unreachable!("broadcast channel should only be messaged once here")
                         }
                     };
@@ -442,7 +442,7 @@ mod tests {
     use std::env::temp_dir;
     use std::sync::Arc;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fs_blockstore() {
         let mut tmp = temp_dir();
         tmp.push("blockstore1");
@@ -480,7 +480,7 @@ mod tests {
         std::fs::remove_dir_all(tmp).ok();
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fs_blockstore_open() {
         let mut tmp = temp_dir();
         tmp.push("blockstore2");
@@ -505,7 +505,7 @@ mod tests {
         std::fs::remove_dir_all(&tmp).ok();
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fs_blockstore_list() {
         let mut tmp = temp_dir();
         tmp.push("blockstore_list");
@@ -529,7 +529,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn race_to_insert_new() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();
@@ -560,7 +560,7 @@ mod tests {
         assert_eq!(existing, count - 1);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn race_to_insert_with_existing() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();
@@ -633,7 +633,7 @@ mod tests {
         (writes, existing)
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn remove() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -659,7 +659,7 @@ mod tests {
     use multihash::Sha2_256;
     use std::env::temp_dir;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_mem_blockstore() {
         let tmp = temp_dir();
         let store = MemBlockStore::new(tmp);
@@ -692,7 +692,7 @@ mod tests {
         assert_eq!(get.await.unwrap(), None);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_mem_blockstore_list() {
         let tmp = temp_dir();
         let mem_store = MemBlockStore::new(tmp);
@@ -715,7 +715,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_mem_datastore() {
         let tmp = temp_dir();
         let store = MemDataStore::new(tmp);

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -429,7 +429,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn subscription_basics() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -441,7 +441,7 @@ mod tests {
         assert_eq!(s3.await.unwrap(), 10);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn subscription_cancelled_on_dropping_registry() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -449,7 +449,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn subscription_cancelled_on_shutdown() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -457,7 +457,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn new_subscriptions_cancelled_after_shutdown() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         registry.shutdown();
@@ -465,7 +465,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn dropping_subscription_future_after_registering() {
         use std::time::Duration;
         use tokio::time::timeout;
@@ -488,12 +488,12 @@ mod tests {
 
     // this test is designed to verify that the subscription registry is working properly
     // and doesn't break even under extreme conditions
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn subscription_stress_test() {
         use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
         use std::time::Duration;
-        use tokio::{task, time::delay_for};
+        use tokio::{task, time::sleep};
 
         // optional
         tracing_subscriber::fmt::init();
@@ -527,7 +527,7 @@ mod tests {
             let (mut kind, mut count);
 
             loop {
-                delay_for(Duration::from_millis(CREATE_WAIT_TIME)).await;
+                sleep(Duration::from_millis(CREATE_WAIT_TIME)).await;
 
                 // the id of the object that will gain subscriptions
                 kind = rng_clone.gen_range(0, KIND_COUNT);
@@ -553,7 +553,7 @@ mod tests {
             let (mut kinds, mut count);
 
             loop {
-                delay_for(Duration::from_millis(FINISH_WAIT_TIME)).await;
+                sleep(Duration::from_millis(FINISH_WAIT_TIME)).await;
 
                 kinds = reg_clone
                     .subscriptions
@@ -576,7 +576,7 @@ mod tests {
             let (mut count, mut idx);
 
             loop {
-                delay_for(Duration::from_millis(CANCEL_WAIT_TIME)).await;
+                sleep(Duration::from_millis(CANCEL_WAIT_TIME)).await;
 
                 let subs_unlocked = &mut *subs.lock().unwrap();
                 count = rng.gen_range(0, subs_unlocked.len());

--- a/tests/bitswap.rs
+++ b/tests/bitswap.rs
@@ -8,7 +8,7 @@ mod common;
 use common::{spawn_nodes, Topology};
 
 // Ensure that the Bitswap object doesn't leak.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn check_bitswap_cleanups() {
     // create a few nodes and connect the first one to others
     let mut nodes = spawn_nodes(3, Topology::Star).await;
@@ -19,7 +19,7 @@ async fn check_bitswap_cleanups() {
     // last node says goodbye; check the number of bitswap peers
     if let Some(node) = nodes.pop() {
         node.shutdown().await;
-        time::delay_for(Duration::from_millis(200)).await;
+        time::sleep(Duration::from_millis(200)).await;
     }
 
     let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
@@ -28,7 +28,7 @@ async fn check_bitswap_cleanups() {
     // another node says goodbye; check the number of bitswap peers
     if let Some(node) = nodes.pop() {
         node.shutdown().await;
-        time::delay_for(Duration::from_millis(200)).await;
+        time::sleep(Duration::from_millis(200)).await;
     }
 
     let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
@@ -41,7 +41,7 @@ async fn check_bitswap_cleanups() {
 // testing the bitswap protocol (though it would be advised to uncomment
 // the tracing_subscriber for stress-testing purposes)
 #[ignore]
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn bitswap_stress_test() {
     fn filter(i: usize) -> bool {
         i % 2 == 0

--- a/tests/block_exchange.rs
+++ b/tests/block_exchange.rs
@@ -31,6 +31,7 @@ async fn two_node_put_get() {
 
 // check that a long line of nodes still works with get_block
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore]
 async fn long_get_block() {
     // this number could be higher, but it starts hanging above ~24
     const N: usize = 10;

--- a/tests/block_exchange.rs
+++ b/tests/block_exchange.rs
@@ -15,7 +15,7 @@ fn create_block() -> Block {
 }
 
 // verify that a put block can be received via get_block and the data matches
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn two_node_put_get() {
     let nodes = spawn_nodes(2, Topology::Line).await;
     let block = create_block();
@@ -30,7 +30,7 @@ async fn two_node_put_get() {
 }
 
 // check that a long line of nodes still works with get_block
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn long_get_block() {
     // this number could be higher, but it starts hanging above ~24
     const N: usize = 10;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -68,7 +68,7 @@ mod tests {
 
     const N: usize = 5;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_topology_line() {
         let nodes = spawn_nodes(N, Topology::Line).await;
 
@@ -81,7 +81,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_topology_ring() {
         let nodes = spawn_nodes(N, Topology::Ring).await;
 
@@ -90,7 +90,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_topology_mesh() {
         let nodes = spawn_nodes(N, Topology::Mesh).await;
 
@@ -99,7 +99,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_topology_star() {
         let nodes = spawn_nodes(N, Topology::Star).await;
 

--- a/tests/connectivity.rs
+++ b/tests/connectivity.rs
@@ -11,7 +11,7 @@ use common::interop::ForeignNode;
 const TIMEOUT: Duration = Duration::from_secs(5);
 
 // Make sure two instances of ipfs can be connected by `Multiaddr`.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_two_nodes_by_addr() {
     let node_a = Node::new("a").await;
 
@@ -27,7 +27,7 @@ async fn connect_two_nodes_by_addr() {
 }
 
 // Make sure only a `Multiaddr` with `/p2p/` can be used to connect.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: MissingProtocolP2p")]
 async fn dont_connect_without_p2p() {
     let node_a = Node::new("a").await;
@@ -45,7 +45,7 @@ async fn dont_connect_without_p2p() {
 
 // Make sure two instances of ipfs can be connected by `PeerId`.
 #[ignore = "connecting just by PeerId is not currently supported"]
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_two_nodes_by_peer_id() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;
@@ -63,7 +63,7 @@ async fn connect_two_nodes_by_peer_id() {
 }
 
 // Ensure that duplicate connection attempts don't cause hangs.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_duplicate_multiaddr() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;
@@ -79,7 +79,7 @@ async fn connect_duplicate_multiaddr() {
 
 // More complicated one to the above; first node will have two listening addresses and the second
 // one should dial both of the addresses, resulting in two connections.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_two_nodes_with_two_connections_doesnt_panic() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -15,7 +15,7 @@ fn strip_peer_id(addr: Multiaddr) -> Multiaddr {
 }
 
 /// Check if `Ipfs::find_peer` works without DHT involvement.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn find_peer_local() {
     let nodes = spawn_nodes(2, Topology::None).await;
     nodes[0].connect(nodes[1].addrs[0].clone()).await.unwrap();
@@ -101,7 +101,7 @@ async fn spawn_bootstrapped_nodes(n: usize) -> (Vec<Node>, Option<ForeignNode>) 
 }
 
 /// Check if `Ipfs::find_peer` works using DHT.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_find_peer() {
     // works for numbers >=2, though 2 would essentially just
     // be the same as find_peer_local, so it should be higher
@@ -121,7 +121,7 @@ async fn dht_find_peer() {
     assert_eq!(found_addrs, vec![to_be_found]);
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_get_closest_peers() {
     const CHAIN_LEN: usize = 10;
     let (nodes, _foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;
@@ -137,7 +137,7 @@ async fn dht_get_closest_peers() {
 }
 
 #[ignore = "targets an actual bootstrapper, so random failures can happen"]
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_popular_content_discovery() {
     let peer = Node::new("a").await;
 
@@ -154,7 +154,7 @@ async fn dht_popular_content_discovery() {
 }
 
 /// Check if Ipfs::{get_providers, provide} does its job.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_providing() {
     const CHAIN_LEN: usize = 10;
     let (nodes, foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;
@@ -183,7 +183,7 @@ async fn dht_providing() {
 }
 
 /// Check if Ipfs::{get, put} does its job.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_get_put() {
     const CHAIN_LEN: usize = 10;
     let (nodes, foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;

--- a/tests/listening_addresses.rs
+++ b/tests/listening_addresses.rs
@@ -1,4 +1,4 @@
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn multiple_consecutive_ephemeral_listening_addresses() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -12,7 +12,7 @@ async fn multiple_consecutive_ephemeral_listening_addresses() {
     assert_ne!(first, second);
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -41,7 +41,7 @@ async fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
     );
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[cfg(not(target_os = "macos"))]
 async fn multiple_concurrent_ephemeral_listening_addresses_on_different_ip() {
     let node = ipfs::Node::new("test_node").await;
@@ -59,7 +59,7 @@ async fn multiple_concurrent_ephemeral_listening_addresses_on_different_ip() {
     second.unwrap();
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn adding_unspecified_addr_resolves_with_first() {
     let node = ipfs::Node::new("test_node").await;
     // there is no test in trying to match this with others as ... that would be quite
@@ -69,7 +69,7 @@ async fn adding_unspecified_addr_resolves_with_first() {
         .unwrap();
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn listening_for_multiple_unspecified_addresses() {
     let node = ipfs::Node::new("test_node").await;
     // there is no test in trying to match this with others as ... that would be quite
@@ -93,7 +93,7 @@ async fn listening_for_multiple_unspecified_addresses() {
     );
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn remove_listening_address() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -117,7 +117,7 @@ fn remove_listening_address_before_completing() {
     // "immediatedly".
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn pre_configured_listening_addrs() {
     use ipfs::{IpfsOptions, MultiaddrWithPeerId, MultiaddrWithoutPeerId, Node};
     use libp2p::Multiaddr;

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -7,14 +7,14 @@ use tokio::time::timeout;
 mod common;
 use common::{spawn_nodes, Topology};
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn subscribe_only_once() {
     let a = Node::new("test_node").await;
     let _stream = a.pubsub_subscribe("some_topic".into()).await.unwrap();
     a.pubsub_subscribe("some_topic".into()).await.unwrap_err();
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn resubscribe_after_unsubscribe() {
     let a = Node::new("test_node").await;
 
@@ -26,7 +26,7 @@ async fn resubscribe_after_unsubscribe() {
     drop(a.pubsub_subscribe("topic".into()).await.unwrap());
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn unsubscribe_via_drop() {
     let a = Node::new("test_node").await;
 
@@ -39,7 +39,7 @@ async fn unsubscribe_via_drop() {
     assert_eq!(a.pubsub_subscribed().await.unwrap(), empty);
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn can_publish_without_subscribing() {
     let a = Node::new("test_node").await;
     a.pubsub_publish("topic".into(), b"foobar".to_vec())
@@ -47,7 +47,7 @@ async fn can_publish_without_subscribing() {
         .unwrap()
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[allow(clippy::mutable_key_type)] // clippy doesn't like Vec inside HashSet
 async fn publish_between_two_nodes() {
     use futures::stream::StreamExt;
@@ -140,7 +140,7 @@ async fn publish_between_two_nodes() {
 }
 
 #[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[ignore = "doesn't work yet"]
 async fn pubsub_interop() {
     use common::interop::{api_call, ForeignNode};

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -4,7 +4,7 @@ use futures::future::{AbortHandle, Abortable};
 use ipfs::Node;
 use tokio::{
     task,
-    time::{delay_for, timeout},
+    time::{sleep, timeout},
 };
 
 use std::{
@@ -33,7 +33,7 @@ where
         if check(future().await) {
             return Ok(());
         }
-        delay_for(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(100)).await;
         elapsed = started.elapsed();
     }
 }
@@ -51,7 +51,7 @@ async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) 
 }
 
 /// Check if canceling a Cid affects the wantlist.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn wantlist_cancellation() {
     tracing_subscriber::fmt::init();
 


### PR DESCRIPTION
A mostly straightforward update to more recent versions of these dependencies.

Filing it as a draft due to the `block_exchange::long_get_block` mysteriously failing, at least locally.