### PR TITLE
Clippy changes for 1.49, doc fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,10 @@ jobs:
       run: cargo clippy --all-targets --workspace -- -D warnings
 
   # adapted from https://github.com/taiki-e/pin-project/blob/5878410863f5f25e21f7cba97b035501749850f9/.github/workflows/ci.yml#L136-L167
+  # further enchanced following solutions to
+  # https://github.com/bors-ng/bors-ng/issues/1115 -- bors now considers the
+  # skipped task a failure, or overrides the status for a task with a same name
+  # with the one which came later.
   ci-success:
       # this is read by bors
       name: ci
@@ -205,15 +209,3 @@ jobs:
       steps:
         - name: Mark the job as a success
           run: exit 0
-
-  ci-failure:
-      # again, read by bors
-      name: ci
-      if: github.event_name == 'push' && !success()
-      needs:
-        - ci-matrix
-        - lint-rust
-      runs-on: ubuntu-latest
-      steps:
-        - name: Mark the job as failure
-          run: exit 1

--- a/bitswap/src/ledger.rs
+++ b/bitswap/src/ledger.rs
@@ -131,21 +131,26 @@ impl Into<Vec<u8>> for &Message {
         let mut proto = bitswap_pb::Message::default();
         let mut wantlist = bitswap_pb::message::Wantlist::default();
         for (cid, priority) in self.want() {
-            let mut entry = bitswap_pb::message::wantlist::Entry::default();
-            entry.block = cid.to_bytes();
-            entry.priority = *priority;
+            let entry = bitswap_pb::message::wantlist::Entry {
+                block: cid.to_bytes(),
+                priority: *priority,
+                ..Default::default()
+            };
             wantlist.entries.push(entry);
         }
         for cid in self.cancel() {
-            let mut entry = bitswap_pb::message::wantlist::Entry::default();
-            entry.block = cid.to_bytes();
-            entry.cancel = true;
+            let entry = bitswap_pb::message::wantlist::Entry {
+                block: cid.to_bytes(),
+                cancel: true,
+                ..Default::default()
+            };
             wantlist.entries.push(entry);
         }
         for block in self.blocks() {
-            let mut payload = bitswap_pb::message::Block::default();
-            payload.prefix = Prefix::from(block.cid()).to_bytes();
-            payload.data = block.data().to_vec();
+            let payload = bitswap_pb::message::Block {
+                prefix: Prefix::from(block.cid()).to_bytes(),
+                data: block.data().to_vec(),
+            };
             proto.payload.push(payload);
         }
         if !wantlist.entries.is_empty() {

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -72,7 +72,7 @@ pub fn init(
 
     let bits = bits.get();
 
-    if bits < 2048 || bits > 16 * 1024 {
+    if !(2048..=16 * 1024).contains(&bits) {
         // Ring won't accept less than a 2048 bit key.
         return Err(InitializationError::InvalidRsaKeyLength(bits));
     }

--- a/src/ipld/dag_json.rs
+++ b/src/ipld/dag_json.rs
@@ -10,7 +10,6 @@ use serde_json::ser::Serializer;
 use serde_json::Error;
 use std::collections::BTreeMap;
 use std::fmt;
-use std::iter::FromIterator;
 
 /// Json codec.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -215,7 +214,7 @@ impl<'de> de::Visitor<'de> for JSONVisitor {
         let unwrapped = values
             .into_iter()
             .map(|(key, WrapperOwned(value))| (key, value));
-        Ok(Ipld::Map(BTreeMap::from_iter(unwrapped)))
+        Ok(Ipld::Map(unwrapped.collect()))
     }
 
     #[inline]

--- a/src/path.rs
+++ b/src/path.rs
@@ -175,7 +175,7 @@ impl SlashedPath {
     ) -> Result<(), ()> {
         let mut split = split.peekable();
         while let Some(sub_path) = split.next() {
-            if sub_path == "" {
+            if sub_path.is_empty() {
                 return if split.peek().is_none() {
                     // trim trailing
                     Ok(())

--- a/tests/common/interop.rs
+++ b/tests/common/interop.rs
@@ -7,7 +7,6 @@ pub struct ForeignNode;
 
 #[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
 pub mod common {
-    use anyhow;
     use libp2p::{core::PublicKey, Multiaddr, PeerId};
     use rand::prelude::*;
     use serde::Deserialize;

--- a/unixfs/CHANGELOG.md
+++ b/unixfs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Next
 
+* Document panic introduced in walker ergonomics [#435]
+
+[#435]: https://github.com/rs-ipfs/rust-ipfs/pull/435
+
 # 0.2.0
 
 Minor version bump due to ipfs 0.2.0 release.

--- a/unixfs/src/walk.rs
+++ b/unixfs/src/walk.rs
@@ -86,7 +86,7 @@ impl Walker {
     }
 
     /// Returns the next `Cid` to load and pass its associated content to `continue_walk`.
-    pub fn pending_links<'a>(&'a self) -> (&'a Cid, impl Iterator<Item = &'a Cid> + 'a) {
+    pub fn pending_links(&self) -> (&Cid, impl Iterator<Item = &Cid> + '_) {
         use InnerKind::*;
         // rev: because we'll pop any of the pending
         let cids = self.pending.iter().map(|(cid, ..)| cid).rev();

--- a/unixfs/src/walk.rs
+++ b/unixfs/src/walk.rs
@@ -86,6 +86,11 @@ impl Walker {
     }
 
     /// Returns the next `Cid` to load and pass its associated content to `continue_walk`.
+    ///
+    /// # Panics
+    ///
+    /// When `Walker::should_continue()` returns `false`.
+    // TODO: perhaps this should return an option?
     pub fn pending_links(&self) -> (&Cid, impl Iterator<Item = &Cid> + '_) {
         use InnerKind::*;
         // rev: because we'll pop any of the pending

--- a/unixfs/src/walk.rs
+++ b/unixfs/src/walk.rs
@@ -85,11 +85,11 @@ impl Walker {
         }
     }
 
-    /// Returns the next `Cid` to load and pass its associated content to `continue_walk`.
+    /// Returns the next [`Cid`] to load and pass its associated content to [`next`].
     ///
     /// # Panics
     ///
-    /// When `Walker::should_continue()` returns `false`.
+    /// When [`should_continue()`] returns `false`.
     // TODO: perhaps this should return an option?
     pub fn pending_links(&self) -> (&Cid, impl Iterator<Item = &Cid> + '_) {
         use InnerKind::*;
@@ -304,7 +304,7 @@ impl Walker {
         }
     }
 
-    /// `true` if the walk of `inspect` should continue
+    /// Returns `true` if there are more links to walk over.
     pub fn should_continue(&self) -> bool {
         self.should_continue
     }


### PR DESCRIPTION
Address latest warnings with 1.48. It feels like we should have gotten the `some_str == ""` in earlier versions as well, other than this these are just minor idiomatic changes. Also includes:
 - a previously forgotten panic documentation on ipfs-unxifs walker
 - workflow fix to enable merges again (see #436)
 
 Closes #436.