### PR TITLE
Transactional sled pinstore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 * ci: update go-ipfs to `0.7.0` for interop tests [#428]
 * refactor(http): introduce `Config` as the facade for configuration [#423]
 * feat(http): create `Profile` abstraction [#421]
+* feat: `sled` pinstore [#439]
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
 [#423]: https://github.com/rs-ipfs/rust-ipfs/pull/423
 [#421]: https://github.com/rs-ipfs/rust-ipfs/pull/421
+[#439]: https://github.com/rs-ipfs/rust-ipfs/pull/439
 
 # 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 * ci: update go-ipfs to `0.7.0` for interop tests [#428]
 * refactor(http): introduce `Config` as the facade for configuration [#423]
 * feat(http): create `Profile` abstraction [#421]
-* feat: `sled` pinstore [#439]
+* feat: `sled` pinstore [#439], [#442]
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
 [#423]: https://github.com/rs-ipfs/rust-ipfs/pull/423
 [#421]: https://github.com/rs-ipfs/rust-ipfs/pull/421
 [#439]: https://github.com/rs-ipfs/rust-ipfs/pull/439
+[#442]: https://github.com/rs-ipfs/rust-ipfs/pull/442
 
 # 0.2.1
 

--- a/src/repo/common_tests.rs
+++ b/src/repo/common_tests.rs
@@ -63,11 +63,25 @@ macro_rules! pinstore_interface_tests {
                 let empty =
                     Cid::try_from("QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH").unwrap();
 
-                assert_eq!(repo.is_pinned(&empty).await.unwrap(), false);
+                assert_eq!(
+                    repo.is_pinned(&empty).await.unwrap(),
+                    false,
+                    "initially unpinned"
+                );
                 repo.insert_direct_pin(&empty).await.unwrap();
-                assert_eq!(repo.is_pinned(&empty).await.unwrap(), true);
-                repo.insert_direct_pin(&empty).await.unwrap();
-                assert_eq!(repo.is_pinned(&empty).await.unwrap(), true);
+                assert_eq!(
+                    repo.is_pinned(&empty).await.unwrap(),
+                    true,
+                    "must be pinned following direct pin"
+                );
+                repo.insert_direct_pin(&empty)
+                    .await
+                    .expect("rewriting existing direct pin as direct should be noop");
+                assert_eq!(
+                    repo.is_pinned(&empty).await.unwrap(),
+                    true,
+                    "must be pinned following two direct pins"
+                );
             }
 
             #[tokio::test(max_threads = 1)]
@@ -146,7 +160,11 @@ macro_rules! pinstore_interface_tests {
 
                 let pins = repo.list(None).await.try_collect::<Vec<_>>().await.unwrap();
 
-                assert_eq!(pins, vec![(root.clone(), PinMode::Direct)]);
+                assert_eq!(
+                    pins,
+                    vec![(root.clone(), PinMode::Direct)],
+                    "must find direct pin for root"
+                );
 
                 // first refs
 

--- a/src/repo/fs/pinstore.rs
+++ b/src/repo/fs/pinstore.rs
@@ -523,7 +523,7 @@ fn sync_read_direct_or_recursive(block_path: &mut PathBuf) -> Option<PinMode> {
         // Path::is_file calls fstat and coerces errors to false; this might be enough, as
         // we are holding the lock
         if block_path.is_file() {
-            return Some(mode.clone());
+            return Some(*mode);
         }
     }
     None

--- a/src/repo/fs/pinstore.rs
+++ b/src/repo/fs/pinstore.rs
@@ -1,7 +1,7 @@
 //! Persistent filesystem backed pin store. See [`FsDataStore`] for more information.
 use super::{filestem_to_pin_cid, pin_path, FsDataStore};
 use crate::error::Error;
-use crate::repo::{PinKind, PinMode, PinStore, References};
+use crate::repo::{PinKind, PinMode, PinModeRequirement, PinStore, References};
 use async_trait::async_trait;
 use cid::Cid;
 use core::convert::TryFrom;
@@ -242,6 +242,8 @@ impl PinStore for FsDataStore {
 
         let path = self.path.clone();
 
+        let requirement = PinModeRequirement::from(requirement);
+
         // depending on what was queried we must iterate through the results in the order of
         // recursive, direct and indirect.
         //
@@ -258,13 +260,13 @@ impl PinStore for FsDataStore {
             let mut recursive: HashSet<Cid> = HashSet::new();
             let mut direct: HashSet<Cid> = HashSet::new();
 
-            let collect_recursive_for_indirect = requirement.as_ref().map(|r| *r == PinMode::Indirect).unwrap_or(true);
+            let collect_recursive_for_indirect = requirement.is_indirect_or_any();
 
             futures::pin_mut!(cids);
 
             while let Some((cid, mode)) = cids.try_next().await? {
 
-                let matches = requirement.as_ref().map(|r| *r == mode).unwrap_or(true);
+                let matches = requirement.matches(&mode);
 
                 if mode == PinMode::Recursive {
                     if collect_recursive_for_indirect {
@@ -338,6 +340,8 @@ impl PinStore for FsDataStore {
             None => (true, None, true),
         };
 
+        let searched_suffix = PinModeRequirement::from(searched_suffix);
+
         let (mut response, mut remaining) = if check_direct {
             // find the recursive and direct ones by just seeing if the files exist
             let base = self.path.clone();
@@ -346,7 +350,7 @@ impl PinStore for FsDataStore {
                     let mut path = pin_path(base.clone(), &cid);
 
                     if let Some(mode) = sync_read_direct_or_recursive(&mut path) {
-                        if searched_suffix.as_ref().map(|m| *m == mode).unwrap_or(true) {
+                        if searched_suffix.matches(&mode) {
                             response[i] = Some((
                                 cid,
                                 match mode {

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -350,7 +350,7 @@ fn get_pinned_mode(kv_db: &KvDataStore, block: &Cid) -> Result<Option<PinMode>, 
         let db = kv_db.get_db();
 
         match db.get(key.as_str())? {
-            Some(_) => return Ok(Some(mode.clone())),
+            Some(_) => return Ok(Some(*mode)),
             None => {}
         }
     }

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -263,7 +263,7 @@ impl PinStore for KvDataStore {
         ids: Vec<Cid>,
         requirement: Option<PinMode>,
     ) -> Result<Vec<(Cid, PinKind<Cid>)>, Error> {
-        let mut res = Vec::<(Cid, PinKind<Cid>)>::new();
+        let mut res = Vec::with_capacity(ids.len());
 
         let requirement = PinModeRequirement::from(requirement);
 

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -20,6 +20,7 @@ pub struct KvDataStore {
 }
 
 impl KvDataStore {
+    // unused for now, but might be needed if we implement the DataStore api
     fn _put(&self, key: &str, value: &str) -> Result<(), Error> {
         let db = self.get_db();
 
@@ -28,7 +29,7 @@ impl KvDataStore {
         Ok(())
     }
 
-    fn _remove(&self, key: &str) -> Result<(), Error> {
+    fn remove(&self, key: &str) -> Result<(), Error> {
         let db = self.get_db();
 
         match db.remove(key) {
@@ -37,7 +38,7 @@ impl KvDataStore {
         }
     }
 
-    fn _apply_batch(&self, batch: sled::Batch) -> Result<(), Error> {
+    fn apply_batch(&self, batch: sled::Batch) -> Result<(), Error> {
         let db = self.get_db();
 
         Ok(db.apply_batch(batch)?)
@@ -126,7 +127,7 @@ impl PinStore for KvDataStore {
 
         batch.insert(direct_key.as_str(), "");
 
-        Ok(self._apply_batch(batch)?)
+        Ok(self.apply_batch(batch)?)
     }
 
     async fn insert_recursive_pin(
@@ -164,7 +165,7 @@ impl PinStore for KvDataStore {
             batch.insert(indirect_key.as_str(), target.to_string().as_str());
         }
 
-        Ok(self._apply_batch(batch)?)
+        Ok(self.apply_batch(batch)?)
     }
 
     async fn remove_direct_pin(&self, target: &Cid) -> Result<(), Error> {
@@ -174,7 +175,7 @@ impl PinStore for KvDataStore {
 
         let key = get_pin_key(target, &PinMode::Direct);
 
-        Ok(self._remove(&key)?)
+        Ok(self.remove(&key)?)
     }
 
     async fn remove_recursive_pin(
@@ -207,7 +208,7 @@ impl PinStore for KvDataStore {
             }
         }
 
-        Ok(self._apply_batch(batch)?)
+        Ok(self.apply_batch(batch)?)
     }
 
     async fn list(

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -232,7 +232,7 @@ impl PinStore for KvDataStore {
                 continue;
             }
 
-            all_keys.push(key.to_owned().to_string());
+            all_keys.push(key.into_owned());
         }
 
         let st = async_stream::try_stream! {

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -263,7 +263,7 @@ impl PinStore for KvDataStore {
         let requirement = PinModeRequirement::from(requirement);
 
         let adapted = iter
-            .map(|res| res.map_err(|e| Error::from(e)))
+            .map(|res| res.map_err(Error::from))
             .filter_map(move |res| match res {
                 Ok((k, _v)) => {
                     if !k.starts_with(b"pin.") || k.len() < 7 {
@@ -421,9 +421,8 @@ fn get_pinned_mode(
     for mode in &[PinMode::Direct, PinMode::Recursive, PinMode::Indirect] {
         let key = get_pin_key(block, mode);
 
-        match tree.get(key.as_str())? {
-            Some(_) => return Ok(Some(*mode)),
-            None => {}
+        if tree.get(key.as_str())?.is_some() {
+            return Ok(Some(*mode));
         }
     }
 

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -133,7 +133,7 @@ impl PinStore for KvDataStore {
             Ok(true)
         });
 
-        if unwrap_tx_result(res)? {
+        if launder(res)? {
             self.flush_async().await
         } else {
             Ok(())
@@ -204,7 +204,7 @@ impl PinStore for KvDataStore {
             tx_tree.remove(key.as_str())?;
             Ok(())
         });
-        unwrap_tx_result(res)?;
+        launder(res)?;
 
         self.flush_async().await
     }
@@ -244,7 +244,7 @@ impl PinStore for KvDataStore {
             Ok(())
         });
 
-        unwrap_tx_result(res)?;
+        launder(res)?;
 
         self.flush_async().await
     }
@@ -364,7 +364,7 @@ impl PinStore for KvDataStore {
             Ok(res)
         });
 
-        let indices = unwrap_tx_result(result)?;
+        let indices = launder(result)?;
 
         assert_eq!(indices.len(), ids.len());
 
@@ -383,8 +383,8 @@ impl PinStore for KvDataStore {
     }
 }
 
-/// Helper needed as the error cannot just `?` converted. TODO: rename to launder?
-fn unwrap_tx_result<T>(res: TransactionResult<T, Error>) -> Result<T, Error> {
+/// Helper needed as the error cannot just `?` converted.
+fn launder<T>(res: TransactionResult<T, Error>) -> Result<T, Error> {
     use TransactionError::*;
     match res {
         Ok(t) => Ok(t),

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -108,11 +108,12 @@ impl PinStore for KvDataStore {
                     // TODO: I think the direct should live alongside the indirect?
                     let pin_key = get_pin_key(target, &PinMode::Indirect);
                     tx_tree.remove(pin_key.as_str())?;
-                    let direct_key = get_pin_key(target, &PinMode::Direct);
-                    tx_tree.insert(direct_key.as_str(), "")?;
                 }
                 None => {}
             }
+
+            let direct_key = get_pin_key(target, &PinMode::Direct);
+            tx_tree.insert(direct_key.as_str(), "")?;
 
             Ok(())
         });

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -236,7 +236,7 @@ pub enum Column {
 }
 
 /// `PinMode` is the description of pin type for quering purposes.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PinMode {
     Indirect,
     Direct,

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -243,6 +243,50 @@ pub enum PinMode {
     Recursive,
 }
 
+/// Helper for around the quite confusing test required in [`PinStore::list`] and
+/// [`PinStore::query`].
+#[derive(Debug, Clone, Copy)]
+enum PinModeRequirement {
+    Only(PinMode),
+    Any,
+}
+
+impl From<Option<PinMode>> for PinModeRequirement {
+    fn from(filter: Option<PinMode>) -> Self {
+        match filter {
+            Some(one) => PinModeRequirement::Only(one),
+            None => PinModeRequirement::Any,
+        }
+    }
+}
+
+impl PinModeRequirement {
+    fn is_indirect_or_any(&self) -> bool {
+        use PinModeRequirement::*;
+        match self {
+            Only(PinMode::Indirect) | Any => true,
+            Only(_) => false,
+        }
+    }
+
+    fn matches<P: PartialEq<PinMode>>(&self, other: &P) -> bool {
+        use PinModeRequirement::*;
+        match self {
+            Only(one) if other == one => true,
+            Only(_) => false,
+            Any => true,
+        }
+    }
+
+    fn required(&self) -> Option<PinMode> {
+        use PinModeRequirement::*;
+        match self {
+            Only(one) => Some(*one),
+            Any => None,
+        }
+    }
+}
+
 impl<B: Borrow<Cid>> PartialEq<PinMode> for PinKind<B> {
     fn eq(&self, other: &PinMode) -> bool {
         matches!((self, other),


### PR DESCRIPTION
This enables the pinstore to use transactions for almost all operations. Big ticket TODOs remaining:
- handling duplicate indirect pins (missing test)
- handling pin combinations (missing test)
- cidv0 compatible cidv1 normalization (missing test)
- the str representation could probably be changed?
- sled usage still needs to be wrapped in spawn_blocking

In smaller changes:
- makes PinMode Copy
- extracts a `PinModeRequirement` out of the `Option<PinMode>` which is hopefully more readable (list, query)

CC: @fetchadd, got the PR I promised made. Do you have any ideas? Sadly the changeset is probably quite difficult to review. I could split it up to have just the small fixes followed by the transactional stuff, but the smaller changes can probably by diffing only up until some commits.