### PR TITLE
ci: no longer require review approvals to merge

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -6,5 +6,7 @@ status = ["ci"]
 
 delete_merged_branches = true
 
-# requires review approvals, which can also contain the bors command
-required_approvals = 1
+# required review approvals, which can also contain the bors command. this was
+# removed after finding it makes small maintenance tasks quite communication
+# heavy.
+required_approvals = 0


### PR DESCRIPTION
This PR will allow `bors r+` before there are any review approvals. It will be good for smaller PRs like #436 or things which happen right before releasing. Alternatives include:
- to request and await for approvals (current situation)
- to merge without bors -- this is something I'd like to avoid doing

Now bors uses the PRs configuration so I don't require any approvals on this, but it has to come after #436 so that the workflow is fixed so at least this is gated on that :) So @aphelionz, @ljedrz, or anyone interested in this, how do you see this? I think the policy should still be to review all non-boring maintenance PRs.

I did check CONTRIBUTING.md and found that there is nothing regarding this.

I'll merge this at the earliest of tomorrow morning on +02:00.