### PR TITLE
ci: hold back at cargo ndk 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
     - name: Install cargo-ndk
       if: contains(matrix.platform.target, 'android')
-      run: cargo install cargo-ndk
+      run: cargo install --version '<2.0.0' cargo-ndk
 
     - name: Build (others)
       if: matrix.platform.cross == false


### PR DESCRIPTION
This PR delays the changing to `cargo ndk` version 2.0, which has different cmdline API.