### PR TITLE
Using leveldb for DataStore and PinStore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,6 +406,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1229,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
+ "rs-leveldb",
  "serde",
  "serde_json",
  "sha2 0.9.1",
@@ -1362,6 +1372,17 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "leveldb-sys"
+version = "2.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "618aee5ba3d32cb8456420a9a454aa71c1af5b3e9c7a2ec20a0f3cbbe47246cb"
+dependencies = [
+ "cmake",
+ "libc",
+ "num_cpus",
+]
 
 [[package]]
 name = "libc"
@@ -2377,6 +2398,16 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "rs-leveldb"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45bd5782e78f9c4dd1e232c3439c2db9ec4c73075e5dd6fb65fb7daae33812d"
+dependencies = [
+ "leveldb-sys",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ tracing-futures = { default-features = false, features = ["std", "futures-03"], 
 void = { default-features = false, version = "1.0" }
 fs2 = "0.4.3"
 tempfile = "3.1.0"
+rs-leveldb = "0.1.5"
 
 [target.'cfg(windows)'.dependencies]
 # required for DNS resolution

--- a/examples/dag_creation.rs
+++ b/examples/dag_creation.rs
@@ -19,6 +19,10 @@ async fn main() {
     let cid = ipfs.put_dag(root).await.unwrap();
     let path = IpfsPath::from(cid);
 
+    for p in path.iter() {
+        println!("path: {}", p);
+    }
+
     // Query the DAG
     let path1 = path.sub_path("0").unwrap();
     let path2 = path.sub_path("1").unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,7 +103,7 @@ impl<T: RepoTypes> IpfsTypes for T {}
 pub struct Types;
 impl RepoTypes for Types {
     type TBlockStore = repo::fs::FsBlockStore;
-    type TDataStore = repo::fs::FsDataStore;
+    type TDataStore = repo::leveldb::LeveldbStore;
     type TLock = repo::fs::FsLock;
 }
 

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -415,7 +415,7 @@ fn write_through_tempfile(
         .truncate(true)
         .open(&temp_path)?;
 
-    temp.write_all(&*data)?;
+    temp.write_all(data)?;
     temp.flush()?;
 
     // safe default

--- a/src/repo/leveldb.rs
+++ b/src/repo/leveldb.rs
@@ -1,0 +1,388 @@
+#![allow(unused_variables)]
+#![allow(unused_imports)]
+#![allow(dead_code)]
+
+use leveldb::database::Database;
+use leveldb::options::{Options, ReadOptions, WriteOptions};
+use leveldb::batch::{WriteBatch, Batch};
+use leveldb::iterator::{Iterable, KeyIterator};
+use async_trait::async_trait;
+use std::path::PathBuf;
+use std::str::FromStr;
+use cid::{self, Cid};
+use std::sync::{Mutex, Arc};
+use std::cell::{RefCell, Ref};
+use futures::stream::{StreamExt, TryStreamExt};
+use crate::error::Error;
+use crate::repo::{PinStore, References, PinMode, PinKind};
+use super::{Column, DataStore};
+use tracing_futures::Instrument;
+
+
+#[derive(Debug)]
+pub struct LeveldbStore {
+    path: PathBuf,
+    database: Option<Database>,
+    read_options: ReadOptions,
+    write_options: WriteOptions,
+}
+
+impl LeveldbStore {
+    fn get_u8(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+        let db = self.get_database();
+        let value = db.get_u8(&self.read_options, key)?;
+
+        Ok(value)
+    }
+
+    fn put_u8(&self, key: &[u8], value: &[u8]) -> Result<(), Error> {
+        let db = self.get_database();
+
+        match db.put_u8(&self.write_options, key, value) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into())
+        }
+    }
+
+    fn write_batch(&self, batch: &WriteBatch) -> Result<(), Error> {
+        let db = self.get_database();
+
+        match db.write(&self.write_options, batch) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into())
+        }
+    }
+
+    fn delete(&self, key: &[u8]) -> Result<(), Error> {
+        let db = self.get_database();
+
+        match db.delete_u8(&self.write_options, key) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into())
+        }
+    }
+
+    fn get_database(&self) -> &Database {
+        self.database.as_ref().unwrap()
+    }
+
+    fn key_iter(&self) -> KeyIterator {
+        let db = self.get_database();
+
+        db.keys_iter(&self.read_options)
+    }
+
+}
+
+#[async_trait]
+impl DataStore for LeveldbStore {
+    fn new(root: PathBuf) -> LeveldbStore {
+        LeveldbStore {
+            path: root,
+            database: None,
+            read_options: ReadOptions::new(),
+            write_options: WriteOptions::new(),
+        }
+    }
+
+    async fn init(&self) -> Result<(), Error> {
+        let mut options = Options::new();
+        options.create_if_missing = true;
+
+        let database = Database::open(self.path.as_path(), &options)?;
+
+        unsafe {
+            let db_ref = self as * const LeveldbStore;
+            let db_mut = db_ref as * mut LeveldbStore;
+            (*db_mut).database = Some(database);
+        }
+
+        Ok(())
+    }
+
+    async fn open(&self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    /// Checks if a key is present in the datastore.
+    async fn contains(&self, col: Column, key: &[u8]) -> Result<bool, Error> {
+        unimplemented!("")
+    }
+
+    /// Returns the value associated with a key from the datastore.
+    async fn get(&self, col: Column, key: &[u8]) -> Result<Option<Vec<u8>>, Error> {
+        unimplemented!("")
+    }
+
+    /// Puts the value under the key in the datastore.
+    async fn put(&self, col: Column, key: &[u8], value: &[u8]) -> Result<(), Error> {
+        unimplemented!("")
+    }
+
+    /// Removes a key-value pair from the datastore.
+    async fn remove(&self, col: Column, key: &[u8]) -> Result<(), Error> {
+        unimplemented!("")
+    }
+
+    /// Wipes the datastore.
+    async fn wipe(&self) {
+        unimplemented!("")
+    }
+}
+
+
+#[async_trait]
+impl PinStore for LeveldbStore {
+    async fn is_pinned(&self, block: &Cid) -> Result<bool, Error> {
+        is_pinned(self, block)
+    }
+
+    async fn insert_direct_pin(&self, target: &Cid) -> Result<(), Error> {
+        let already_pinned = get_pinned_mode(self, target)?;
+
+        let batch = WriteBatch::new();
+
+        match already_pinned {
+            Some(PinMode::Direct) => return Ok(()),
+            Some(PinMode::Recursive) => return Err(anyhow::anyhow!("pin: {} already pinned recursively", target.to_string())),
+            Some(PinMode::Indirect) => batch.delete_u8(get_pin_key(target, &PinMode::Indirect).as_bytes()),
+            _ => {}
+        }
+
+        let direct_key = get_pin_key(target, &PinMode::Direct);
+
+        batch.put_u8(direct_key.as_bytes(), &[][..]);
+
+        match self.write_batch(&batch) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into())
+        }
+    }
+
+    async fn insert_recursive_pin(&self, target: &Cid, referenced: References<'_>, )
+                                  -> Result<(), Error>
+    {
+
+        let set = referenced.try_collect::<std::collections::BTreeSet<_>>()
+            .await?;
+
+        let batch = WriteBatch::new();
+        let already_pinned = get_pinned_mode(self, target)?;
+
+        match already_pinned {
+            Some(PinMode::Recursive) => return Ok(()),
+            Some(mode@PinMode::Direct) | Some(mode@PinMode::Indirect) => {
+                let key = get_pin_key(target, &mode);
+                batch.delete_u8(key.as_bytes());
+            }
+            _ => {}
+        }
+
+
+        let recursive_key = get_pin_key(target, &PinMode::Recursive);
+        batch.put_u8(recursive_key.as_bytes(), &[][..]);
+
+        for cid in &set {
+            let indirect_key = get_pin_key(cid, &PinMode::Indirect);
+
+            let is_already_pinned = is_pinned(self,target);
+
+            match is_already_pinned {
+                Ok(true) => continue,
+                _ => {},
+            }
+
+            // value is for get information like Qmd9WDTA2Kph4MKiDDiaZdiB4HJQpKcxjnJQfQmM5rHhYK indirect through QmXr1XZBg1CQv17BPvSWRmM7916R6NLL7jt19rhCPdVhc5
+            batch.put_u8(indirect_key.as_bytes(), target.to_string().as_bytes());
+        }
+
+        match self.write_batch(&batch) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn remove_direct_pin(&self, target: &Cid) -> Result<(), Error> {
+        let key = get_pin_key(target, &PinMode::Direct);
+
+        match self.delete(key.as_bytes()) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn remove_recursive_pin(&self, target: &Cid, referenced: References<'_>, ) -> Result<(), Error> {
+        let set = referenced.try_collect::<std::collections::BTreeSet<_>>()
+            .await?;
+        let cid_str = target.to_string();
+
+        let batch = WriteBatch::new();
+
+        batch.delete_u8(get_pin_key(target, &PinMode::Recursive).as_bytes());
+
+        for cid in &set {
+            let already_pinned = get_pinned_mode(self, cid)?;
+
+            match already_pinned {
+                Some(PinMode::Recursive) | Some(PinMode::Direct) => continue,
+                Some(PinMode::Indirect) => {
+                    let indirect_key = get_pin_key(cid, &PinMode::Indirect);
+
+                    // cid is used by other block
+                    match self.get_u8(indirect_key.as_bytes()) {
+                        Ok(Some(value)) => {
+                            let value = String::from_utf8_lossy(value.as_slice());
+
+                            if cid_str == value {
+                                batch.delete_u8(get_pin_key(cid, &PinMode::Indirect).as_bytes());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        match self.write_batch(&batch) {
+            Ok(_) => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn list(&self, expected_mode: Option<PinMode>) -> futures::stream::BoxStream<'static, Result<(Cid, PinMode), Error>> {
+        let iter = self.key_iter();
+
+        let mut all_keys = vec![];
+
+        for item in iter {
+            all_keys.push(item);
+        }
+
+        let st = async_stream::try_stream! {
+            for raw_key in all_keys.iter() {
+                let key = String::from_utf8_lossy(raw_key.as_slice());
+
+                if key.starts_with("pin.") {
+                    let cid_str_with_prefix = &key[4..];
+
+                    let (cid_str, pin_mode) = match cid_str_with_prefix {
+                        direct_str if cid_str_with_prefix.starts_with("direct") => {
+                            (&cid_str_with_prefix["direct".len() + 1..], PinMode::Direct)
+                        },
+
+                        recursive_str if cid_str_with_prefix.starts_with("recursive") => {
+                            (&cid_str_with_prefix["recursive".len() + 1..], PinMode::Recursive)
+                        }
+
+                        indirect_str if cid_str_with_prefix.starts_with("indirect") => {
+                            (&cid_str_with_prefix["indirect".len() + 1..], PinMode::Indirect)
+                        }
+
+                        _ =>  continue,
+                    };
+
+                    match Cid::from_str(cid_str) {
+                        Ok(cid) =>  {
+                            match expected_mode {
+                                Some(ref expected) => if pin_mode == *expected {
+                                    yield (cid, pin_mode);
+                                }
+                                _ => yield (cid, pin_mode),
+                            }
+                        }
+                        Err(_) => {}
+                    }
+                }
+           }
+        };
+
+        st.in_current_span().boxed()
+    }
+
+
+    async fn query(&self, ids: Vec<Cid>, requirement: Option<PinMode>) -> Result<Vec<(Cid, PinKind<Cid>)>, Error> {
+        let mut res = Vec::<(Cid, PinKind<Cid>)>::new();
+
+        let pin_mode_matches = |cid: &Cid, pin_mode: &PinMode| {
+            match requirement {
+                Some(ref expected) => *expected == *pin_mode,
+                None => true
+            }
+        };
+
+        for id in ids.iter() {
+            match get_pinned_mode(self, id) {
+                Ok(Some(pin_mode)) => {
+                    if !pin_mode_matches(id, &pin_mode) {
+                        continue
+                    }
+
+                    match pin_mode {
+                        PinMode::Direct => res.push((id.clone(), PinKind::Direct)),
+                        PinMode::Recursive => res.push((id.clone(), PinKind::Recursive(0))),
+                        PinMode::Indirect => {
+                            let pin_key = get_pin_key(id, &PinMode::Indirect);
+
+                            match self.get_u8(pin_key.as_bytes()) {
+                                Ok(Some(indirect_from_raw)) => {
+                                    let indirect_from_str = String::from_utf8_lossy(indirect_from_raw.as_slice());
+
+                                    match Cid::from_str(&indirect_from_str) {
+                                        Ok(indirect_from_cid) =>
+                                            res.push((id.clone(), PinKind::IndirectFrom(indirect_from_cid))),
+                                        _ => {
+                                            warn!("invalid indirect from cid of {}", id);
+                                            continue
+                                        }
+                                    }
+                                }
+                                Ok(_) => {}
+                                Err(e) => return Err(e.into())
+                            }
+                        }
+                    }
+                }
+                Ok(_) => {}
+                Err(e) => return Err(e.into())
+            }
+        }
+
+        Ok(res)
+    }
+}
+
+
+fn pin_mode_literal(pin_mode: &PinMode) -> &'static str {
+    match pin_mode {
+        PinMode::Direct => "direct",
+        PinMode::Indirect => "indirect",
+        PinMode::Recursive => "recursive",
+    }
+}
+
+fn get_pin_key(cid: &Cid, pin_mode: &PinMode) -> String {
+    format!("pin.{}.{}", pin_mode_literal(pin_mode), cid.to_string())
+}
+
+fn get_pinned_mode(database: &LeveldbStore, block: &Cid) -> Result<Option<PinMode>, Error> {
+    for mode in &[PinMode::Direct, PinMode::Recursive, PinMode::Indirect] {
+        let key =  get_pin_key(block, mode);
+
+        match database.get_u8(key.as_bytes()) {
+            Ok(Some(_)) => return Ok(Some(mode.clone())),
+            Ok(_) => {}
+            Err(e) => return Err(e.into())
+        }
+    }
+
+    Ok(None)
+}
+
+fn is_pinned(database: &LeveldbStore, block: &Cid) -> Result<bool, Error> {
+    match get_pinned_mode(database, block) {
+        Ok(Some(_)) => return Ok(true),
+        Ok(_) => return Ok(false),
+        Err(e) => Err(e.into())
+    }
+}

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -26,6 +26,7 @@ mod common_tests;
 
 pub mod fs;
 pub mod mem;
+pub mod leveldb;
 
 /// Consolidates `BlockStore` and `DataStore` into a representation of storage.
 pub trait RepoTypes: Send + Sync + 'static {


### PR DESCRIPTION
This PR is for replacing FsDataStore with LeveldbDataStore, so that it is easy to realize MFS.  
The FsDatastore is inefficiency now,  when checking a indirect pinned cid,  all file in the FsDatastore will be visited, what more important is that it is hard to distinguish the data for pinning and the data for DataStore. The leveldb  will bring convenience and efficiency in the next work with its high efficiency and easy key/value operation.