### PR TITLE
Update libp2p, tokio, warp, prost, futures, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * refactor(http): introduce `Config` as the facade for configuration [#423]
 * feat(http): create `Profile` abstraction [#421]
 * feat: `sled` pinstore [#439], [#442], [#444]
+* chore: update a lot of dependencies including libp2p, tokio, warp [#446]
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
@@ -12,7 +13,8 @@
 [#421]: https://github.com/rs-ipfs/rust-ipfs/pull/421
 [#439]: https://github.com/rs-ipfs/rust-ipfs/pull/439
 [#442]: https://github.com/rs-ipfs/rust-ipfs/pull/442
-[#442]: https://github.com/rs-ipfs/rust-ipfs/pull/444
+[#444]: https://github.com/rs-ipfs/rust-ipfs/pull/444
+[#446]: https://github.com/rs-ipfs/rust-ipfs/pull/446
 
 # 0.2.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,8 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.2.5"
-source = "git+https://github.com/seanmonstar/warp.git#ffefea08050ffe8022d3391f4bd5e5ab4e95d7c9"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dafd0aac2818a94a34df0df1100a7356c493d8ede4393875fd0b5c51bb6bc80"
 dependencies = [
  "bytes 1.0.1",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63dd91889c49327ad7ef3b500fd1109dbd3c509a03db0d4a9ce413b79f575cb6"
 dependencies = [
  "block-cipher",
- "byteorder 1.3.4",
+ "byteorder",
  "opaque-debug 0.3.0",
 ]
 
@@ -134,9 +134,12 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64f46ca51dca4837f1520754d1c8c36636356b81553d928dc9c177025369a06e"
+checksum = "c3410529e8288c463bedb5930f82833bc0c90e5d2fe639a56582a4d09220b281"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "atty"
@@ -180,7 +183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
 dependencies = [
  "byte-tools",
- "byteorder 1.3.4",
+ "byteorder",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
  "opaque-debug 0.2.3",
@@ -216,7 +219,7 @@ checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
  "block-padding 0.1.5",
  "byte-tools",
- "byteorder 1.3.4",
+ "byteorder",
  "generic-array 0.12.3",
 ]
 
@@ -256,9 +259,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bs58"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
@@ -286,12 +289,6 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc10e8cc6b2580fda3f36eb6dc5316657f812a3df879a44a66fc9f0fdbc4855"
-
-[[package]]
-name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
@@ -301,12 +298,6 @@ name = "bytes"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "c_linked_list"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4964518bd3b4a8190e832886cdc0da9794f12e8e6c1613a9e90ff331c4c8724b"
 
 [[package]]
 name = "cast"
@@ -391,15 +382,6 @@ dependencies = [
  "bitflags",
  "textwrap",
  "unicode-width",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -596,25 +578,13 @@ dependencies = [
 
 [[package]]
 name = "cuckoofilter"
-version = "0.3.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd43f7cfaffe0a386636a10baea2ee05cc50df3b77bea4a456c9572a939bf1f"
+checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
 dependencies = [
- "byteorder 0.5.3",
- "rand 0.3.23",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d85653f070353a16313d0046f173f70d1aadd5b42600a14de626f0dfb3473a5"
-dependencies = [
- "byteorder 1.3.4",
- "digest 0.8.1",
- "rand_core 0.5.1",
- "subtle 2.3.0",
- "zeroize",
+ "byteorder",
+ "fnv",
+ "rand",
 ]
 
 [[package]]
@@ -623,9 +593,9 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "digest 0.9.0",
- "rand_core 0.5.1",
+ "rand_core",
  "subtle 2.3.0",
  "zeroize",
 ]
@@ -702,7 +672,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "quick-error",
 ]
 
@@ -713,7 +683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc2157cca35ae62d3d6281d876cc1b3f0f71a3409fe4b7c8d8790b441e9bc2b"
 dependencies = [
  "bytes",
- "rand 0.7.3",
+ "rand",
  "smallvec",
 ]
 
@@ -726,9 +696,9 @@ dependencies = [
  "bytes",
  "domain",
  "futures",
- "rand 0.7.3",
+ "rand",
  "smallvec",
- "tokio",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -752,9 +722,9 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek 3.0.0",
+ "curve25519-dalek",
  "ed25519",
- "rand 0.7.3",
+ "rand",
  "serde",
  "sha2 0.9.1",
  "zeroize",
@@ -820,12 +790,6 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuchsia-zircon"
@@ -938,7 +902,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project 0.4.26",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -954,7 +918,7 @@ dependencies = [
  "bytes",
  "futures",
  "memchr",
- "pin-project",
+ "pin-project 0.4.26",
 ]
 
 [[package]]
@@ -963,14 +927,8 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
 name = "generic-array"
@@ -989,28 +947,6 @@ checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "get_if_addrs"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abddb55a898d32925f3148bd281174a68eeb68bbfd9a5938a57b18f506ee4ef7"
-dependencies = [
- "c_linked_list",
- "get_if_addrs-sys",
- "libc",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "get_if_addrs-sys"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04f9fb746cf36b191c00f3ede8bde9c8e64f9f4b05ae2694a9ccf5e3f5ab48"
-dependencies = [
- "gcc",
- "libc",
 ]
 
 [[package]]
@@ -1047,7 +983,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
+ "tokio 0.2.22",
  "tokio-util",
  "tracing",
 ]
@@ -1189,9 +1125,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project",
+ "pin-project 0.4.26",
  "socket2",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "want",
@@ -1206,6 +1142,27 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
+dependencies = [
+ "if-addrs-sys",
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "if-addrs-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -1256,7 +1213,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "base64",
- "byteorder 1.3.4",
+ "byteorder",
  "bytes",
  "cid",
  "dirs",
@@ -1275,14 +1232,14 @@ dependencies = [
  "once_cell",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand",
  "serde",
  "serde_json",
  "sha2 0.9.1",
  "sled",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1302,7 +1259,7 @@ dependencies = [
  "prost",
  "prost-build",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "unsigned-varint 0.3.3",
 ]
@@ -1334,7 +1291,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio",
+ "tokio 0.2.22",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1428,9 +1385,9 @@ checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libp2p"
-version = "0.28.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f5a4604c1a40d75651da141dfde29ad15329f537a779528803297d2220274"
+checksum = "e3c2b4c99f8798be90746fc226acf95d3e6cff0655883634cc30dab1f64f438b"
 dependencies = [
  "atomic",
  "bytes",
@@ -1451,17 +1408,17 @@ dependencies = [
  "libp2p-yamux",
  "multihash",
  "parity-multiaddr",
- "parking_lot 0.10.2",
- "pin-project",
+ "parking_lot",
+ "pin-project 1.0.4",
  "smallvec",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.22.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f13ba8c7df0768af2eb391696d562c7de88cc3a35122531aaa6a7d77754d25"
+checksum = "1b8186060d6bd415e4e928e6cb44c4fe7e7a7dd53437bd936ce7e5f421e45a51"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1476,17 +1433,17 @@ dependencies = [
  "multihash",
  "multistream-select",
  "parity-multiaddr",
- "parking_lot 0.10.2",
- "pin-project",
+ "parking_lot",
+ "pin-project 1.0.4",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand",
  "ring",
  "rw-stream-sink",
- "sha2 0.8.2",
+ "sha2 0.9.1",
  "smallvec",
  "thiserror",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "void",
  "zeroize",
 ]
@@ -1503,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cf319822e08dd65c8e060d2354e9f952895bbc433f5706c75ed010c152aee5e"
+checksum = "0baeff71fb5cb1fe1604f74a712a44b66a8c5900f4022411a1d550f09d6bb776"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1514,26 +1471,27 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a9acb43a3e4a4e413e0c4abe0fa49308df7c6335c88534757b647199cb8a51"
+checksum = "db0f925a45f310b678e70faf71a10023b829d02eb9cc2628a63de928936f3ade"
 dependencies = [
  "cuckoofilter",
  "fnv",
  "futures",
  "libp2p-core",
  "libp2p-swarm",
+ "log",
  "prost",
  "prost-build",
- "rand 0.7.3",
+ "rand",
  "smallvec",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56396ee63aa9164eacf40c2c5d2bda8c4133c2f57e1b0425d51d3a4e362583b1"
+checksum = "e074124669840484de564901d47f2d0892e73f6d8ee7c37e9c2644af1b217bf4"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1547,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7fa9047f8b8f544278a35c2d9d45d3b2c1785f2d86d4e1629d6edf97be3955"
+checksum = "78a2653b2e3254a3bbeb66bfc3f0dca7d6cba6aa2a96791db114003dec1b5394"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1563,20 +1521,20 @@ dependencies = [
  "multihash",
  "prost",
  "prost-build",
- "rand 0.7.3",
- "sha2 0.8.2",
+ "rand",
+ "sha2 0.9.1",
  "smallvec",
  "uint",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mdns"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3173b5a6b2f690c29ae07798d85b9441a131ac76ddae9015ef22905b623d0c69"
+checksum = "786b068098794322239f8f04df88a52daeb7863b2e77501c4d85d32e0a8f2d26"
 dependencies = [
  "data-encoding",
  "dns-parser",
@@ -1587,77 +1545,79 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "net2",
- "rand 0.7.3",
+ "rand",
  "smallvec",
- "tokio",
+ "tokio 0.3.6",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a73a799cc8410b36e40b8f4c4b6babbcb9efd3727111bf517876e4acfa612d3"
+checksum = "ed764eab613a8fb6b7dcf6c796f55a06fef2270e528329903e25cd3311b99663"
 dependencies = [
  "bytes",
- "fnv",
  "futures",
  "futures_codec",
  "libp2p-core",
  "log",
- "parking_lot 0.10.2",
- "unsigned-varint 0.4.0",
+ "nohash-hasher",
+ "parking_lot",
+ "rand",
+ "smallvec",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.24.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef6c490042f549fb1025f2892dfe6083d97a77558f450c1feebe748ca9eb15a"
+checksum = "fb441fb015ec16690099c5d910fcba271d357763b3dcb784db7b27bbb0b68372"
 dependencies = [
  "bytes",
- "curve25519-dalek 2.1.0",
+ "curve25519-dalek",
  "futures",
  "lazy_static",
  "libp2p-core",
  "log",
  "prost",
  "prost-build",
- "rand 0.7.3",
- "sha2 0.8.2",
+ "rand",
+ "sha2 0.9.1",
  "snow",
  "static_assertions",
- "x25519-dalek 0.6.0",
+ "x25519-dalek",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-ping"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad063c21dfcea4518ac9e8bd4119d33a5b26c41e674f602f41f05617a368a5c8"
+checksum = "82e5c50936cfdbe96a514e8992f304fa44cd3a681b6f779505f1ae62b3474705"
 dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand 0.7.3",
+ "rand",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193e444210132237b81b755ec7fe53f1c4bd2f53cf719729b94c0c72eb6eaa1"
+checksum = "565f0e06674b4033c978471e4083d5aaa8e03cef0719a0ec0905aaeaad39a919"
 dependencies = [
  "either",
  "futures",
  "libp2p-core",
  "log",
- "rand 0.7.3",
+ "rand",
  "smallvec",
  "void",
  "wasm-timer",
@@ -1665,29 +1625,29 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f42ec130d7a37a7e47bf4398026b7ad9185c08ed26972e2720f8b94112796f"
+checksum = "33f3dce259c0d3127af5167f45c275b6c047320efdd0e40fde947482487af0a3"
 dependencies = [
  "futures",
  "futures-timer",
- "get_if_addrs",
+ "if-addrs",
  "ipnet",
  "libp2p-core",
  "log",
  "socket2",
- "tokio",
+ "tokio 0.3.6",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.25.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "781d9b9f043dcdabc40640807125368596b849fd4d96cdca2dcf052fdf6f33fd"
+checksum = "1a0798cbb58535162c40858493d09af06eac42a26e4966e58de0df701f559348"
 dependencies = [
  "futures",
  "libp2p-core",
- "parking_lot 0.11.0",
+ "parking_lot",
  "thiserror",
  "yamux",
 ]
@@ -1702,19 +1662,10 @@ dependencies = [
  "crunchy",
  "digest 0.8.1",
  "hmac-drbg",
- "rand 0.7.3",
+ "rand",
  "sha2 0.8.2",
  "subtle 2.3.0",
  "typenum",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
 ]
 
 [[package]]
@@ -1809,10 +1760,23 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow",
+ "miow 0.2.1",
  "net2",
  "slab",
  "winapi 0.2.8",
+]
+
+[[package]]
+name = "mio"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+dependencies = [
+ "libc",
+ "log",
+ "miow 0.3.6",
+ "ntapi",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1828,6 +1792,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "miow"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+dependencies = [
+ "socket2",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "mpart-async"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,7 +1813,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.7.3",
+ "rand",
  "thiserror",
  "twoway",
 ]
@@ -1878,16 +1852,16 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9157e87afbc2ef0d84cc0345423d715f445edde00141c93721c162de35a05e5"
+checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
 dependencies = [
  "bytes",
  "futures",
  "log",
- "pin-project",
+ "pin-project 1.0.4",
  "smallvec",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
 ]
 
 [[package]]
@@ -1906,6 +1880,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "num-integer"
@@ -1989,30 +1972,20 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.2"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2165a93382a93de55868dcbfa11e4a8f99676a9164eee6a2b4a9479ad319c257"
+checksum = "43244a26dc1ddd3097216bb12eaa6cf8a07b060c72718d9ebd60fd297d6401df"
 dependencies = [
  "arrayref",
  "bs58",
- "byteorder 1.3.4",
+ "byteorder",
  "data-encoding",
  "multihash",
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.4.0",
+ "unsigned-varint 0.5.1",
  "url",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
 ]
 
 [[package]]
@@ -2022,22 +1995,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
 dependencies = [
  "instant",
- "lock_api 0.4.1",
- "parking_lot_core 0.8.0",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi 0.0.3",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi 0.3.9",
+ "lock_api",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2047,7 +2006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
 dependencies = [
  "cfg-if 0.1.10",
- "cloudabi 0.1.0",
+ "cloudabi",
  "instant",
  "libc",
  "redox_syscall",
@@ -2077,7 +2036,16 @@ version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
 dependencies = [
- "pin-project-internal",
+ "pin-project-internal 0.4.26",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
+dependencies = [
+ "pin-project-internal 1.0.4",
 ]
 
 [[package]]
@@ -2092,10 +2060,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project-internal"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -2254,7 +2239,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e489d4a83c17ea69b0291630229b5d4c92a94a3bf0165f7f72f506e94cda8b4b"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
 ]
 
 [[package]]
@@ -2268,29 +2253,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.3.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
-dependencies = [
- "libc",
- "rand 0.4.6",
-]
-
-[[package]]
-name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "rand"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
@@ -2298,7 +2260,7 @@ dependencies = [
  "getrandom",
  "libc",
  "rand_chacha",
- "rand_core 0.5.1",
+ "rand_core",
  "rand_hc",
 ]
 
@@ -2309,23 +2271,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2342,7 +2289,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core 0.5.1",
+ "rand_core",
 ]
 
 [[package]]
@@ -2368,15 +2315,6 @@ dependencies = [
  "crossbeam-utils 0.7.2",
  "lazy_static",
  "num_cpus",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2411,7 +2349,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "regex-syntax",
 ]
 
@@ -2479,7 +2417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
  "futures",
- "pin-project",
+ "pin-project 0.4.26",
  "static_assertions",
 ]
 
@@ -2674,7 +2612,7 @@ dependencies = [
  "fxhash",
  "libc",
  "log",
- "parking_lot 0.11.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2692,24 +2630,23 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "rand 0.7.3",
- "rand_core 0.5.1",
+ "rand",
+ "rand_core",
  "ring",
  "rustc_version",
  "sha2 0.9.1",
  "subtle 2.3.0",
- "x25519-dalek 1.1.0",
+ "x25519-dalek",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.3.15"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1fa70dc5c8104ec096f4fe7ede7a221d35ae13dcd19ba1ad9a81d2cab9a1c44"
+checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
  "winapi 0.3.9",
 ]
 
@@ -2773,9 +2710,9 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.42"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c51d92969d209b54a98397e1b91c8ae82d8c87a7bb87df0b29aa2ad81454228"
+checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2813,7 +2750,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand 0.7.3",
+ "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2896,11 +2833,23 @@ dependencies = [
  "iovec",
  "lazy_static",
  "memchr",
- "mio",
+ "mio 0.6.22",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.10",
  "slab",
  "tokio-macros",
+]
+
+[[package]]
+name = "tokio"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
+dependencies = [
+ "autocfg",
+ "libc",
+ "mio 0.7.7",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -2924,8 +2873,8 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
- "tokio",
+ "pin-project-lite 0.1.10",
+ "tokio 0.2.22",
 ]
 
 [[package]]
@@ -2942,7 +2891,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.10",
  "tracing-core",
 ]
 
@@ -2963,7 +2912,7 @@ checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
  "futures",
  "futures-task",
- "pin-project",
+ "pin-project 0.4.26",
  "tracing",
 ]
 
@@ -3022,7 +2971,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
 dependencies = [
- "byteorder 1.3.4",
+ "byteorder",
  "crunchy",
  "rustc-hex",
  "static_assertions",
@@ -3097,19 +3046,13 @@ checksum = "f67332660eb59a6f1eb24ff1220c9e8d01738a8503c6002e30bcfe4bd9f2b4a9"
 
 [[package]]
 name = "unsigned-varint"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669d776983b692a906c881fcd0cfb34271a48e197e4d6cb8df32b05bfc3d3fa5"
+checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 dependencies = [
  "bytes",
  "futures_codec",
 ]
-
-[[package]]
-name = "unsigned-varint"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 
 [[package]]
 name = "untrusted"
@@ -3197,12 +3140,12 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "pin-project",
+ "pin-project 0.4.26",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio",
+ "tokio 0.2.22",
  "tower-service",
  "tracing",
  "tracing-futures",
@@ -3295,7 +3238,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot 0.11.0",
+ "parking_lot",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3391,23 +3334,12 @@ dependencies = [
 
 [[package]]
 name = "x25519-dalek"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
-dependencies = [
- "curve25519-dalek 2.1.0",
- "rand_core 0.5.1",
- "zeroize",
-]
-
-[[package]]
-name = "x25519-dalek"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
- "curve25519-dalek 3.0.0",
- "rand_core 0.5.1",
+ "curve25519-dalek",
+ "rand_core",
  "zeroize",
 ]
 
@@ -3420,8 +3352,8 @@ dependencies = [
  "futures",
  "log",
  "nohash-hasher",
- "parking_lot 0.11.0",
- "rand 0.7.3",
+ "parking_lot",
+ "rand",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1783,8 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "mpart-async"
-version = "0.4.2"
-source = "git+https://github.com/gferon/mpart-async.git?branch=tokio-1.0#2a6ca2202bac931f6b5ac2ad8c545c2994aa30ad"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77db2fea7d8439c7e6a621618902635cb1841e62d5e3b17f7fc48e2ecca6b467"
 dependencies = [
  "bytes 1.0.1",
  "futures-core",
@@ -1792,7 +1793,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "pin-project 0.4.26",
+ "pin-project 1.0.4",
  "rand 0.7.3",
  "thiserror",
  "twoway",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,12 +334,6 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
-
-[[package]]
-name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
@@ -736,7 +730,7 @@ dependencies = [
  "libc",
  "rand 0.7.3",
  "smallvec",
- "tokio 1.0.1",
+ "tokio",
 ]
 
 [[package]]
@@ -844,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -859,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -869,15 +863,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -887,9 +881,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-lite"
@@ -908,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -920,15 +914,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
@@ -941,9 +935,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.9"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1032,7 +1026,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.0.1",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1183,7 +1177,7 @@ dependencies = [
  "itoa",
  "pin-project 1.0.4",
  "socket2",
- "tokio 1.0.1",
+ "tokio",
  "tower-service",
  "tracing",
  "want",
@@ -1301,8 +1295,7 @@ dependencies = [
  "sled",
  "tempfile",
  "thiserror",
- "tokio 0.3.6",
- "tokio 1.0.1",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -1324,7 +1317,7 @@ dependencies = [
  "prost",
  "prost-build",
  "thiserror",
- "tokio 1.0.1",
+ "tokio",
  "tracing",
  "unsigned-varint 0.3.3",
 ]
@@ -1355,7 +1348,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio 1.0.1",
+ "tokio",
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
@@ -1660,7 +1653,7 @@ dependencies = [
  "libp2p-core",
  "log",
  "socket2",
- "tokio 1.0.1",
+ "tokio",
 ]
 
 [[package]]
@@ -2899,18 +2892,6 @@ checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
 
 [[package]]
 name = "tokio"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
-dependencies = [
- "autocfg",
- "bytes 0.6.0",
- "memchr",
- "pin-project-lite 0.2.4",
-]
-
-[[package]]
-name = "tokio"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
@@ -2944,7 +2925,7 @@ checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
 dependencies = [
  "futures-core",
  "pin-project-lite 0.2.4",
- "tokio 1.0.1",
+ "tokio",
 ]
 
 [[package]]
@@ -2958,7 +2939,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite 0.2.4",
- "tokio 1.0.1",
+ "tokio",
  "tokio-stream",
 ]
 
@@ -3252,7 +3233,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 1.0.1",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "tower-service",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,7 +688,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc2157cca35ae62d3d6281d876cc1b3f0f71a3409fe4b7c8d8790b441e9bc2b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "rand",
  "smallvec",
 ]
@@ -693,7 +699,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836b2fbda90bc12569223077c1fa0a62a8eee8b78f4e5d82a8f20b20ca1ccf0f"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "domain",
  "futures",
  "rand",
@@ -915,7 +921,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "memchr",
  "pin-project 0.4.26",
@@ -975,7 +981,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1008,7 +1014,7 @@ checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
 dependencies = [
  "base64",
  "bitflags",
- "bytes",
+ "bytes 0.5.6",
  "headers-core",
  "http",
  "mime",
@@ -1076,7 +1082,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "itoa",
 ]
@@ -1087,7 +1093,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "http",
 ]
 
@@ -1115,7 +1121,7 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1214,7 +1220,7 @@ dependencies = [
  "async-trait",
  "base64",
  "byteorder",
- "bytes",
+ "bytes 0.5.6",
  "cid",
  "dirs",
  "domain",
@@ -1239,7 +1245,7 @@ dependencies = [
  "sled",
  "tempfile",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.3.6",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1259,7 +1265,7 @@ dependencies = [
  "prost",
  "prost-build",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.3.6",
  "tracing",
  "unsigned-varint 0.3.3",
 ]
@@ -1270,7 +1276,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "bytes",
+ "bytes 0.5.6",
  "cid",
  "futures",
  "hex-literal",
@@ -1291,7 +1297,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio 0.2.22",
+ "tokio 0.3.6",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1390,7 +1396,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c2b4c99f8798be90746fc226acf95d3e6cff0655883634cc30dab1f64f438b"
 dependencies = [
  "atomic",
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -1510,7 +1516,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78a2653b2e3254a3bbeb66bfc3f0dca7d6cba6aa2a96791db114003dec1b5394"
 dependencies = [
  "arrayvec",
- "bytes",
+ "bytes 0.5.6",
  "either",
  "fnv",
  "futures",
@@ -1558,7 +1564,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed764eab613a8fb6b7dcf6c796f55a06fef2270e528329903e25cd3311b99663"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "futures_codec",
  "libp2p-core",
@@ -1576,7 +1582,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb441fb015ec16690099c5d910fcba271d357763b3dcb784db7b27bbb0b68372"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "curve25519-dalek",
  "futures",
  "lazy_static",
@@ -1808,7 +1814,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea338ffba87fdaaea364b314301ead2ee38e584a7a7b06e881ca101a2a059d0f"
 dependencies = [
  "anyhow",
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "http",
  "httparse",
@@ -1856,7 +1862,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "log",
  "pin-project 1.0.4",
@@ -2182,7 +2188,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "prost-derive",
 ]
 
@@ -2192,7 +2198,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "heck",
  "itertools 0.8.2",
  "log",
@@ -2223,7 +2229,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "prost",
 ]
 
@@ -2827,17 +2833,16 @@ version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "fnv",
  "futures-core",
  "iovec",
  "lazy_static",
  "memchr",
  "mio 0.6.22",
- "num_cpus",
  "pin-project-lite 0.1.10",
  "slab",
- "tokio-macros",
+ "tokio-macros 0.2.5",
 ]
 
 [[package]]
@@ -2847,9 +2852,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
 dependencies = [
  "autocfg",
+ "bytes 0.6.0",
+ "futures-core",
  "libc",
+ "memchr",
  "mio 0.7.7",
+ "num_cpus",
  "pin-project-lite 0.2.4",
+ "slab",
+ "tokio-macros 0.3.2",
 ]
 
 [[package]]
@@ -2864,12 +2875,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-macros"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures-core",
  "futures-sink",
  "log",
@@ -3050,7 +3072,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures_codec",
 ]
 
@@ -3132,7 +3154,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
 dependencies = [
- "bytes",
+ "bytes 0.5.6",
  "futures",
  "headers",
  "http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,7 +30,7 @@ dependencies = [
  "aes",
  "block-cipher",
  "ghash",
- "subtle 2.3.0",
+ "subtle 2.4.0",
 ]
 
 [[package]]
@@ -65,9 +65,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.32"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
+checksum = "afddf7f520a80dbf76e6f50a35bca42a2331ef227a28b3b6dc5c2e2338d114b1"
 
 [[package]]
 name = "arrayref"
@@ -77,9 +77,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "asn1_der"
@@ -143,9 +143,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b246867b8b3b6ae56035f1eb1ed557c1d8eae97f0d53696138a50fa0e3a3b8c0"
+checksum = "8d3a45e77e34375a7923b1e8febb049bb011f064714a8e17a1a616fef01da13d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -158,11 +158,11 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-sink",
  "futures-util",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -193,15 +193,21 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base-x"
-version = "0.2.6"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b20b618342cf9891c292c4f5ac2cde7287cc5c87e87e9c769d617793607dec1"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
+
+[[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bitflags"
@@ -211,22 +217,20 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84ce5b6108f8e154604bd4eb76a2f726066c3464d5a552a4229262a18c9bb471"
+checksum = "10a5720225ef5daecf08657f23791354e1685a8c91a4c60c7f3d3b2892f978f4"
 dependencies = [
- "byte-tools",
- "byteorder",
  "crypto-mac 0.8.0",
  "digest 0.9.0",
- "opaque-debug 0.2.3",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -235,9 +239,9 @@ dependencies = [
 
 [[package]]
 name = "blake2s_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9e07352b829279624ceb7c64adb4f585dacdb81d35cafae81139ccd617cf44"
+checksum = "9e461a7034e85b211a4acb57ee2e6730b32912b06c08cc242243c39fc21ae6a2"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -298,9 +302,9 @@ checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
 name = "bstr"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
 dependencies = [
  "lazy_static",
  "memchr",
@@ -310,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+checksum = "f07aa6688c702439a1be0307b6a94dffe1168569e45b9500c1372bc580740d59"
 
 [[package]]
 name = "byte-tools"
@@ -322,15 +326,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
@@ -355,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.60"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -430,15 +428,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
@@ -466,6 +455,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,16 +471,16 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
+checksum = "ab327ed7354547cc2ef43cbe20ef68b988e70b4b593cbd66a2a61733123a3d23"
 dependencies = [
  "atty",
  "cast",
  "clap",
  "criterion-plot",
  "csv",
- "itertools",
+ "itertools 0.10.0",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -507,43 +502,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.9.0",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f02af974daeee82218205558e51ec8768b48cf524bd01d550abe5573a608285"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "crossbeam-epoch 0.8.2",
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "058ed274caafc1f60c4997b5fc07bf7dc7cca454af7c6e81edffe5f33f70dace"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "crossbeam-utils 0.7.2",
- "lazy_static",
- "maybe-uninit",
- "memoffset 0.5.6",
- "scopeguard",
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -554,21 +534,10 @@ checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
  "lazy_static",
- "memoffset 0.6.1",
+ "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -605,14 +574,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.3.0",
+ "subtle 2.4.0",
 ]
 
 [[package]]
 name = "csv"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00affe7f6ab566df61b4be3ce8cf16bc2576bca0963ceb0955e45d514bf9a279"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
 dependencies = [
  "bstr",
  "csv-core",
@@ -643,42 +612,40 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "subtle 2.3.0",
+ "subtle 2.4.0",
  "zeroize",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d0e2d24e5ee3b23a01de38eefdcd978907890701f08ffffd4cb457ca4ee8d6"
+checksum = "993a608597367c6377b258c25d7120740f00ed23a2252b729b1932dd7866f908"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de6489dde5128f5ab2f71f88f8807a237cecf08d96dc7ca4be64e0730dc7d961"
+checksum = "0a94feec3d2ba66c0b6621bca8bc6f68415b1e5c69af3586fdd0af9fd9f29b17"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
- "proc-macro-hack",
 ]
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d2d6daefd5f1d4b74a891a5d2ab7dccba028d423107c074232a0c5dc0d40a9e"
+checksum = "f0f83e699727abca3c56e187945f303389590305ab2f0185ea445aa66e8d5f2a"
 dependencies = [
  "data-encoding",
- "proc-macro-hack",
  "syn",
 ]
 
@@ -725,7 +692,7 @@ name = "domain"
 version = "0.5.3"
 source = "git+https://github.com/NLnetLabs/domain.git#0ddde30e716dc23bc07de53acc7377092e7e1204"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures",
  "libc",
  "rand 0.7.3",
@@ -735,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dfc993ea376e864fe29a4099a61ca0bb994c6d7745a61bf60ddb3d64e05237"
+checksum = "37c66a534cbb46ab4ea03477eae19d5c22c01da8258030280b7bd9d8433fb6ef"
 dependencies = [
  "signature",
 ]
@@ -752,7 +719,7 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "zeroize",
 ]
 
@@ -779,13 +746,13 @@ dependencies = [
 
 [[package]]
 name = "filetime"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed85775dcc68644b5c950ac06a2b23768d3bc9390464151aaf27136998dcf9e"
+checksum = "1d34cfa13a63ae058bfa601fe9e313bbdb3746427c1459185464ce0fcf62e1e8"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.4",
  "winapi",
 ]
 
@@ -896,7 +863,7 @@ dependencies = [
  "futures-io",
  "memchr",
  "parking",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "waker-fn",
 ]
 
@@ -946,7 +913,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -983,11 +950,11 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -1000,15 +967,16 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
 dependencies = [
+ "opaque-debug 0.3.0",
  "polyval",
 ]
 
@@ -1018,7 +986,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1034,9 +1002,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
+checksum = "62aca2aba2d62b4a7f5b33f3712cb1b0692779a56fb510499d5c0aa594daeaf3"
 
 [[package]]
 name = "hashbrown"
@@ -1046,13 +1014,13 @@ checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "headers"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed18eb2459bf1a09ad2d6b1547840c3e5e62882fa09b9a6a20b1de8e3228848f"
+checksum = "62689dc57c7456e69712607ffcbd0aa1dfcccf9af73727e9b25bc1825375cac3"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "bitflags",
- "bytes 0.5.6",
+ "bytes",
  "headers-core",
  "http",
  "mime",
@@ -1071,18 +1039,18 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -1122,11 +1090,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d569972648b2c512421b5f2a405ad6ac9666547189d0c5477a3f200f3e02f9"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 0.5.6",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1137,7 +1105,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "http",
 ]
 
@@ -1155,9 +1123,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "humantime"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1165,7 +1133,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1233,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
+checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -1243,11 +1211,11 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.7"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63312a18f7ea8760cdd0a7c5aac1a619752a246b833545e3e36d1f81f7cd9e66"
+checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1269,9 +1237,9 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "base64",
+ "base64 0.12.3",
  "byteorder",
- "bytes 1.0.1",
+ "bytes",
  "cid",
  "dirs",
  "domain",
@@ -1291,7 +1259,7 @@ dependencies = [
  "rand 0.8.2",
  "serde",
  "serde_json",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "sled",
  "tempfile",
  "thiserror",
@@ -1328,7 +1296,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "bytes 1.0.1",
+ "bytes",
  "cid",
  "futures",
  "hex-literal",
@@ -1370,7 +1338,7 @@ dependencies = [
  "multibase",
  "multihash 0.11.4",
  "quick-protobuf",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "tar",
 ]
 
@@ -1390,16 +1358,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "0.4.6"
+name = "itertools"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "37d572918e350e82412fe766d24b15e6682fb2ed2bbe018280caa810397cb319"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1418,9 +1395,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "libp2p"
@@ -1429,7 +1406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
 dependencies = [
  "atomic",
- "bytes 1.0.1",
+ "bytes",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -1477,7 +1454,7 @@ dependencies = [
  "rand 0.7.3",
  "ring",
  "rw-stream-sink",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "smallvec",
  "thiserror",
  "unsigned-varint 0.6.0",
@@ -1548,7 +1525,7 @@ checksum = "456f5de8e283d7800ca848b9b9a4e2a578b790bd8ae582b885e831353cf0e5df"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
- "bytes 1.0.1",
+ "bytes",
  "either",
  "fnv",
  "futures",
@@ -1558,7 +1535,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "smallvec",
  "uint",
  "unsigned-varint 0.6.0",
@@ -1573,7 +1550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.0.1",
+ "bytes",
  "futures",
  "libp2p-core",
  "log",
@@ -1590,7 +1567,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "curve25519-dalek",
  "futures",
  "lazy_static",
@@ -1599,7 +1576,7 @@ dependencies = [
  "prost",
  "prost-build",
  "rand 0.7.3",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "snow",
  "static_assertions",
  "x25519-dalek",
@@ -1681,24 +1658,24 @@ dependencies = [
  "hmac-drbg",
  "rand 0.7.3",
  "sha2 0.8.2",
- "subtle 2.3.0",
+ "subtle 2.4.0",
  "typenum",
 ]
 
 [[package]]
 name = "lock_api"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
 dependencies = [
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
@@ -1719,25 +1696,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-
-[[package]]
-name = "memoffset"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
-dependencies = [
- "autocfg",
-]
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
@@ -1793,7 +1755,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77db2fea7d8439c7e6a621618902635cb1841e62d5e3b17f7fc48e2ecca6b467"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-util",
  "http",
@@ -1825,8 +1787,8 @@ dependencies = [
  "blake2b_simd",
  "blake2s_simd",
  "digest 0.9.0",
- "sha-1 0.9.1",
- "sha2 0.9.1",
+ "sha-1 0.9.2",
+ "sha2 0.9.2",
  "sha3",
  "unsigned-varint 0.5.1",
 ]
@@ -1840,7 +1802,7 @@ dependencies = [
  "digest 0.9.0",
  "generic-array 0.14.4",
  "multihash-derive",
- "sha2 0.9.1",
+ "sha2 0.9.2",
  "unsigned-varint 0.5.1",
 ]
 
@@ -1870,7 +1832,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10ddc0eb0117736f19d556355464fc87efc8ad98b29e3fd84f02531eb6e90840"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures",
  "log",
  "pin-project 1.0.4",
@@ -1905,9 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1915,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -1940,9 +1902,9 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "oorandom"
-version = "11.1.2"
+version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a170cebd8021a008ea92e4db85a72f80b35df514ec664b296fdcbb654eac0b2c"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
@@ -1958,12 +1920,12 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
  "lazy_static",
  "libc",
@@ -1972,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg",
  "cc",
@@ -2009,9 +1971,9 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
 dependencies = [
  "instant",
  "lock_api",
@@ -2020,15 +1982,14 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
  "winapi",
 ]
@@ -2051,11 +2012,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fbdfd6bdee3dc9be46452f86af4a4072975899cf8592466668620bebfbcc17"
+checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
 dependencies = [
- "pin-project-internal 0.4.26",
+ "pin-project-internal 0.4.27",
 ]
 
 [[package]]
@@ -2069,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c82fb1329f632c3552cf352d14427d57a511b1cf41db93b3a7d77906a82dcc8e"
+checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2091,12 +2052,6 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e555d9e657502182ac97b539fb3dae8b79cda19e3e4f8ffb5e8de4f18df93c95"
-
-[[package]]
-name = "pin-project-lite"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
@@ -2109,20 +2064,36 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "plotters"
-version = "0.2.15"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
+checksum = "45ca0ae5f169d0917a7c7f5a9c1a3d3d9598f18f529dd2b8373ed988efea307a"
 dependencies = [
- "js-sys",
  "num-traits",
+ "plotters-backend",
+ "plotters-svg",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07fffcddc1cb3a1de753caa4e4df03b79922ba43cf882acc1bdd7e8df9f4590"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38a02e23bd9604b842a812063aec4ef702b57989c37b655254bb61c471ad211"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -2140,28 +2111,30 @@ dependencies = [
 
 [[package]]
 name = "poly1305"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ce46de8e53ee414ca4d02bfefac75d8c12fba948b76622a40b4be34dfce980"
+checksum = "4b7456bc1ad2d4cf82b3a016be4c2ac48daf11bf990c1603ebd447fe6f30fca8"
 dependencies = [
+ "cpuid-bool 0.2.0",
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.4.1"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5884790f1ce3553ad55fec37b5aaac5882e0e845a2612df744d6c85c9bf046c"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
 dependencies = [
- "cfg-if 0.1.10",
+ "cpuid-bool 0.2.0",
+ "opaque-debug 0.3.0",
  "universal-hash",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-crate"
@@ -2204,9 +2177,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -2223,7 +2196,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "prost-derive",
 ]
 
@@ -2233,9 +2206,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "heck",
- "itertools",
+ "itertools 0.9.0",
  "log",
  "multimap",
  "petgraph",
@@ -2252,7 +2225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.9.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2264,7 +2237,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "prost",
 ]
 
@@ -2279,9 +2252,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -2292,7 +2265,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -2337,7 +2310,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.15",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -2369,9 +2342,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf6960dc9a5b4ee8d3e4c5787b4a112a8818e0290a42ff664ad60692fdf2032"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -2381,13 +2354,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c4fec834fb6e6d2dd5eece3c7b432a52f0ba887cf40e595190c4107edc08bf"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -2399,21 +2372,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05ec8ca9416c5ea37062b502703cd7fcb207736bc294f6e0cf367ac6fc234570"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.15",
- "redox_syscall",
+ "getrandom 0.1.16",
+ "redox_syscall 0.1.57",
  "rust-argon2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "regex-syntax",
 ]
@@ -2430,9 +2412,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "remove_dir_all"
@@ -2445,9 +2427,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.15"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952cd6b98c85bbc30efa1ba5783b8abf12fec8b3287ffa52605b9432313e34e4"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
@@ -2460,14 +2442,14 @@ dependencies = [
 
 [[package]]
 name = "rust-argon2"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dab61250775933275e84053ac235621dfb739556d5c54a2f2e9313b7cf43a19"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
- "base64",
+ "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.7.2",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -2486,7 +2468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4da5fcb054c46f5a5dff833b129285a93d3f0179531735e6c866e8cc307d2020"
 dependencies = [
  "futures",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "static_assertions",
 ]
 
@@ -2534,9 +2516,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "974ef1bd2ad8a507599b336595454081ff68a9599b4890af7643c0c0ed73a62c"
 dependencies = [
  "serde_derive",
 ]
@@ -2553,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "8dee1f300f838c8ac340ecb0112b3ac472464fa67e87292bdb3dfc9c49128e17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2564,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.58"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a230ea9107ca2220eea9d46de97eddcb04cd00e92d13dda78e478dd33fa82bd4"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "itoa",
  "ryu",
@@ -2599,13 +2581,13 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
+checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
- "cpuid-bool",
+ "cfg-if 1.0.0",
+ "cpuid-bool 0.1.2",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -2624,13 +2606,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2933378ddfeda7ea26f48c555bdad8bb446bf8a3d17832dc83e380d444cfb8c1"
+checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 0.1.10",
- "cpuid-bool",
+ "cfg-if 1.0.0",
+ "cpuid-bool 0.1.2",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
 ]
@@ -2649,18 +2631,18 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.0.9"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
 ]
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "slab"
@@ -2675,8 +2657,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d0132f3e393bcb7390c60bb45769498cf4550bcb7a21d7f95c02b69f6362cdc"
 dependencies = [
  "crc32fast",
- "crossbeam-epoch 0.9.1",
- "crossbeam-utils 0.8.1",
+ "crossbeam-epoch",
+ "crossbeam-utils",
  "fs2",
  "fxhash",
  "libc",
@@ -2686,9 +2668,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "snow"
@@ -2703,8 +2685,8 @@ dependencies = [
  "rand_core 0.5.1",
  "ring",
  "rustc_version",
- "sha2 0.9.1",
- "subtle 2.3.0",
+ "sha2 0.9.2",
+ "subtle 2.4.0",
  "x25519-dalek",
 ]
 
@@ -2743,9 +2725,9 @@ dependencies = [
 
 [[package]]
 name = "structopt"
-version = "0.3.18"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33f6461027d7f08a13715659b2948e1602c31a3756aeae9378bfe7518c72e82"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2754,9 +2736,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92e775028122a4b3dd55d58f14fc5120289c69bee99df1d117ae30f84b225c9"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2773,15 +2755,15 @@ checksum = "2d67a5a62ba6e01cb2192ff309324cb4875d0c451d55fe2319433abe7a05a8ee"
 
 [[package]]
 name = "subtle"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.58"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc60a3d73ea6594cd712d830cc1f0390fd71542d8c8cd24e70cc54cdfd5e05d5"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2808,19 +2790,19 @@ checksum = "489997b7557e9a43e192c527face4feacc78bfbe6eed67fd55c4c9e381cba290"
 dependencies = [
  "filetime",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
- "rand 0.7.3",
- "redox_syscall",
+ "rand 0.8.2",
+ "redox_syscall 0.2.4",
  "remove_dir_all",
  "winapi",
 ]
@@ -2836,18 +2818,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2856,29 +2838,28 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
 [[package]]
 name = "tinytemplate"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d3dc76004a03cec1c5932bca4cdc2e39aaa798e3f82363dd94f9adf6098c12f"
+checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
 dependencies = [
  "serde",
  "serde_json",
@@ -2886,23 +2867,32 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
+checksum = "8efab2086f17abcddb8f756117665c958feee6b2e39974c2f1600592ab3a4195"
 dependencies = [
  "autocfg",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "tokio-macros",
 ]
 
@@ -2919,26 +2909,27 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
+checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36135b7e7da911f5f8b9331209f7fab4cc13498f3fff52f72a710c78187e3148"
+checksum = "feb971a26599ffd28066d387f109746df178eff14d5ea1e235015c5601967a4b"
 dependencies = [
- "bytes 1.0.1",
+ "async-stream",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "tokio",
  "tokio-stream",
 ]
@@ -2954,20 +2945,32 @@ dependencies = [
 
 [[package]]
 name = "tower-service"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e987b6bf443f4b5b3b6f38704195592cca41c5bb7aedd3c3693c7081f8289860"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
+checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "log",
- "pin-project-lite 0.1.10",
+ "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2987,7 +2990,7 @@ checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
 dependencies = [
  "futures",
  "futures-task",
- "pin-project 0.4.26",
+ "pin-project 0.4.27",
  "tracing",
 ]
 
@@ -3004,9 +3007,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.12"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82bb5079aa76438620837198db8a5c529fb9878c730bc2b28179b0241cf04c10"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
 dependencies = [
  "ansi_term",
  "lazy_static",
@@ -3014,6 +3017,7 @@ dependencies = [
  "regex",
  "sharded-slab",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -3078,18 +3082,18 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -3110,7 +3114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array 0.14.4",
- "subtle 2.3.0",
+ "subtle 2.4.0",
 ]
 
 [[package]]
@@ -3132,7 +3136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
  "asynchronous-codec",
- "bytes 1.0.1",
+ "bytes",
 ]
 
 [[package]]
@@ -3143,10 +3147,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
 dependencies = [
+ "form_urlencoded",
  "idna",
  "matches",
  "percent-encoding",
@@ -3154,9 +3159,9 @@ dependencies = [
 
 [[package]]
 name = "vcpkg"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
+checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "vec-arena"
@@ -3219,7 +3224,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dafd0aac2818a94a34df0df1100a7356c493d8ede4393875fd0b5c51bb6bc80"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures",
  "headers",
  "http",
@@ -3249,25 +3254,25 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3280,11 +3285,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3292,9 +3297,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3302,9 +3307,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3315,9 +3320,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasm-timer"
@@ -3336,9 +3341,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3436,9 +3441,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f33972566adbd2d3588b0491eb94b98b43695c4ef897903470ede4f3f5a28a"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,7 +60,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ dependencies = [
  "polling",
  "vec-arena",
  "waker-fn",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -410,7 +410,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "time",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -723,32 +723,20 @@ checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "domain"
 version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc2157cca35ae62d3d6281d876cc1b3f0f71a3409fe4b7c8d8790b441e9bc2b"
+source = "git+https://github.com/NLnetLabs/domain.git#0ddde30e716dc23bc07de53acc7377092e7e1204"
 dependencies = [
- "bytes 0.5.6",
- "rand",
- "smallvec",
-]
-
-[[package]]
-name = "domain-resolv"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836b2fbda90bc12569223077c1fa0a62a8eee8b78f4e5d82a8f20b20ca1ccf0f"
-dependencies = [
- "bytes 0.5.6",
- "domain",
+ "bytes 1.0.1",
  "futures",
+ "libc",
  "rand",
  "smallvec",
- "tokio 0.2.22",
+ "tokio 1.0.1",
 ]
 
 [[package]]
@@ -804,7 +792,7 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "redox_syscall",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -851,24 +839,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
-
-[[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
@@ -1225,7 +1197,7 @@ checksum = "28538916eb3f3976311f5dfbe67b5362d0add1293d0a9cad17debf86f8e3aa48"
 dependencies = [
  "if-addrs-sys",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1251,7 +1223,7 @@ dependencies = [
  "ipnet",
  "libc",
  "log",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1274,15 +1246,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,7 +1253,7 @@ checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
  "socket2",
  "widestring",
- "winapi 0.3.9",
+ "winapi",
  "winreg",
 ]
 
@@ -1303,11 +1266,10 @@ dependencies = [
  "async-trait",
  "base64",
  "byteorder",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "cid",
  "dirs",
  "domain",
- "domain-resolv",
  "either",
  "fs2",
  "futures",
@@ -1373,7 +1335,6 @@ dependencies = [
  "multibase",
  "multihash 0.11.4",
  "openssl",
- "parity-multiaddr 0.9.6",
  "percent-encoding",
  "prost 0.6.1",
  "prost-build 0.6.1",
@@ -1455,16 +1416,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,7 +1430,7 @@ checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 [[package]]
 name = "libp2p"
 version = "0.34.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "atomic",
  "bytes 1.0.1",
@@ -1497,7 +1448,7 @@ dependencies = [
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
- "parity-multiaddr 0.11.0",
+ "parity-multiaddr",
  "parking_lot",
  "pin-project 1.0.4",
  "smallvec",
@@ -1507,7 +1458,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1521,7 +1472,7 @@ dependencies = [
  "log",
  "multihash 0.13.2",
  "multistream-select",
- "parity-multiaddr 0.11.0",
+ "parity-multiaddr",
  "parking_lot",
  "pin-project 1.0.4",
  "prost 0.7.0",
@@ -1540,7 +1491,7 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.21.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "quote",
  "syn",
@@ -1549,7 +1500,7 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1559,7 +1510,7 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -1576,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1591,7 +1542,7 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.28.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -1616,7 +1567,7 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
@@ -1633,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.29.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "bytes 1.0.1",
  "curve25519-dalek",
@@ -1654,7 +1605,7 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1668,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "either",
  "futures",
@@ -1683,7 +1634,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "async-io",
  "futures",
@@ -1701,7 +1652,7 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.30.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1807,46 +1758,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
-dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
- "libc",
- "log",
- "miow 0.2.1",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
  "libc",
  "log",
- "miow 0.3.6",
+ "miow",
  "ntapi",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1856,7 +1776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1938,7 +1858,7 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 [[package]]
 name = "multistream-select"
 version = "0.10.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "bytes 1.0.1",
  "futures",
@@ -1955,18 +1875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
 dependencies = [
  "libc",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1981,7 +1890,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2066,25 +1975,8 @@ dependencies = [
 
 [[package]]
 name = "parity-multiaddr"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43244a26dc1ddd3097216bb12eaa6cf8a07b060c72718d9ebd60fd297d6401df"
-dependencies = [
- "arrayref",
- "bs58",
- "byteorder",
- "data-encoding",
- "multihash 0.11.4",
- "percent-encoding",
- "serde",
- "static_assertions",
- "unsigned-varint 0.5.1",
-]
-
-[[package]]
-name = "parity-multiaddr"
 version = "0.11.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
 dependencies = [
  "arrayref",
  "bs58",
@@ -2127,7 +2019,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2232,7 +2124,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2548,7 +2440,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2563,7 +2455,7 @@ dependencies = [
  "spin",
  "untrusted",
  "web-sys",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2824,7 +2716,7 @@ checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2930,7 +2822,7 @@ dependencies = [
  "rand",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2979,7 +2871,7 @@ checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
 dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2997,22 +2889,6 @@ name = "tinyvec"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "238ce071d267c5710f9d31451efec16c5ee22de34df17cc05e56cbc92e967117"
-
-[[package]]
-name = "tokio"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
-dependencies = [
- "bytes 0.5.6",
- "iovec",
- "lazy_static",
- "memchr",
- "mio 0.6.22",
- "pin-project-lite 0.1.10",
- "slab",
- "tokio-macros 0.2.5",
-]
 
 [[package]]
 name = "tokio"
@@ -3036,21 +2912,10 @@ dependencies = [
  "bytes 1.0.1",
  "libc",
  "memchr",
- "mio 0.7.7",
+ "mio",
  "num_cpus",
  "pin-project-lite 0.2.4",
- "tokio-macros 1.0.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c3acc6aa564495a0f2e1d59fab677cd7f81a19994cfc7f3ad0e64301560389"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "tokio-macros",
 ]
 
 [[package]]
@@ -3346,7 +3211,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777182bc735b6424e1a57516d35ed72cb8019d85c8c9bf536dccb3445c1a2f7d"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -3363,7 +3228,7 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.2.5"
-source = "git+https://github.com/aknuds1/warp.git?branch=chore/upgrade-tokio#bb2f511fc8785784089ebdb12861bbc32e4cef5d"
+source = "git+https://github.com/seanmonstar/warp.git#ffefea08050ffe8022d3391f4bd5e5ab4e95d7c9"
 dependencies = [
  "bytes 1.0.1",
  "futures",
@@ -3526,12 +3391,6 @@ checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -3539,12 +3398,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -3558,7 +3411,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3573,17 +3426,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-io"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
+dependencies = [
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "libc",
+ "log",
+ "nb-connect",
+ "once_cell",
+ "parking",
+ "polling",
+ "vec-arena",
+ "waker-fn",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +150,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "asynchronous-codec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4401f0a3622dad2e0763fa79e0eb328bc70fb7dccfdd645341f00d671247d6"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -312,6 +345,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,7 +420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8709d481fb78b9808f34a1b4b4fadd08a15a0971052c18bc2b751faefaed595e"
 dependencies = [
  "multibase",
- "multihash",
+ "multihash 0.11.4",
  "unsigned-varint 0.3.3",
 ]
 
@@ -403,6 +442,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ed07550be01594c6026cff2a1d7fe9c8f683caa798e12b68694ac9e88286a3"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]
@@ -679,16 +727,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dns-parser"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4d33be9473d06f75f58220f71f7a9317aca647dc061dbd3c361b0bef505fbea"
-dependencies = [
- "byteorder",
- "quick-error",
-]
-
-[[package]]
 name = "domain"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,6 +785,15 @@ name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "fastrand"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca5faf057445ce5c9d4329e382b2ce7ca38550ef3b73a5348362d5f24e0c7fe3"
+dependencies = [
+ "instant",
+]
 
 [[package]]
 name = "filetime"
@@ -825,9 +872,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8e3078b7b2a8a671cb7a3d17b4760e4181ea243227776ba83fd043b4ca034e"
+checksum = "c70be434c505aee38639abccb918163b63158a4b4bb791b45b7023044bdc3c9c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -840,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
+checksum = "f01c61843314e95f96cc9245702248733a3a3d744e43e2e755e3c7af8348a0a9"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -850,15 +897,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
+checksum = "db8d3b0917ff63a2a96173133c02818fac4a746b0a57569d3baca9ec0e945e08"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc709ca1da6f66143b8c9bec8e6260181869893714e9b5a490b169b0414144ab"
+checksum = "9ee9ca2f7eb4475772cf39dd1cd06208dce2670ad38f4d9c7262b3e15f127068"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -868,15 +915,30 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
+checksum = "e37c1a51b037b80922864b8eed90692c5cd8abd4c71ce49b77146caa47f3253b"
+
+[[package]]
+name = "futures-lite"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite 0.2.4",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
+checksum = "0f8719ca0e1f3c5e34f3efe4570ef2c0610ca6da85ae7990d472e9cbfba13664"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -886,15 +948,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
+checksum = "f6adabac1290109cfa089f79192fb6244ad2c3f1cc2281f3e1dd987592b71feb"
 
 [[package]]
 name = "futures-task"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
+checksum = "a92a0843a2ff66823a8f7c77bffe9a09be2b64e533562c412d63075643ec0038"
 dependencies = [
  "once_cell",
 ]
@@ -907,9 +969,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
+checksum = "036a2107cdeb57f6d7322f1b6c363dad67cd63ca3b7d1b925bdf75bd5d96cda9"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -918,23 +980,11 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 0.4.26",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
  "slab",
-]
-
-[[package]]
-name = "futures_codec"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce54d63f8b0c75023ed920d46fd71d0cbbb830b0ee012726b5b4f506fb6dea5b"
-dependencies = [
- "bytes 0.5.6",
- "futures",
- "memchr",
- "pin-project 0.4.26",
 ]
 
 [[package]]
@@ -1061,6 +1111,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
 name = "hex-literal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1239,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-watch"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16d7c5e361e6b05c882b4847dd98992534cebc6fcde7f4bc98225bcf10fd6d0d"
+dependencies = [
+ "async-io",
+ "futures",
+ "futures-lite",
+ "if-addrs",
+ "ipnet",
+ "libc",
+ "log",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,10 +1317,10 @@ dependencies = [
  "ipfs-unixfs",
  "libp2p",
  "multibase",
- "multihash",
+ "multihash 0.11.4",
  "once_cell",
- "prost",
- "prost-build",
+ "prost 0.6.1",
+ "prost-build 0.6.1",
  "rand",
  "serde",
  "serde_json",
@@ -1275,9 +1347,9 @@ dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-swarm",
- "multihash",
- "prost",
- "prost-build",
+ "multihash 0.11.4",
+ "prost 0.6.1",
+ "prost-build 0.6.1",
  "thiserror",
  "tokio 0.3.6",
  "tracing",
@@ -1299,12 +1371,12 @@ dependencies = [
  "mime",
  "mpart-async",
  "multibase",
- "multihash",
+ "multihash 0.11.4",
  "openssl",
- "parity-multiaddr",
+ "parity-multiaddr 0.9.6",
  "percent-encoding",
- "prost",
- "prost-build",
+ "prost 0.6.1",
+ "prost-build 0.6.1",
  "serde",
  "serde_json",
  "structopt",
@@ -1331,7 +1403,7 @@ dependencies = [
  "hex-literal",
  "libc",
  "multibase",
- "multihash",
+ "multihash 0.11.4",
  "quick-protobuf",
  "sha2 0.9.1",
  "tar",
@@ -1406,12 +1478,11 @@ checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "libp2p"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c2b4c99f8798be90746fc226acf95d3e6cff0655883634cc30dab1f64f438b"
+version = "0.34.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "atomic",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures",
  "lazy_static",
  "libp2p-core",
@@ -1420,15 +1491,13 @@ dependencies = [
  "libp2p-floodsub",
  "libp2p-identify",
  "libp2p-kad",
- "libp2p-mdns",
  "libp2p-mplex",
  "libp2p-noise",
  "libp2p-ping",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-yamux",
- "multihash",
- "parity-multiaddr",
+ "parity-multiaddr 0.11.0",
  "parking_lot",
  "pin-project 1.0.4",
  "smallvec",
@@ -1437,9 +1506,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-core"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8186060d6bd415e4e928e6cb44c4fe7e7a7dd53437bd936ce7e5f421e45a51"
+version = "0.27.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1451,29 +1519,28 @@ dependencies = [
  "lazy_static",
  "libsecp256k1",
  "log",
- "multihash",
+ "multihash 0.13.2",
  "multistream-select",
- "parity-multiaddr",
+ "parity-multiaddr 0.11.0",
  "parking_lot",
  "pin-project 1.0.4",
- "prost",
- "prost-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
  "rand",
  "ring",
  "rw-stream-sink",
  "sha2 0.9.1",
  "smallvec",
  "thiserror",
- "unsigned-varint 0.5.1",
+ "unsigned-varint 0.6.0",
  "void",
  "zeroize",
 ]
 
 [[package]]
 name = "libp2p-core-derive"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f753d9324cd3ec14bf04b8a8cd0d269c87f294153d6bf2a84497a63a5ad22213"
+version = "0.21.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "quote",
  "syn",
@@ -1481,9 +1548,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-dns"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0baeff71fb5cb1fe1604f74a712a44b66a8c5900f4022411a1d550f09d6bb776"
+version = "0.27.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1492,9 +1558,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-floodsub"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0f925a45f310b678e70faf71a10023b829d02eb9cc2628a63de928936f3ade"
+version = "0.27.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -1502,109 +1567,82 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
- "prost-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
  "rand",
  "smallvec",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e074124669840484de564901d47f2d0892e73f6d8ee7c37e9c2644af1b217bf4"
+version = "0.27.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "futures",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost",
- "prost-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
  "smallvec",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-kad"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78a2653b2e3254a3bbeb66bfc3f0dca7d6cba6aa2a96791db114003dec1b5394"
+version = "0.28.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "arrayvec",
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "either",
  "fnv",
  "futures",
- "futures_codec",
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "multihash",
- "prost",
- "prost-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
  "rand",
  "sha2 0.9.1",
  "smallvec",
  "uint",
- "unsigned-varint 0.5.1",
- "void",
- "wasm-timer",
-]
-
-[[package]]
-name = "libp2p-mdns"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786b068098794322239f8f04df88a52daeb7863b2e77501c4d85d32e0a8f2d26"
-dependencies = [
- "data-encoding",
- "dns-parser",
- "either",
- "futures",
- "lazy_static",
- "libp2p-core",
- "libp2p-swarm",
- "log",
- "net2",
- "rand",
- "smallvec",
- "tokio 0.3.6",
+ "unsigned-varint 0.6.0",
  "void",
  "wasm-timer",
 ]
 
 [[package]]
 name = "libp2p-mplex"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed764eab613a8fb6b7dcf6c796f55a06fef2270e528329903e25cd3311b99663"
+version = "0.27.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
- "bytes 0.5.6",
+ "asynchronous-codec",
+ "bytes 1.0.1",
  "futures",
- "futures_codec",
  "libp2p-core",
  "log",
  "nohash-hasher",
  "parking_lot",
  "rand",
  "smallvec",
- "unsigned-varint 0.5.1",
+ "unsigned-varint 0.6.0",
 ]
 
 [[package]]
 name = "libp2p-noise"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb441fb015ec16690099c5d910fcba271d357763b3dcb784db7b27bbb0b68372"
+version = "0.29.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "curve25519-dalek",
  "futures",
  "lazy_static",
  "libp2p-core",
  "log",
- "prost",
- "prost-build",
+ "prost 0.7.0",
+ "prost-build 0.7.0",
  "rand",
  "sha2 0.9.1",
  "snow",
@@ -1615,9 +1653,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-ping"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e5c50936cfdbe96a514e8992f304fa44cd3a681b6f779505f1ae62b3474705"
+version = "0.27.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1630,9 +1667,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565f0e06674b4033c978471e4083d5aaa8e03cef0719a0ec0905aaeaad39a919"
+version = "0.27.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "either",
  "futures",
@@ -1646,25 +1682,26 @@ dependencies = [
 
 [[package]]
 name = "libp2p-tcp"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33f3dce259c0d3127af5167f45c275b6c047320efdd0e40fde947482487af0a3"
+version = "0.27.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
+ "async-io",
  "futures",
  "futures-timer",
  "if-addrs",
+ "if-watch",
  "ipnet",
+ "libc",
  "libp2p-core",
  "log",
  "socket2",
- "tokio 0.3.6",
+ "tokio 1.0.1",
 ]
 
 [[package]]
 name = "libp2p-yamux"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0798cbb58535162c40858493d09af06eac42a26e4966e58de0df701f559348"
+version = "0.30.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1866,6 +1903,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "multihash"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dac63698b887d2d929306ea48b63760431ff8a24fac40ddb22f9c7f49fb7cab"
+dependencies = [
+ "digest 0.9.0",
+ "generic-array 0.14.4",
+ "multihash-derive",
+ "sha2 0.9.1",
+ "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "multihash-derive"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ee3c48cb9d9b275ad967a0e96715badc13c6029adb92f34fa17b9ff28fd81f"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,16 +1937,25 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 
 [[package]]
 name = "multistream-select"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93faf2e41f9ee62fb01680ed48f3cc26652352327aa2e59869070358f6b7dd75"
+version = "0.10.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures",
  "log",
  "pin-project 1.0.4",
  "smallvec",
- "unsigned-varint 0.5.1",
+ "unsigned-varint 0.6.0",
+]
+
+[[package]]
+name = "nb-connect"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8123a81538e457d44b933a02faf885d3fe8408806b23fa700e8f01c6c3a98998"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2001,13 +2074,35 @@ dependencies = [
  "bs58",
  "byteorder",
  "data-encoding",
- "multihash",
+ "multihash 0.11.4",
  "percent-encoding",
  "serde",
  "static_assertions",
  "unsigned-varint 0.5.1",
+]
+
+[[package]]
+name = "parity-multiaddr"
+version = "0.11.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git#75b5fdfbca293b7ae8bb546b9730531016f4caea"
+dependencies = [
+ "arrayref",
+ "bs58",
+ "byteorder",
+ "data-encoding",
+ "multihash 0.13.2",
+ "percent-encoding",
+ "serde",
+ "static_assertions",
+ "unsigned-varint 0.6.0",
  "url",
 ]
+
+[[package]]
+name = "parking"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
@@ -2128,6 +2223,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "polling"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a7bc6b2a29e632e45451c941832803a18cce6781db04de8a04696cdca8bde4"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "log",
+ "wepoll-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "poly1305"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,6 +2259,15 @@ name = "ppv-lite86"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
+
+[[package]]
+name = "proc-macro-crate"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
+dependencies = [
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2178,9 +2295,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2204,7 +2321,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
 dependencies = [
  "bytes 0.5.6",
- "prost-derive",
+ "prost-derive 0.6.1",
+]
+
+[[package]]
+name = "prost"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
+dependencies = [
+ "bytes 1.0.1",
+ "prost-derive 0.7.0",
 ]
 
 [[package]]
@@ -2219,10 +2346,28 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prost",
- "prost-types",
+ "prost 0.6.1",
+ "prost-types 0.6.1",
  "tempfile",
- "which",
+ "which 3.1.1",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
+dependencies = [
+ "bytes 1.0.1",
+ "heck",
+ "itertools 0.9.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prost 0.7.0",
+ "prost-types 0.7.0",
+ "tempfile",
+ "which 4.0.2",
 ]
 
 [[package]]
@@ -2239,20 +2384,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
+dependencies = [
+ "anyhow",
+ "itertools 0.9.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
 dependencies = [
  "bytes 0.5.6",
- "prost",
+ "prost 0.6.1",
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
+name = "prost-types"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
+dependencies = [
+ "bytes 1.0.1",
+ "prost 0.7.0",
+]
 
 [[package]]
 name = "quick-protobuf"
@@ -2415,12 +2577,6 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils 0.7.2",
 ]
-
-[[package]]
-name = "rustc-hex"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
@@ -2866,9 +3022,7 @@ checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
 dependencies = [
  "autocfg",
  "bytes 0.6.0",
- "libc",
  "memchr",
- "mio 0.7.7",
  "pin-project-lite 0.2.4",
 ]
 
@@ -2934,6 +3088,15 @@ dependencies = [
  "pin-project-lite 0.2.4",
  "tokio 1.0.1",
  "tokio-stream",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3026,13 +3189,13 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
 dependencies = [
  "byteorder",
  "crunchy",
- "rustc-hex",
+ "hex",
  "static_assertions",
 ]
 
@@ -3108,9 +3271,15 @@ name = "unsigned-varint"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fdeedbf205afadfe39ae559b75c3240f24e257d0ca27e85f85cb82aa19ac35"
+
+[[package]]
+name = "unsigned-varint"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35581ff83d4101e58b582e607120c7f5ffb17e632a980b1f38334d76b36908b2"
 dependencies = [
- "bytes 0.5.6",
- "futures_codec",
+ "asynchronous-codec",
+ "bytes 1.0.1",
 ]
 
 [[package]]
@@ -3137,6 +3306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
+name = "vec-arena"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eafc1b9b2dfc6f5529177b62cf806484db55b32dc7c9658a118e11bbeb33061d"
+
+[[package]]
 name = "vergen"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,6 +3332,12 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -3310,12 +3491,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "wepoll-sys"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "which"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "which"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c14ef7e1b8b8ecfc75d5eca37949410046e66f15d185c01d70824f1f8111ef"
+dependencies = [
+ "libc",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,7 @@ checksum = "b810a8449931679f64cd7eef1bbd0fa315801b6d5d9cdc1ace2804d6529eee18"
 dependencies = [
  "byteorder",
  "fnv",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -655,7 +655,7 @@ checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core",
+ "rand_core 0.5.1",
  "subtle 2.3.0",
  "zeroize",
 ]
@@ -734,7 +734,7 @@ dependencies = [
  "bytes 1.0.1",
  "futures",
  "libc",
- "rand",
+ "rand 0.7.3",
  "smallvec",
  "tokio 1.0.1",
 ]
@@ -756,7 +756,7 @@ checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand",
+ "rand 0.7.3",
  "serde",
  "sha2 0.9.1",
  "zeroize",
@@ -996,6 +996,17 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1283,7 +1294,7 @@ dependencies = [
  "once_cell",
  "prost",
  "prost-build",
- "rand",
+ "rand 0.8.2",
  "serde",
  "serde_json",
  "sha2 0.9.1",
@@ -1468,7 +1479,7 @@ dependencies = [
  "pin-project 1.0.4",
  "prost",
  "prost-build",
- "rand",
+ "rand 0.7.3",
  "ring",
  "rw-stream-sink",
  "sha2 0.9.1",
@@ -1511,7 +1522,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "rand",
+ "rand 0.7.3",
  "smallvec",
 ]
 
@@ -1546,7 +1557,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "rand",
+ "rand 0.7.3",
  "sha2 0.9.1",
  "smallvec",
  "uint",
@@ -1567,7 +1578,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
- "rand",
+ "rand 0.7.3",
  "smallvec",
  "unsigned-varint 0.6.0",
 ]
@@ -1585,7 +1596,7 @@ dependencies = [
  "log",
  "prost",
  "prost-build",
- "rand",
+ "rand 0.7.3",
  "sha2 0.9.1",
  "snow",
  "static_assertions",
@@ -1602,7 +1613,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand",
+ "rand 0.7.3",
  "void",
  "wasm-timer",
 ]
@@ -1616,7 +1627,7 @@ dependencies = [
  "futures",
  "libp2p-core",
  "log",
- "rand",
+ "rand 0.7.3",
  "smallvec",
  "void",
  "wasm-timer",
@@ -1662,7 +1673,7 @@ dependencies = [
  "crunchy",
  "digest 0.8.1",
  "hmac-drbg",
- "rand",
+ "rand 0.7.3",
  "sha2 0.8.2",
  "subtle 2.3.0",
  "typenum",
@@ -1782,7 +1793,7 @@ dependencies = [
  "httparse",
  "log",
  "pin-project 0.4.26",
- "rand",
+ "rand 0.7.3",
  "thiserror",
  "twoway",
 ]
@@ -2272,11 +2283,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -2286,7 +2309,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2295,7 +2328,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -2304,7 +2346,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -2344,7 +2395,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -2639,8 +2690,8 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "rand",
- "rand_core",
+ "rand 0.7.3",
+ "rand_core 0.5.1",
  "ring",
  "rustc_version",
  "sha2 0.9.1",
@@ -2759,7 +2810,7 @@ checksum = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "rand",
+ "rand 0.7.3",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -3367,7 +3418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc614d95359fd7afc321b66d2107ede58b246b844cf5d8a0adcca413e439f088"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.5.1",
  "zeroize",
 ]
 
@@ -3381,7 +3432,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
- "rand",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0dcbc35f504eb6fc275a6d20e4ebcda18cf50d40ba6fabff8c711fa16cb3b16"
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
 name = "cast"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,12 +714,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-
-[[package]]
 name = "ed25519"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +786,16 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fs2"
@@ -977,11 +987,11 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993f9e0baeed60001cf565546b0d3dbe6a6ad23f2bd31644a133c641eccf6d53"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -989,9 +999,10 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 0.2.22",
+ "tokio 1.0.1",
  "tokio-util",
  "tracing",
+ "tracing-futures",
 ]
 
 [[package]]
@@ -1089,11 +1100,11 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d5ff830006f7646652e057693569bfe0d51760c0085a071769d142a205111b"
+checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "http",
 ]
 
@@ -1117,11 +1128,11 @@ checksum = "3c1ad908cc71012b7bea4d0c53ba96a8cba9962f048fa68d143376143d863b7a"
 
 [[package]]
 name = "hyper"
-version = "0.13.8"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3afcfae8af5ad0576a31e768415edb627824129e8e5a29b8bfccb2f234e835"
+checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures-channel",
  "futures-core",
  "futures-util",
@@ -1131,9 +1142,9 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 0.4.26",
+ "pin-project 1.0.4",
  "socket2",
- "tokio 0.2.22",
+ "tokio 1.0.1",
  "tower-service",
  "tracing",
  "want",
@@ -1246,6 +1257,9 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio 0.3.6",
+ "tokio 1.0.1",
+ "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
@@ -1276,7 +1290,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-stream",
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "cid",
  "futures",
  "hex-literal",
@@ -1297,7 +1311,8 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
- "tokio 0.3.6",
+ "tokio 1.0.1",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -1809,16 +1824,16 @@ dependencies = [
 
 [[package]]
 name = "mpart-async"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea338ffba87fdaaea364b314301ead2ee38e584a7a7b06e881ca101a2a059d0f"
+version = "0.4.2"
+source = "git+https://github.com/gferon/mpart-async.git?branch=tokio-1.0#2a6ca2202bac931f6b5ac2ad8c545c2994aa30ad"
 dependencies = [
- "anyhow",
- "bytes 0.5.6",
- "futures",
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-util",
  "http",
  "httparse",
  "log",
+ "pin-project 0.4.26",
  "rand",
  "thiserror",
  "twoway",
@@ -2512,14 +2527,14 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url",
 ]
 
 [[package]]
@@ -2834,8 +2849,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d34ca54d84bf2b5b4d7d31e901a8464f7b60ac145a284fba25ceb801f2ddccd"
 dependencies = [
  "bytes 0.5.6",
- "fnv",
- "futures-core",
  "iovec",
  "lazy_static",
  "memchr",
@@ -2853,14 +2866,26 @@ checksum = "720ba21c25078711bf456d607987d95bce90f7c3bea5abe1db587862e7a1e87c"
 dependencies = [
  "autocfg",
  "bytes 0.6.0",
- "futures-core",
+ "libc",
+ "memchr",
+ "mio 0.7.7",
+ "pin-project-lite 0.2.4",
+]
+
+[[package]]
+name = "tokio"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d258221f566b6c803c7b4714abadc080172b272090cdc5e244a6d4dd13c3a6bd"
+dependencies = [
+ "autocfg",
+ "bytes 1.0.1",
  "libc",
  "memchr",
  "mio 0.7.7",
  "num_cpus",
  "pin-project-lite 0.2.4",
- "slab",
- "tokio-macros 0.3.2",
+ "tokio-macros 1.0.0",
 ]
 
 [[package]]
@@ -2876,9 +2901,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "0.3.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dfffa59fc3c8aad216ed61bdc2c263d2b9d87a9c8ac9de0c11a813e51b6db7"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2886,17 +2911,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.3.1"
+name = "tokio-stream"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "e4cdeb73537e63f98adcd73138af75e3f368ccaecffaa29d7eb61b9f5a440457"
 dependencies = [
- "bytes 0.5.6",
+ "futures-core",
+ "pin-project-lite 0.2.4",
+ "tokio 1.0.1",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36135b7e7da911f5f8b9331209f7fab4cc13498f3fff52f72a710c78187e3148"
+dependencies = [
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.10",
- "tokio 0.2.22",
+ "pin-project-lite 0.2.4",
+ "tokio 1.0.1",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -3094,12 +3131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9232eb53352b4442e40d7900465dfc534e8cb2dc8f18656fcb2ac16112b5593"
-
-[[package]]
 name = "vcpkg"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3151,10 +3182,9 @@ dependencies = [
 [[package]]
 name = "warp"
 version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f41be6df54c97904af01aa23e613d4521eed7ab23537cede692d4058f6449407"
+source = "git+https://github.com/aknuds1/warp.git?branch=chore/upgrade-tokio#bb2f511fc8785784089ebdb12861bbc32e4cef5d"
 dependencies = [
- "bytes 0.5.6",
+ "bytes 1.0.1",
  "futures",
  "headers",
  "http",
@@ -3162,16 +3192,18 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "pin-project 0.4.26",
+ "percent-encoding",
+ "pin-project 1.0.4",
  "scoped-tls",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "tokio 0.2.22",
+ "tokio 1.0.1",
+ "tokio-stream",
+ "tokio-util",
  "tower-service",
  "tracing",
  "tracing-futures",
- "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,7 +1432,8 @@ checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 [[package]]
 name = "libp2p"
 version = "0.34.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5133112ce42be9482f6a87be92a605dd6bbc9e93c297aee77d172ff06908f3a"
 dependencies = [
  "atomic",
  "bytes 1.0.1",
@@ -1460,7 +1461,8 @@ dependencies = [
 [[package]]
 name = "libp2p-core"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad04d3cef6c1df366a6ab58c9cf8b06497699e335d83ac2174783946ff847d6"
 dependencies = [
  "asn1_der",
  "bs58",
@@ -1493,7 +1495,8 @@ dependencies = [
 [[package]]
 name = "libp2p-core-derive"
 version = "0.21.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4bc40943156e42138d22ed3c57ff0e1a147237742715937622a99b10fbe0156"
 dependencies = [
  "quote",
  "syn",
@@ -1502,7 +1505,8 @@ dependencies = [
 [[package]]
 name = "libp2p-dns"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5153b6db68fd4baa3b304e377db744dd8fea8ff4e4504509ee636abcde88d3e3"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1512,7 +1516,8 @@ dependencies = [
 [[package]]
 name = "libp2p-floodsub"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3c63dfa06581b24b1d12bf9815b43689a784424be217d6545c800c7c75a207f"
 dependencies = [
  "cuckoofilter",
  "fnv",
@@ -1529,7 +1534,8 @@ dependencies = [
 [[package]]
 name = "libp2p-identify"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b40fb36a059b7a8cce1514bd8b546fa612e006c9937caa7f5950cb20021fe91e"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1544,7 +1550,8 @@ dependencies = [
 [[package]]
 name = "libp2p-kad"
 version = "0.28.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456f5de8e283d7800ca848b9b9a4e2a578b790bd8ae582b885e831353cf0e5df"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -1569,7 +1576,8 @@ dependencies = [
 [[package]]
 name = "libp2p-mplex"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2705dc94b01ab9e3779b42a09bbf3712e637ed213e875c30face247291a85af0"
 dependencies = [
  "asynchronous-codec",
  "bytes 1.0.1",
@@ -1586,7 +1594,8 @@ dependencies = [
 [[package]]
 name = "libp2p-noise"
 version = "0.29.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aca322b52a0c5136142a7c3971446fb1e9964923a526c9cc6ef3b7c94e57778"
 dependencies = [
  "bytes 1.0.1",
  "curve25519-dalek",
@@ -1607,7 +1616,8 @@ dependencies = [
 [[package]]
 name = "libp2p-ping"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3813276d0708c8db0f500d8beda1bda9ad955723b9cb272c41f4727256f73c"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1621,7 +1631,8 @@ dependencies = [
 [[package]]
 name = "libp2p-swarm"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ea8c69839a0e593c8c6a24282cb234d48ac37be4153183f4914e00f5303e75"
 dependencies = [
  "either",
  "futures",
@@ -1636,7 +1647,8 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.27.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dbd3d7076a478ac5a6aca55e74bdc250ac539b95de09b9d09915e0b8d01a6b2"
 dependencies = [
  "async-io",
  "futures",
@@ -1654,7 +1666,8 @@ dependencies = [
 [[package]]
 name = "libp2p-yamux"
 version = "0.30.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490b8b27fc40fe35212df1b6a3d14bffaa4117cbff956fdc2892168a371102ad"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -1861,7 +1874,8 @@ checksum = "1255076139a83bb467426e7f8d0134968a8118844faa755985e077cf31850333"
 [[package]]
 name = "multistream-select"
 version = "0.10.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10ddc0eb0117736f19d556355464fc87efc8ad98b29e3fd84f02531eb6e90840"
 dependencies = [
  "bytes 1.0.1",
  "futures",
@@ -1979,7 +1993,8 @@ dependencies = [
 [[package]]
 name = "parity-multiaddr"
 version = "0.11.0"
-source = "git+https://github.com/libp2p/rust-libp2p.git#2c4de90356fb0ddee68dc12de6417d79954fef4c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bfda2e46fc5e14122649e2645645a81ee5844e0fb2e727ef560cc71a8b2d801"
 dependencies = [
  "arrayref",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -491,7 +491,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "csv",
- "itertools 0.9.0",
+ "itertools",
  "lazy_static",
  "num-traits",
  "oorandom",
@@ -513,7 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
 dependencies = [
  "cast",
- "itertools 0.9.0",
+ "itertools",
 ]
 
 [[package]]
@@ -1281,8 +1281,8 @@ dependencies = [
  "multibase",
  "multihash 0.11.4",
  "once_cell",
- "prost 0.6.1",
- "prost-build 0.6.1",
+ "prost",
+ "prost-build",
  "rand",
  "serde",
  "serde_json",
@@ -1310,10 +1310,10 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "multihash 0.11.4",
- "prost 0.6.1",
- "prost-build 0.6.1",
+ "prost",
+ "prost-build",
  "thiserror",
- "tokio 0.3.6",
+ "tokio 1.0.1",
  "tracing",
  "unsigned-varint 0.3.3",
 ]
@@ -1336,8 +1336,8 @@ dependencies = [
  "multihash 0.11.4",
  "openssl",
  "percent-encoding",
- "prost 0.6.1",
- "prost-build 0.6.1",
+ "prost",
+ "prost-build",
  "serde",
  "serde_json",
  "structopt",
@@ -1375,15 +1375,6 @@ name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
-
-[[package]]
-name = "itertools"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1475,8 +1466,8 @@ dependencies = [
  "parity-multiaddr",
  "parking_lot",
  "pin-project 1.0.4",
- "prost 0.7.0",
- "prost-build 0.7.0",
+ "prost",
+ "prost-build",
  "rand",
  "ring",
  "rw-stream-sink",
@@ -1518,8 +1509,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.7.0",
- "prost-build 0.7.0",
+ "prost",
+ "prost-build",
  "rand",
  "smallvec",
 ]
@@ -1533,8 +1524,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.7.0",
- "prost-build 0.7.0",
+ "prost",
+ "prost-build",
  "smallvec",
  "wasm-timer",
 ]
@@ -1553,8 +1544,8 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "prost 0.7.0",
- "prost-build 0.7.0",
+ "prost",
+ "prost-build",
  "rand",
  "sha2 0.9.1",
  "smallvec",
@@ -1592,8 +1583,8 @@ dependencies = [
  "lazy_static",
  "libp2p-core",
  "log",
- "prost 0.7.0",
- "prost-build 0.7.0",
+ "prost",
+ "prost-build",
  "rand",
  "sha2 0.9.1",
  "snow",
@@ -2208,40 +2199,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce49aefe0a6144a45de32927c77bd2859a5f7677b55f220ae5b744e87389c212"
-dependencies = [
- "bytes 0.5.6",
- "prost-derive 0.6.1",
-]
-
-[[package]]
-name = "prost"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e6984d2f1a23009bd270b8bb56d0926810a3d483f59c987d77969e9d8e840b2"
 dependencies = [
  "bytes 1.0.1",
- "prost-derive 0.7.0",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
-dependencies = [
- "bytes 0.5.6",
- "heck",
- "itertools 0.8.2",
- "log",
- "multimap",
- "petgraph",
- "prost 0.6.1",
- "prost-types 0.6.1",
- "tempfile",
- "which 3.1.1",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2252,27 +2215,14 @@ checksum = "32d3ebd75ac2679c2af3a92246639f9fcc8a442ee420719cc4fe195b98dd5fa3"
 dependencies = [
  "bytes 1.0.1",
  "heck",
- "itertools 0.9.0",
+ "itertools",
  "log",
  "multimap",
  "petgraph",
- "prost 0.7.0",
- "prost-types 0.7.0",
+ "prost",
+ "prost-types",
  "tempfile",
- "which 4.0.2",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
-dependencies = [
- "anyhow",
- "itertools 0.8.2",
- "proc-macro2",
- "quote",
- "syn",
+ "which",
 ]
 
 [[package]]
@@ -2282,20 +2232,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "169a15f3008ecb5160cba7d37bcd690a7601b6d30cfb87a117d45e59d52af5d4"
 dependencies = [
  "anyhow",
- "itertools 0.9.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1834f67c0697c001304b75be76f67add9c89742eda3a085ad8ee0bb38c3417aa"
-dependencies = [
- "bytes 0.5.6",
- "prost 0.6.1",
 ]
 
 [[package]]
@@ -2305,7 +2245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b518d7cdd93dab1d1122cf07fa9a60771836c668dde9d9e2a139f957f0d9f1bb"
 dependencies = [
  "bytes 1.0.1",
- "prost 0.7.0",
+ "prost",
 ]
 
 [[package]]
@@ -3362,15 +3302,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb14dea929042224824779fbc82d9fab8d2e6d3cbc0ac404de8edf489e77ff"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "which"
-version = "3.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
-dependencies = [
- "libc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,26 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "domain"
 version = "0.5.3"
 source = "git+https://github.com/NLnetLabs/domain.git#0ddde30e716dc23bc07de53acc7377092e7e1204"
@@ -1241,7 +1221,6 @@ dependencies = [
  "byteorder",
  "bytes",
  "cid",
- "dirs",
  "domain",
  "either",
  "fs2",
@@ -2381,17 +2360,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
-dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
-]
-
-[[package]]
 name = "regex"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,18 +2406,6 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ rand = { default-features = false, version = "0.7" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, features = ["fs", "rt-threaded", "stream", "sync", "blocking"], version = "0.2" }
+tokio = { default-features = false, features = ["fs", "macros", "rt-multi-thread", "stream", "sync"], version = "0.3" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = ["std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }
@@ -59,7 +59,7 @@ prost-build = { default-features = false, version = "0.6" }
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
-tokio = { default-features = false, features = ["io-std"], version = "0.2" }
+tokio = { default-features = false, features = ["io-std", "io-util"], version = "0.3" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
 tokio = { default-features = false, features = ["io-std", "io-util", "time"], version = "1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
-rand = { default-features = false, version = "0.7" }
+rand = { default-features = false, version = "0.8", features = ["std", "std_rng"] }
 
 [workspace]
 members = [ "bitswap", "http", "unixfs" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ libp2p = { default-features = false, features = ["floodsub", "identify", "kad", 
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.7" }
-rand = { default-features = false, version = "0.7" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
 thiserror = { default-features = false, version = "1.0" }
@@ -62,6 +61,7 @@ hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
 tokio = { default-features = false, features = ["io-std", "io-util", "time"], version = "1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
+rand = { default-features = false, version = "0.7" }
 
 [workspace]
 members = [ "bitswap", "http", "unixfs" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,11 @@ rand = { default-features = false, version = "0.7" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, features = ["fs", "macros", "rt-multi-thread", "stream", "sync"], version = "0.3" }
+tokio = { default-features = false, features = ["fs", "macros", "rt-multi-thread", "sync"], version = "1.0" }
+tokio-stream = { version = "0.1", features = ["fs"] }
+tokio-util = { version = "0.6" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
-tracing-futures = { default-features = false, features = ["std", "futures-03"], version = "0.2" }
+tracing-futures = { default-features = false, features = ["std-future", "std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }
 fs2 = "0.4.3"
 tempfile = "3.1.0"
@@ -59,7 +61,7 @@ prost-build = { default-features = false, version = "0.6" }
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
-tokio = { default-features = false, features = ["io-std", "io-util", "time"], version = "0.3" }
+tokio = { default-features = false, features = ["io-std", "io-util", "time"], version = "1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,10 @@ async-trait = { default-features = false, version = "0.1" }
 base64 = { default-features = false, features = ["alloc"], version = "0.12" }
 ipfs-bitswap = { version = "0.1", path = "bitswap" }
 byteorder = { default-features = false, version = "1.3" }
-bytes = { default-features = false, version = "0.5" }
+bytes = { default-features = false, version = "1" }
 cid = { default-features = false, version = "0.5" }
 dirs = { default-features = false, version = "3.0" }
-domain = { default-features = false, git = "https://github.com/NLnetLabs/domain.git", features = ["resolv"] }
+domain = { default-features = false, git = "https://github.com/NLnetLabs/domain.git", features = ["resolv", "bytes"] }
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
 ipfs-unixfs = { version = "0.2", path = "unixfs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ domain = { default-features = false, git = "https://github.com/NLnetLabs/domain.
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns"], git = "https://github.com/libp2p/rust-libp2p.git" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.34" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ ipfs-unixfs = { version = "0.2", path = "unixfs" }
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns"], git = "https://github.com/libp2p/rust-libp2p.git" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
-prost = { default-features = false, version = "0.6" }
+prost = { default-features = false, version = "0.7" }
 rand = { default-features = false, version = "0.7" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
@@ -55,7 +55,7 @@ once_cell = "1.5.2"
 ipconfig = { default-features = false, version = "0.2" }
 
 [build-dependencies]
-prost-build = { default-features = false, version = "0.6" }
+prost-build = { default-features = false, version = "0.7" }
 
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ domain-resolv = { default-features = false, version = "0.5" }
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mdns-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.28" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mdns-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.30" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ prost-build = { default-features = false, version = "0.6" }
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
-tokio = { default-features = false, features = ["io-std", "io-util"], version = "0.3" }
+tokio = { default-features = false, features = ["io-std", "io-util", "time"], version = "0.3" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ ipfs-bitswap = { version = "0.1", path = "bitswap" }
 byteorder = { default-features = false, version = "1.3" }
 bytes = { default-features = false, version = "1" }
 cid = { default-features = false, version = "0.5" }
-dirs = { default-features = false, version = "3.0" }
 domain = { default-features = false, git = "https://github.com/NLnetLabs/domain.git", features = ["resolv", "bytes"] }
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ cid = { default-features = false, version = "0.5" }
 dirs = { default-features = false, version = "3.0" }
 domain = { default-features = false, git = "https://github.com/NLnetLabs/domain.git", features = ["resolv", "bytes"] }
 either = { default-features = false, version = "1.5" }
-futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
+futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mdns-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.30" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns"], git = "https://github.com/libp2p/rust-libp2p.git" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,6 @@ tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-futures = { default-features = false, features = ["std-future", "std", "futures-03"], version = "0.2" }
 void = { default-features = false, version = "1.0" }
 fs2 = "0.4.3"
-tempfile = "3.1.0"
 sled = "0.34"
 once_cell = "1.5.2"
 
@@ -62,6 +61,7 @@ sha2 = { default-features = false, version = "0.9" }
 tokio = { default-features = false, features = ["io-std", "io-util", "time"], version = "1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
 rand = { default-features = false, version = "0.8", features = ["std", "std_rng"] }
+tempfile = "3.1.0"
 
 [workspace]
 members = [ "bitswap", "http", "unixfs" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,7 @@ byteorder = { default-features = false, version = "1.3" }
 bytes = { default-features = false, version = "0.5" }
 cid = { default-features = false, version = "0.5" }
 dirs = { default-features = false, version = "3.0" }
-domain = { default-features = false, version = "0.5" }
-domain-resolv = { default-features = false, version = "0.5" }
+domain = { default-features = false, git = "https://github.com/NLnetLabs/domain.git", features = ["resolv"] }
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.5", features = ["alloc", "std"] }
 ipfs-unixfs = { version = "0.2", path = "unixfs" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rs-ipfs/rust-ipfs"
 
 [build-dependencies]
-prost-build = { default-features = false, version = "0.6" }
+prost-build = { default-features = false, version = "0.7" }
 
 [dependencies]
 cid = { default-features = false, version = "0.5" }
@@ -17,7 +17,7 @@ futures = { default-features = false, version = "0.3" }
 libp2p-core = { default-features = false, git = "https://github.com/libp2p/rust-libp2p.git" }
 libp2p-swarm = { default-features = false, git = "https://github.com/libp2p/rust-libp2p.git" }
 multihash = { default-features = false, version = "0.11" }
-prost = { default-features = false, version = "0.6" }
+prost = { default-features = false, version = "0.7" }
 thiserror = { default-features = false, version = "1.0" }
 tokio = { default-features = false, version = "1", features = ["rt"] }
 tracing = { default-features = false, version = "0.1" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -14,8 +14,8 @@ prost-build = { default-features = false, version = "0.7" }
 cid = { default-features = false, version = "0.5" }
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
-libp2p-core = { default-features = false, git = "https://github.com/libp2p/rust-libp2p.git" }
-libp2p-swarm = { default-features = false, git = "https://github.com/libp2p/rust-libp2p.git" }
+libp2p-core = { default-features = false, version = "0.27" }
+libp2p-swarm = { default-features = false, version = "0.27" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.7" }
 thiserror = { default-features = false, version = "1.0" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -19,6 +19,6 @@ libp2p-swarm = { default-features = false, version = "0.24" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, version = "0.2" }
+tokio = { default-features = false, version = "0.3" }
 tracing = { default-features = false, version = "0.1" }
 unsigned-varint = { default-features = false, version = "0.3" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -14,8 +14,8 @@ prost-build = { default-features = false, version = "0.6" }
 cid = { default-features = false, version = "0.5" }
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
-libp2p-core = { default-features = false, version = "0.22" }
-libp2p-swarm = { default-features = false, version = "0.22" }
+libp2p-core = { default-features = false, version = "0.24" }
+libp2p-swarm = { default-features = false, version = "0.24" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }
 thiserror = { default-features = false, version = "1.0" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -14,8 +14,8 @@ prost-build = { default-features = false, version = "0.6" }
 cid = { default-features = false, version = "0.5" }
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
-libp2p-core = { default-features = false, version = "0.24" }
-libp2p-swarm = { default-features = false, version = "0.24" }
+libp2p-core = { default-features = false, git = "https://github.com/libp2p/rust-libp2p.git" }
+libp2p-swarm = { default-features = false, git = "https://github.com/libp2p/rust-libp2p.git" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }
 thiserror = { default-features = false, version = "1.0" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -19,6 +19,6 @@ libp2p-swarm = { default-features = false, version = "0.24" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.6" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, version = "0.3" }
+tokio = { default-features = false, version = "1", features = ["rt"] }
 tracing = { default-features = false, version = "0.1" }
 unsigned-varint = { default-features = false, version = "0.3" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -23,7 +23,6 @@ multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 # openssl is required for rsa keygen but not used by the rust-ipfs or its dependencies
 openssl = { default-features = false, version = "0.10" }
-parity-multiaddr = { default-features = false, version = "0.9" }
 percent-encoding = { default-features = false, version = "2.1" }
 prost = { default-features = false, version = "0.6.1" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -35,7 +35,7 @@ tokio-stream = { version = "0.1" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "env-filter"], version = "0.2" }
 url = { default-features = false, version = "2.1" }
-warp = { default-features = false, version = "0.2", git = "https://github.com/seanmonstar/warp.git" }
+warp = { default-features = false, version = "0.3" }
 
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -12,13 +12,13 @@ vergen = { default-features = false, version = "3.1" }
 [dependencies]
 anyhow = "*" # temporarily needed until the next release of mpart-async
 async-stream = { default-features = false, version = "0.3" }
-bytes = { default-features = false, version = "0.5" }
+bytes = { default-features = false, version = "1.0" }
 cid = { default-features = false, version = "0.5" }
 futures = { default-features = false, version = "0.3" }
 humantime = { default-features = false, version = "2.0" }
 ipfs = { path = "../" }
 mime = { default-features = false, version = "0.3" }
-mpart-async = { default-features = false, version = "0.4" }
+mpart-async = { default-features = false, version = "0.4", git = "https://github.com/gferon/mpart-async.git", branch = "tokio-1.0" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 # openssl is required for rsa keygen but not used by the rust-ipfs or its dependencies
@@ -31,11 +31,12 @@ serde_json = { default-features = false, version = "1.0" }
 structopt = { default-features = false, version = "0.3" }
 tar = { default-features = false, version = "0.4" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, features = ["time"], version = "0.3" }
+tokio = { default-features = false, features = ["time", "sync"], version = "1.0" }
+tokio-stream = { version = "0.1" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "env-filter"], version = "0.2" }
 url = { default-features = false, version = "2.1" }
-warp = { default-features = false, version = "0.2" }
+warp = { default-features = false, version = "0.2", git = "https://github.com/aknuds1/warp.git", branch = "chore/upgrade-tokio" }
 
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -31,7 +31,7 @@ serde_json = { default-features = false, version = "1.0" }
 structopt = { default-features = false, version = "0.3" }
 tar = { default-features = false, version = "0.4" }
 thiserror = { default-features = false, version = "1.0" }
-tokio = { default-features = false, version = "0.2" }
+tokio = { default-features = false, features = ["time"], version = "0.3" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "env-filter"], version = "0.2" }
 url = { default-features = false, version = "2.1" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -36,7 +36,7 @@ tokio-stream = { version = "0.1" }
 tracing = { default-features = false, features = ["log"], version = "0.1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "env-filter"], version = "0.2" }
 url = { default-features = false, version = "2.1" }
-warp = { default-features = false, version = "0.2", git = "https://github.com/aknuds1/warp.git", branch = "chore/upgrade-tokio" }
+warp = { default-features = false, version = "0.2", git = "https://github.com/seanmonstar/warp.git" }
 
 [dev-dependencies]
 hex-literal = { default-features = false, version = "0.3" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -18,7 +18,7 @@ futures = { default-features = false, version = "0.3" }
 humantime = { default-features = false, version = "2.0" }
 ipfs = { path = "../" }
 mime = { default-features = false, version = "0.3" }
-mpart-async = { default-features = false, version = "0.4", git = "https://github.com/gferon/mpart-async.git", branch = "tokio-1.0" }
+mpart-async = { default-features = false, version = "0.5" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 # openssl is required for rsa keygen but not used by the rust-ipfs or its dependencies

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -6,7 +6,7 @@ name = "ipfs-http"
 version = "0.1.0"
 
 [build-dependencies]
-prost-build = { default-features = false, version = "0.6" }
+prost-build = { default-features = false, version = "0.7" }
 vergen = { default-features = false, version = "3.1" }
 
 [dependencies]
@@ -24,7 +24,7 @@ multihash = { default-features = false, version = "0.11" }
 # openssl is required for rsa keygen but not used by the rust-ipfs or its dependencies
 openssl = { default-features = false, version = "0.10" }
 percent-encoding = { default-features = false, version = "2.1" }
-prost = { default-features = false, version = "0.6.1" }
+prost = { default-features = false, version = "0.7" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, version = "1.0" }
 structopt = { default-features = false, version = "0.3" }

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -1,6 +1,6 @@
 //! go-ipfs compatible configuration file handling and setup.
 
-use parity_multiaddr::{multiaddr, Multiaddr};
+use ipfs::{multiaddr, Multiaddr};
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
 use std::num::NonZeroU16;

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 use structopt::StructOpt;
 
 use ipfs::{Ipfs, IpfsOptions, IpfsTypes, UninitializedIpfs};
+use ipfs::{Multiaddr, Protocol};
 use ipfs_http::{config, v0};
-use parity_multiaddr::{Multiaddr, Protocol};
 
 #[macro_use]
 extern crate tracing;
@@ -111,6 +111,7 @@ fn main() {
             }
         }
         Options::Daemon => {
+            // FIXME: toctou, should just match for this err?
             if !config_path.is_file() {
                 eprintln!("Error: no IPFS repo found in {:?}", home);
                 eprintln!("please run: 'ipfs init'");

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -130,7 +130,7 @@ fn main() {
     // TODO: sigterm should initiate graceful shutdown, second time should shutdown right now
     // NOTE: sigkill ... well surely it will stop the process right away
 
-    let mut rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
+    let rt = tokio::runtime::Runtime::new().expect("Failed to create event loop");
 
     rt.block_on(async move {
         let opts = IpfsOptions {

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -190,7 +190,6 @@ fn serve<Types: IpfsTypes>(
     listening_addr: Multiaddr,
 ) -> (std::net::SocketAddr, impl std::future::Future<Output = ()>) {
     use std::net::SocketAddr;
-    use tokio::stream::StreamExt;
     use warp::Filter;
 
     let (shutdown_tx, mut shutdown_rx) = tokio::sync::mpsc::channel::<()>(1);
@@ -211,7 +210,7 @@ fn serve<Types: IpfsTypes>(
     };
 
     warp::serve(routes).bind_with_graceful_shutdown(socket_addr, async move {
-        shutdown_rx.next().await;
+        let _ = shutdown_rx.recv().await;
         info!("Shutdown trigger received; starting shutdown");
         ipfs.exit_daemon().await;
     })

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -155,7 +155,7 @@ pub fn routes<T: IpfsTypes>(
 }
 
 pub(crate) async fn handle_shutdown(
-    mut tx: tokio::sync::mpsc::Sender<()>,
+    tx: tokio::sync::mpsc::Sender<()>,
 ) -> Result<impl warp::Reply, std::convert::Infallible> {
     Ok(match tx.send(()).await {
         Ok(_) => warp::http::StatusCode::OK,
@@ -185,7 +185,7 @@ mod tests {
         routes(&ipfs, shutdown_tx)
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn not_found_as_plaintext() {
         let routes = testing_routes().await;
         let resp = warp::test::request()
@@ -199,7 +199,7 @@ mod tests {
         assert_eq!(resp.body(), "404 page not found");
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn invalid_peer_id_as_messageresponse() {
         let routes = testing_routes().await;
         let resp = warp::test::request()

--- a/http/src/v0.rs
+++ b/http/src/v0.rs
@@ -185,7 +185,7 @@ mod tests {
         routes(&ipfs, shutdown_tx)
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn not_found_as_plaintext() {
         let routes = testing_routes().await;
         let resp = warp::test::request()
@@ -199,7 +199,7 @@ mod tests {
         assert_eq!(resp.body(), "404 page not found");
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn invalid_peer_id_as_messageresponse() {
         let routes = testing_routes().await;
         let resp = warp::test::request()

--- a/http/src/v0/dht.rs
+++ b/http/src/v0/dht.rs
@@ -46,7 +46,7 @@ async fn find_peer_query<T: IpfsTypes>(
     } = query;
     let peer_id = arg.into_inner();
     let addrs = ipfs
-        .find_peer(peer_id.clone())
+        .find_peer(peer_id)
         .maybe_timeout(timeout.map(StringSerialized::into_inner))
         .await
         .map_err(StringError::from)?
@@ -189,7 +189,7 @@ async fn get_closest_peers_query<T: IpfsTypes>(
     } = query;
     let peer_id = arg.into_inner();
     let closest_peers = ipfs
-        .get_closest_peers(peer_id.clone())
+        .get_closest_peers(peer_id)
         .maybe_timeout(timeout.map(StringSerialized::into_inner))
         .await
         .map_err(StringError::from)?

--- a/http/src/v0/pin.rs
+++ b/http/src/v0/pin.rs
@@ -260,7 +260,7 @@ where
     T: Serialize + Send + 'static,
     E: std::fmt::Display + Send + 'static,
 {
-    use bytes::{buf::BufMutExt, BufMut, BytesMut};
+    use bytes::{BufMut, BytesMut};
     use futures::stream::StreamExt;
 
     let mut buffer = BytesMut::with_capacity(256);

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -315,7 +315,7 @@ where
         use multibase::Base::Base64Pad;
         let msg = msg.as_ref();
 
-        let from = Base64Pad.encode(msg.source.as_bytes());
+        let from = Base64Pad.encode(msg.source.to_bytes());
         let data = Base64Pad.encode(&msg.data);
         let seqno = Base64Pad.encode(&msg.sequence_number);
         let topics = msg.topics.clone();

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -548,7 +548,7 @@ mod tests {
         })
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn url_hacked_args() {
         let response = request()
             .path("/pubsub/pub?arg=some_channel&arg=foobar")
@@ -558,7 +558,7 @@ mod tests {
         assert_eq!(body, r#"{"message":"foobar","topic":"some_channel"}"#);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn message_in_body() {
         let response = request()
             .path("/pubsub/pub?arg=some_channel")

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -536,7 +536,7 @@ mod tests {
         })
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn url_hacked_args() {
         let response = request()
             .path("/pubsub/pub?arg=some_channel&arg=foobar")
@@ -546,7 +546,7 @@ mod tests {
         assert_eq!(body, r#"{"message":"foobar","topic":"some_channel"}"#);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn message_in_body() {
         let response = request()
             .path("/pubsub/pub?arg=some_channel")

--- a/http/src/v0/pubsub.rs
+++ b/http/src/v0/pubsub.rs
@@ -13,9 +13,9 @@
 use futures::stream::{Stream, TryStream};
 use serde::{Deserialize, Serialize};
 
-use tokio::stream::StreamExt;
 use tokio::sync::{broadcast, Mutex};
 use tokio::time::timeout;
+use tokio_stream::StreamExt;
 
 use ipfs::{Ipfs, IpfsTypes};
 
@@ -125,7 +125,7 @@ async fn inner_subscribe<T: IpfsTypes>(
     // from write, which is not supported operation either.
     let mut guard = pubsub.subscriptions.lock().await;
 
-    let rx = match guard.entry(topic) {
+    let mut rx = match guard.entry(topic) {
         Entry::Occupied(oe) => {
             // the easiest case: just join in, even if there are no other subscribers at the
             // moment
@@ -160,14 +160,26 @@ async fn inner_subscribe<T: IpfsTypes>(
         }
     };
 
-    // map recv errors into the StreamError and flatten
-    let mut errored = false;
-    rx.into_stream()
-        .map(|res| res.map_err(|_| StreamError::Recv).and_then(|res| res))
-        .take_while(move |res| {
-            // return until the first error
-            !std::mem::replace(&mut errored, res.is_err())
-        })
+    async_stream::stream! {
+        loop {
+            let next = rx.recv().await;
+
+            // map recv errors into the StreamError and flatten
+            let next = match next {
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => Err(StreamError::Recv),
+                Ok(next) => next.and_then(|n| Ok(n)),
+            };
+
+            let was_err = next.is_err();
+
+            yield next;
+
+            if was_err {
+                break;
+            }
+        }
+    }
 }
 
 /// Shovel task takes items from the [`SubscriptionStream`], formats them and passes them on to

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -216,7 +216,7 @@ mod tests {
     use std::collections::HashSet;
     use std::convert::TryFrom;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_inner_local() {
         let filter = local(&*preloaded_testing_ipfs().await);
 
@@ -263,7 +263,7 @@ mod tests {
         assert!(diff.is_empty(), "{:?}", diff);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn refs_with_path() {
         let ipfs = preloaded_testing_ipfs().await;
 

--- a/http/src/v0/refs.rs
+++ b/http/src/v0/refs.rs
@@ -216,7 +216,7 @@ mod tests {
     use std::collections::HashSet;
     use std::convert::TryFrom;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_inner_local() {
         let filter = local(&*preloaded_testing_ipfs().await);
 
@@ -263,7 +263,7 @@ mod tests {
         assert!(diff.is_empty(), "{:?}", diff);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn refs_with_path() {
         let ipfs = preloaded_testing_ipfs().await;
 

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -303,7 +303,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn very_long_file_and_symlink_names() {
         let ipfs = Node::new("test_node").await;
 
@@ -359,7 +359,7 @@ mod tests {
         assert_eq!(found, expected);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn get_multiblock_file() {
         let ipfs = Node::new("test_node").await;
 

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -303,7 +303,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn very_long_file_and_symlink_names() {
         let ipfs = Node::new("test_node").await;
 
@@ -359,7 +359,7 @@ mod tests {
         assert_eq!(found, expected);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn get_multiblock_file() {
         let ipfs = Node::new("test_node").await;
 

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -377,7 +377,7 @@ impl<D: fmt::Display> serde::Serialize for Quoted<D> {
 mod tests {
     use crate::v0::root_files::add;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn add_single_block_file() {
         let ipfs = tokio_ipfs().await;
 

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -106,7 +106,7 @@ fn add_stream<St, E>(
 ) -> impl Stream<Item = Result<Bytes, AddError>> + Send + 'static
 where
     St: Stream<Item = Result<Bytes, E>> + Send + Unpin + 'static,
-    E: Into<anyhow::Error> + Send + 'static,
+    E: Into<anyhow::Error> + Send + Sync + 'static + std::error::Error,
 {
     async_stream::try_stream! {
 

--- a/http/src/v0/root_files/add.rs
+++ b/http/src/v0/root_files/add.rs
@@ -378,7 +378,7 @@ impl<D: fmt::Display> serde::Serialize for Quoted<D> {
 mod tests {
     use crate::v0::root_files::add;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn add_single_block_file() {
         let ipfs = tokio_ipfs().await;
 

--- a/http/src/v0/support.rs
+++ b/http/src/v0/support.rs
@@ -92,31 +92,16 @@ impl warp::reject::Reject for RequiredArgumentMissing {}
 #[derive(Debug)]
 pub(crate) struct InvalidMultipartFormData;
 impl warp::reject::Reject for InvalidMultipartFormData {}
-impl From<InvalidMultipartFormData> for warp::Rejection {
-    fn from(err: InvalidMultipartFormData) -> warp::Rejection {
-        warp::reject::custom(err)
-    }
-}
 
 /// Marker for `warp` specific rejections when something is unimplemented
 #[derive(Debug)]
 pub(crate) struct NotImplemented;
 impl warp::reject::Reject for NotImplemented {}
-impl From<NotImplemented> for warp::Rejection {
-    fn from(err: NotImplemented) -> warp::Rejection {
-        warp::reject::custom(err)
-    }
-}
 
 /// PeerId parsing error, details from `libp2p::identity::ParseError` are lost.
 #[derive(Debug)]
 pub(crate) struct InvalidPeerId;
 impl warp::reject::Reject for InvalidPeerId {}
-impl From<InvalidPeerId> for warp::Rejection {
-    fn from(err: InvalidPeerId) -> warp::Rejection {
-        warp::reject::custom(err)
-    }
-}
 
 /// Default placeholder for ipfs::Error but once we get more typed errors we could start making
 /// them more readable, if needed.
@@ -124,11 +109,6 @@ impl From<InvalidPeerId> for warp::Rejection {
 #[derive(Debug)]
 pub(crate) struct StringError(Cow<'static, str>);
 impl warp::reject::Reject for StringError {}
-impl From<StringError> for warp::Rejection {
-    fn from(err: StringError) -> warp::Rejection {
-        warp::reject::custom(err)
-    }
-}
 
 impl<D: std::fmt::Display> From<D> for StringError {
     fn from(d: D) -> Self {

--- a/http/src/v0/support/body.rs
+++ b/http/src/v0/support/body.rs
@@ -50,8 +50,10 @@ pub async fn try_only_named_multipart<'a>(
     st: impl Stream<Item = Result<impl Buf, warp::Error>> + Unpin + 'a,
 ) -> Result<Vec<u8>, OnlyMultipartFailure> {
     use bytes::Bytes;
-    let mut stream =
-        MultipartStream::new(Bytes::from(boundary), st.map_ok(|mut buf| buf.to_bytes()));
+    let mut stream = MultipartStream::new(
+        Bytes::from(boundary),
+        st.map_ok(|mut buf| buf.copy_to_bytes(buf.remaining())),
+    );
 
     // store the first good field here; optimally this would just be an Option but couldn't figure
     // out a way to handle the "field matched", "field not matched" cases while supporting empty

--- a/http/src/v0/support/timeout.rs
+++ b/http/src/v0/support/timeout.rs
@@ -5,7 +5,7 @@
 use futures::future::{Either, Map};
 use std::future::Future;
 use std::time::Duration;
-use tokio::time::{timeout, Elapsed, Timeout};
+use tokio::time::{error::Elapsed, timeout, Timeout};
 
 pub type MaybeTimeout<F> =
     Either<Timeout<F>, Map<F, fn(<F as Future>::Output) -> Result<<F as Future>::Output, Elapsed>>>;

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -600,7 +600,7 @@ mod tests {
     use super::*;
     use crate::{make_ipld, Node};
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_root_cid() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -610,7 +610,7 @@ mod tests {
         assert_eq!(res, data);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_array_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -623,7 +623,7 @@ mod tests {
         assert_eq!(res, make_ipld!(2));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_nested_array_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -636,7 +636,7 @@ mod tests {
         assert_eq!(res, make_ipld!(2));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_object_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -651,7 +651,7 @@ mod tests {
         assert_eq!(res, make_ipld!(false));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_resolve_cid_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -845,7 +845,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn resolve_through_link() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -874,7 +874,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolving_first_segment() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -890,7 +890,7 @@ mod tests {
         assert_eq!(e.to_string(), format!("no link named \"1\" under {}", cid2));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolving_last_segment() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -906,7 +906,7 @@ mod tests {
         assert_eq!(e.to_string(), format!("no link named \"a\" under {}", cid1));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolving_through_file() {
         let Node { ipfs, .. } = Node::new("test_node").await;
 
@@ -938,7 +938,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn fail_resolving_through_dir() {
         let Node { ipfs, .. } = Node::new("test_node").await;
 

--- a/src/dag.rs
+++ b/src/dag.rs
@@ -600,7 +600,7 @@ mod tests {
     use super::*;
     use crate::{make_ipld, Node};
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_resolve_root_cid() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -610,7 +610,7 @@ mod tests {
         assert_eq!(res, data);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_resolve_array_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -623,7 +623,7 @@ mod tests {
         assert_eq!(res, make_ipld!(2));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_resolve_nested_array_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -636,7 +636,7 @@ mod tests {
         assert_eq!(res, make_ipld!(2));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_resolve_object_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -651,7 +651,7 @@ mod tests {
         assert_eq!(res, make_ipld!(false));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_resolve_cid_elem() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -845,7 +845,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn resolve_through_link() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -874,7 +874,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn fail_resolving_first_segment() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -890,7 +890,7 @@ mod tests {
         assert_eq!(e.to_string(), format!("no link named \"1\" under {}", cid2));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn fail_resolving_last_segment() {
         let Node { ipfs, .. } = Node::new("test_node").await;
         let dag = IpldDag::new(ipfs);
@@ -906,7 +906,7 @@ mod tests {
         assert_eq!(e.to_string(), format!("no link named \"a\" under {}", cid1));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn fail_resolving_through_file() {
         let Node { ipfs, .. } = Node::new("test_node").await;
 
@@ -938,7 +938,7 @@ mod tests {
         );
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn fail_resolving_through_dir() {
         let Node { ipfs, .. } = Node::new("test_node").await;
 

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -4,7 +4,7 @@ use bytes::Bytes;
 use domain::base::iana::Rtype;
 use domain::base::{Dname, Question};
 use domain::rdata::rfc1035::Txt;
-use domain_resolv::{stub::Answer, StubResolver};
+use domain::resolv::{stub::Answer, StubResolver};
 use futures::future::{select_ok, SelectOk};
 use futures::pin_mut;
 use std::future::Future;

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -120,14 +120,14 @@ pub async fn resolve(domain: &str) -> Result<IpfsPath, Error> {
 mod tests {
     use super::*;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn test_resolve1() {
         let res = resolve("ipfs.io").await.unwrap().to_string();
         assert_eq!(res, "/ipns/website.ipfs.io");
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn test_resolve2() {
         let res = resolve("website.ipfs.io").await.unwrap().to_string();

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -120,14 +120,14 @@ pub async fn resolve(domain: &str) -> Result<IpfsPath, Error> {
 mod tests {
     use super::*;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     #[ignore]
     async fn test_resolve1() {
         let res = resolve("ipfs.io").await.unwrap().to_string();
         assert_eq!(res, "/ipns/website.ipfs.io");
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     #[ignore]
     async fn test_resolve2() {
         let res = resolve("website.ipfs.io").await.unwrap().to_string();

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -71,7 +71,7 @@ fn create_resolver() -> Result<StubResolver, Error> {
 
 #[cfg(target_os = "windows")]
 fn create_resolver() -> Result<StubResolver, Error> {
-    use domain_resolv::stub::conf::ResolvConf;
+    use domain::resolv::stub::conf::ResolvConf;
     use std::{collections::HashSet, io::Cursor};
 
     let mut config = ResolvConf::new();
@@ -100,12 +100,12 @@ pub async fn resolve(domain: &str) -> Result<IpfsPath, Error> {
     dnslink.push_str(domain);
     let resolver = create_resolver()?;
 
-    let qname = Dname::<Bytes>::from_str(&domain)?;
+    let qname = Dname::<Bytes>::from_chars(domain.chars())?;
     let question = Question::new_in(qname, Rtype::Txt);
     let resolver1 = resolver.clone();
     let query1 = Box::pin(async move { resolver1.query(question).await });
 
-    let qname = Dname::<Bytes>::from_str(&dnslink)?;
+    let qname = Dname::<Bytes>::from_chars(dnslink.chars())?;
     let question = Question::new_in(qname, Rtype::Txt);
     let resolver2 = resolver;
     let query2 = Box::pin(async move { resolver2.query(question).await });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1404,7 +1404,9 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                         // perhaps this could be moved under `IpfsEvent` or free functions?
                         let mut addresses = Vec::new();
                         addresses.extend(Swarm::listeners(&self.swarm).cloned());
-                        addresses.extend(Swarm::external_addresses(&self.swarm).cloned());
+                        addresses.extend(
+                            Swarm::external_addresses(&self.swarm).map(|ar| ar.addr.clone()),
+                        );
                         // ignore error, perhaps caller went away already
                         let _ = ret.send(addresses);
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,10 @@ pub use self::{
 pub use cid::Cid;
 pub use ipfs_bitswap::Block;
 pub use libp2p::{
-    core::{connection::ListenerId, multiaddr::Protocol, Multiaddr, PeerId, PublicKey},
+    core::{
+        connection::ListenerId, multiaddr::multiaddr, multiaddr::Protocol, Multiaddr, PeerId,
+        PublicKey,
+    },
     identity::Keypair,
     kad::{record::Key, Quorum},
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -921,7 +921,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
 
             self.to_task
                 .clone()
-                .send(IpfsEvent::FindPeer(peer_id.clone(), false, tx))
+                .send(IpfsEvent::FindPeer(peer_id, false, tx))
                 .await?;
 
             match rx.await? {
@@ -934,7 +934,7 @@ impl<Types: IpfsTypes> Ipfs<Types> {
 
                     self.to_task
                         .clone()
-                        .send(IpfsEvent::FindPeer(peer_id.clone(), true, tx))
+                        .send(IpfsEvent::FindPeer(peer_id, true, tx))
                         .await?;
 
                     match rx.await? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1756,7 +1756,7 @@ mod tests {
     use crate::make_ipld;
     use multihash::Sha2_256;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_put_and_get_block() {
         let ipfs = Node::new("test_node").await;
 
@@ -1769,7 +1769,7 @@ mod tests {
         assert_eq!(block, new_block);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_put_and_get_dag() {
         let ipfs = Node::new("test_node").await;
 
@@ -1779,7 +1779,7 @@ mod tests {
         assert_eq!(data, new_data);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_pin_and_unpin() {
         let ipfs = Node::new("test_node").await;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1751,7 +1751,7 @@ mod tests {
     use crate::make_ipld;
     use multihash::Sha2_256;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_put_and_get_block() {
         let ipfs = Node::new("test_node").await;
 
@@ -1764,7 +1764,7 @@ mod tests {
         assert_eq!(block, new_block);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_put_and_get_dag() {
         let ipfs = Node::new("test_node").await;
 
@@ -1774,7 +1774,7 @@ mod tests {
         assert_eq!(data, new_data);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_pin_and_unpin() {
         let ipfs = Node::new("test_node").await;
 

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -473,7 +473,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
 
     pub fn add_peer(&mut self, peer: PeerId, addr: Multiaddr) {
         self.kademlia.add_address(&peer, addr);
-        self.swarm.add_peer(peer.clone());
+        self.swarm.add_peer(peer);
         // FIXME: the call below automatically performs a dial attempt
         // to the given peer; it is unsure that we want it done within
         // add_peer, especially since that peer might not belong to the

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -12,9 +12,9 @@ use libp2p::core::{Multiaddr, PeerId};
 use libp2p::identify::{Identify, IdentifyEvent};
 use libp2p::kad::record::{store::MemoryStore, Key, Record};
 use libp2p::kad::{Kademlia, KademliaConfig, KademliaEvent, Quorum};
-use libp2p::mdns::{MdnsEvent, TokioMdns};
+// use libp2p::mdns::{MdnsEvent, TokioMdns};
 use libp2p::ping::{Ping, PingEvent};
-use libp2p::swarm::toggle::Toggle;
+// use libp2p::swarm::toggle::Toggle;
 use libp2p::swarm::{NetworkBehaviour, NetworkBehaviourEventProcess};
 use multibase::Base;
 use std::{convert::TryInto, sync::Arc};
@@ -25,7 +25,7 @@ use tokio::task;
 pub struct Behaviour<Types: IpfsTypes> {
     #[behaviour(ignore)]
     repo: Arc<Repo<Types>>,
-    mdns: Toggle<TokioMdns>,
+    // mdns: Toggle<TokioMdns>,
     kademlia: Kademlia<MemoryStore>,
     #[behaviour(ignore)]
     kad_subscriptions: SubscriptionRegistry<KadResult, String>,
@@ -54,6 +54,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<void::Void> for Behaviour<Ty
     fn inject_event(&mut self, _event: void::Void) {}
 }
 
+/*
 impl<Types: IpfsTypes> NetworkBehaviourEventProcess<MdnsEvent> for Behaviour<Types> {
     fn inject_event(&mut self, event: MdnsEvent) {
         match event {
@@ -72,6 +73,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<MdnsEvent> for Behaviour<Typ
         }
     }
 }
+*/
 
 impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour<Types> {
     fn inject_event(&mut self, event: KademliaEvent) {
@@ -417,12 +419,14 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     pub async fn new(options: SwarmOptions, repo: Arc<Repo<Types>>) -> Self {
         info!("net: starting with peer id {}", options.peer_id);
 
+        /*
         let mdns = if options.mdns {
             Some(TokioMdns::new().expect("Failed to create mDNS service"))
         } else {
             None
         }
         .into();
+        */
 
         let store = MemoryStore::new(options.peer_id.to_owned());
 
@@ -456,7 +460,7 @@ impl<Types: IpfsTypes> Behaviour<Types> {
 
         Behaviour {
             repo,
-            mdns,
+            // mdns,
             kademlia,
             kad_subscriptions: Default::default(),
             bitswap,
@@ -543,10 +547,11 @@ impl<Types: IpfsTypes> Behaviour<Types> {
     }
 
     pub fn get_closest_peers(&mut self, id: PeerId) -> SubscriptionFuture<KadResult, String> {
-        let id = id.to_base58();
+        // TODO: why was this base58?
+        // let id = id.to_base58();
 
         self.kad_subscriptions
-            .create_subscription(self.kademlia.get_closest_peers(id.as_bytes()).into(), None)
+            .create_subscription(self.kademlia.get_closest_peers(id).into(), None)
     }
 
     pub fn get_providers(&mut self, cid: Cid) -> SubscriptionFuture<KadResult, String> {

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -58,7 +58,7 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     swarm_span: Span,
     repo: Arc<Repo<TIpfsTypes>>,
 ) -> io::Result<TSwarm<TIpfsTypes>> {
-    let peer_id = options.peer_id.clone();
+    let peer_id = options.peer_id;
 
     // Set up an encrypted TCP transport over the Mplex protocol.
     let transport = transport::build_transport(options.keypair.clone())?;

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -37,7 +37,7 @@ pub struct Pubsub {
 pub struct PubsubMessage {
     /// Peer address of the message sender.
     pub source: PeerId,
-    /// The message data.  
+    /// The message data.
     pub data: Vec<u8>,
     /// The sequence number of the message.
     // this could be an enum for gossipsub message compat, it uses u64, though the floodsub

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -430,8 +430,11 @@ impl NetworkBehaviour for Pubsub {
                         handler,
                     });
                 }
-                NetworkBehaviourAction::ReportObservedAddr { address } => {
-                    return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr { address });
+                NetworkBehaviourAction::ReportObservedAddr { address, score } => {
+                    return Poll::Ready(NetworkBehaviourAction::ReportObservedAddr {
+                        address,
+                        score,
+                    });
                 }
             }
         }

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -207,13 +207,7 @@ impl Pubsub {
     pub fn subscribed_peers(&self, topic: &Topic) -> Vec<PeerId> {
         self.peers
             .iter()
-            .filter_map(|(k, v)| {
-                if v.contains(topic) {
-                    Some(k.clone())
-                } else {
-                    None
-                }
-            })
+            .filter_map(|(k, v)| if v.contains(topic) { Some(*k) } else { None })
             .collect()
     }
 
@@ -384,7 +378,7 @@ impl NetworkBehaviour for Pubsub {
                     peer_id,
                     topic,
                 }) => {
-                    let topics = self.peers.entry(peer_id.clone()).or_insert_with(Vec::new);
+                    let topics = self.peers.entry(peer_id).or_insert_with(Vec::new);
                     let appeared = topics.is_empty();
                     if topics.iter().find(|&t| t == &topic).is_none() {
                         topics.push(topic);
@@ -400,7 +394,7 @@ impl NetworkBehaviour for Pubsub {
                     peer_id,
                     topic,
                 }) => {
-                    if let Entry::Occupied(mut oe) = self.peers.entry(peer_id.clone()) {
+                    if let Entry::Occupied(mut oe) = self.peers.entry(peer_id) {
                         let topics = oe.get_mut();
                         if let Some(pos) = topics.iter().position(|t| t == &topic) {
                             topics.swap_remove(pos);

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -267,7 +267,7 @@ mod tests {
     use libp2p::{multiaddr::Protocol, multihash::Multihash, swarm::Swarm};
     use std::convert::TryInto;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn swarm_api() {
         let (peer1_id, trans) = mk_transport();
         let mut swarm1 = Swarm::new(trans, SwarmApi::default(), peer1_id.clone());

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -26,9 +26,7 @@ pub struct Disconnector {
 }
 
 impl Disconnector {
-    pub fn disconnect<T: NetworkBehaviour>(self, swarm: &mut Swarm<T>)
-        where <<<T as NetworkBehaviour>::ProtocolsHandler as IntoProtocolsHandler>::Handler as ProtocolsHandler>::InEvent: std::clone::Clone
-    {
+    pub fn disconnect<T: NetworkBehaviour>(self, swarm: &mut Swarm<T>) {
         Swarm::ban_peer_id(swarm, self.peer_id.clone());
         Swarm::unban_peer_id(swarm, self.peer_id);
     }
@@ -280,7 +278,7 @@ mod tests {
         for l in Swarm::listeners(&swarm1) {
             let mut addr = l.to_owned();
             addr.push(Protocol::P2p(
-                Multihash::from_bytes(peer1_id.clone().into_bytes()).unwrap(),
+                Multihash::from_bytes(&peer1_id.to_bytes()).unwrap(),
             ));
             if let Some(fut) = swarm2.connect(addr.try_into().unwrap()) {
                 fut.await.unwrap();

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -265,7 +265,7 @@ mod tests {
     use libp2p::{multiaddr::Protocol, multihash::Multihash, swarm::Swarm};
     use std::convert::TryInto;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn swarm_api() {
         let (peer1_id, trans) = mk_transport();
         let mut swarm1 = Swarm::new(trans, SwarmApi::default(), peer1_id);

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -27,7 +27,7 @@ pub struct Disconnector {
 
 impl Disconnector {
     pub fn disconnect<T: NetworkBehaviour>(self, swarm: &mut Swarm<T>) {
-        Swarm::ban_peer_id(swarm, self.peer_id.clone());
+        Swarm::ban_peer_id(swarm, self.peer_id);
         Swarm::unban_peer_id(swarm, self.peer_id);
     }
 }
@@ -67,7 +67,7 @@ impl SwarmApi {
 
                 if let Some(any) = conns.first() {
                     Some(Connection {
-                        addr: MultiaddrWithPeerId::from((any.clone(), peer.clone())),
+                        addr: MultiaddrWithPeerId::from((any.clone(), *peer)),
                         rtt,
                     })
                 } else {
@@ -78,7 +78,7 @@ impl SwarmApi {
 
     pub fn set_rtt(&mut self, peer_id: &PeerId, rtt: Duration) {
         // FIXME: this is for any connection
-        self.roundtrip_times.insert(peer_id.clone(), rtt);
+        self.roundtrip_times.insert(*peer_id, rtt);
     }
 
     pub fn connect(&mut self, addr: MultiaddrWithPeerId) -> Option<SubscriptionFuture<(), String>> {
@@ -156,16 +156,16 @@ impl NetworkBehaviour for SwarmApi {
         trace!("inject_connected {} {:?}", peer_id, cp);
         let addr: MultiaddrWithoutPeerId = connection_point_addr(cp).to_owned().try_into().unwrap();
 
-        self.peers.insert(peer_id.clone());
-        let connections = self.connected_peers.entry(peer_id.clone()).or_default();
+        self.peers.insert(*peer_id);
+        let connections = self.connected_peers.entry(*peer_id).or_default();
         connections.push(addr.clone());
 
-        self.connections.insert(addr.clone(), peer_id.clone());
+        self.connections.insert(addr.clone(), *peer_id);
 
         if let ConnectedPoint::Dialer { .. } = cp {
             let addr = MultiaddrWithPeerId {
                 multiaddr: addr,
-                peer_id: peer_id.clone(),
+                peer_id: *peer_id,
             };
 
             self.connect_registry
@@ -268,7 +268,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn swarm_api() {
         let (peer1_id, trans) = mk_transport();
-        let mut swarm1 = Swarm::new(trans, SwarmApi::default(), peer1_id.clone());
+        let mut swarm1 = Swarm::new(trans, SwarmApi::default(), peer1_id);
 
         let (peer2_id, trans) = mk_transport();
         let mut swarm2 = Swarm::new(trans, SwarmApi::default(), peer2_id);

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -1,19 +1,19 @@
 use libp2p::core::muxing::StreamMuxerBox;
-use libp2p::core::transport::boxed::Boxed;
 use libp2p::core::transport::upgrade::Version;
+use libp2p::core::transport::Boxed;
 use libp2p::core::upgrade::SelectUpgrade;
 use libp2p::dns::DnsConfig;
 use libp2p::identity;
 use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseConfig};
 use libp2p::tcp::TokioTcpConfig;
-use libp2p::yamux::Config as YamuxConfig;
+use libp2p::yamux::YamuxConfig;
 use libp2p::{PeerId, Transport};
 use std::io::{self, Error, ErrorKind};
 use std::time::Duration;
 
 /// Transport type.
-pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox), Error>;
+pub(crate) type TTransport = Boxed<(PeerId, StreamMuxerBox)>;
 
 /// Builds the transport that serves as a common ground for all connections.
 ///

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(links, ["african.txt", "americas.txt", "australian.txt",]);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn all_refs_from_root() {
         let Node { ipfs, .. } = preloaded_testing_ipfs().await;
 
@@ -416,7 +416,7 @@ mod tests {
         assert_edges(&expected, all_edges.as_slice());
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn all_unique_refs_from_root() {
         let Node { ipfs, .. } = preloaded_testing_ipfs().await;
 

--- a/src/refs.rs
+++ b/src/refs.rs
@@ -369,7 +369,7 @@ mod tests {
         assert_eq!(links, ["african.txt", "americas.txt", "australian.txt",]);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn all_refs_from_root() {
         let Node { ipfs, .. } = preloaded_testing_ipfs().await;
 
@@ -416,7 +416,7 @@ mod tests {
         assert_edges(&expected, all_edges.as_slice());
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn all_unique_refs_from_root() {
         let Node { ipfs, .. } = preloaded_testing_ipfs().await;
 

--- a/src/repo/common_tests.rs
+++ b/src/repo/common_tests.rs
@@ -56,7 +56,7 @@ macro_rules! pinstore_interface_tests {
             use std::collections::HashMap;
             use std::convert::TryFrom;
 
-            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            #[tokio::test]
             async fn pin_direct_twice_is_good() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -84,7 +84,7 @@ macro_rules! pinstore_interface_tests {
                 );
             }
 
-            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            #[tokio::test]
             async fn cannot_recursively_unpin_unpinned() {
                 let repo = DSTestContext::with($factory).await;
                 // root/nested/deeper: QmX5S2xLu32K6WxWnyLeChQFbDHy79ULV9feJYH2Hy9bgp
@@ -103,7 +103,7 @@ macro_rules! pinstore_interface_tests {
                 assert_eq!(e.to_string(), "not pinned or pinned indirectly");
             }
 
-            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            #[tokio::test]
             async fn cannot_unpin_indirect() {
                 let repo = DSTestContext::with($factory).await;
                 // root/nested/deeper: QmX5S2xLu32K6WxWnyLeChQFbDHy79ULV9feJYH2Hy9bgp
@@ -146,7 +146,7 @@ macro_rules! pinstore_interface_tests {
                 assert_eq!(e.to_string(), "not pinned or pinned indirectly");
             }
 
-            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            #[tokio::test]
             async fn can_pin_direct_as_recursive() {
                 // the other way around doesn't work
                 let repo = DSTestContext::with($factory).await;
@@ -188,7 +188,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            #[tokio::test]
             async fn pin_recursive_pins_all_blocks() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -221,7 +221,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            #[tokio::test]
             async fn indirect_can_be_pinned_directly() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -261,7 +261,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            #[tokio::test]
             async fn direct_and_indirect_when_parent_unpinned() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -311,7 +311,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(one.is_empty(), "{:?}", one);
             }
 
-            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+            #[tokio::test]
             async fn cannot_pin_recursively_pinned_directly() {
                 // this is a bit of odd as other ops are additive
                 let repo = DSTestContext::with($factory).await;

--- a/src/repo/common_tests.rs
+++ b/src/repo/common_tests.rs
@@ -56,7 +56,7 @@ macro_rules! pinstore_interface_tests {
             use std::collections::HashMap;
             use std::convert::TryFrom;
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn pin_direct_twice_is_good() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -84,7 +84,7 @@ macro_rules! pinstore_interface_tests {
                 );
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn cannot_recursively_unpin_unpinned() {
                 let repo = DSTestContext::with($factory).await;
                 // root/nested/deeper: QmX5S2xLu32K6WxWnyLeChQFbDHy79ULV9feJYH2Hy9bgp
@@ -103,7 +103,7 @@ macro_rules! pinstore_interface_tests {
                 assert_eq!(e.to_string(), "not pinned or pinned indirectly");
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn cannot_unpin_indirect() {
                 let repo = DSTestContext::with($factory).await;
                 // root/nested/deeper: QmX5S2xLu32K6WxWnyLeChQFbDHy79ULV9feJYH2Hy9bgp
@@ -146,7 +146,7 @@ macro_rules! pinstore_interface_tests {
                 assert_eq!(e.to_string(), "not pinned or pinned indirectly");
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn can_pin_direct_as_recursive() {
                 // the other way around doesn't work
                 let repo = DSTestContext::with($factory).await;
@@ -188,7 +188,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn pin_recursive_pins_all_blocks() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -221,7 +221,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn indirect_can_be_pinned_directly() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -261,7 +261,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(both.is_empty(), "{:?}", both);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn direct_and_indirect_when_parent_unpinned() {
                 let repo = DSTestContext::with($factory).await;
 
@@ -311,7 +311,7 @@ macro_rules! pinstore_interface_tests {
                 assert!(one.is_empty(), "{:?}", one);
             }
 
-            #[tokio::test(max_threads = 1)]
+            #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
             async fn cannot_pin_recursively_pinned_directly() {
                 // this is a bit of odd as other ops are additive
                 let repo = DSTestContext::with($factory).await;

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -93,9 +93,9 @@ impl FsBlockStore {
 
         match rx.recv().await {
             Ok(Ok(())) => WriteCompletion::KnownGood,
-            Err(broadcast::RecvError::Closed) => WriteCompletion::NotObserved,
+            Err(broadcast::error::RecvError::Closed) => WriteCompletion::NotObserved,
             Ok(Err(_)) => WriteCompletion::KnownBad,
-            Err(broadcast::RecvError::Lagged(_)) => {
+            Err(broadcast::error::RecvError::Lagged(_)) => {
                 unreachable!("sending at most one message to the channel with capacity of one")
             }
         }
@@ -298,12 +298,12 @@ impl BlockStore for FsBlockStore {
                             trace!("synchronized with writer, write outcome: {:?}", message);
                             message
                         }
-                        Err(broadcast::RecvError::Closed) => {
+                        Err(broadcast::error::RecvError::Closed) => {
                             // there was never any write intention by any party, and we may have just
                             // closed the last sender above, or we were late for the one message.
                             Ok(())
                         }
-                        Err(broadcast::RecvError::Lagged(_)) => {
+                        Err(broadcast::error::RecvError::Lagged(_)) => {
                             unreachable!("broadcast channel should only be messaged once here")
                         }
                     };
@@ -442,7 +442,7 @@ mod tests {
     use std::env::temp_dir;
     use std::sync::Arc;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fs_blockstore() {
         let mut tmp = temp_dir();
         tmp.push("blockstore1");
@@ -480,7 +480,7 @@ mod tests {
         std::fs::remove_dir_all(tmp).ok();
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fs_blockstore_open() {
         let mut tmp = temp_dir();
         tmp.push("blockstore2");
@@ -505,7 +505,7 @@ mod tests {
         std::fs::remove_dir_all(&tmp).ok();
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_fs_blockstore_list() {
         let mut tmp = temp_dir();
         tmp.push("blockstore_list");
@@ -529,7 +529,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn race_to_insert_new() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();
@@ -560,7 +560,7 @@ mod tests {
         assert_eq!(existing, count - 1);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn race_to_insert_with_existing() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();
@@ -633,7 +633,7 @@ mod tests {
         (writes, existing)
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn remove() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -443,7 +443,7 @@ mod tests {
     use std::env::temp_dir;
     use std::sync::Arc;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_fs_blockstore() {
         let mut tmp = temp_dir();
         tmp.push("blockstore1");
@@ -481,7 +481,7 @@ mod tests {
         std::fs::remove_dir_all(tmp).ok();
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_fs_blockstore_open() {
         let mut tmp = temp_dir();
         tmp.push("blockstore2");
@@ -506,7 +506,7 @@ mod tests {
         std::fs::remove_dir_all(&tmp).ok();
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_fs_blockstore_list() {
         let mut tmp = temp_dir();
         tmp.push("blockstore_list");
@@ -530,7 +530,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn race_to_insert_new() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();
@@ -561,7 +561,7 @@ mod tests {
         assert_eq!(existing, count - 1);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn race_to_insert_with_existing() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();
@@ -634,7 +634,7 @@ mod tests {
         (writes, existing)
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn remove() {
         // FIXME: why not tempdir?
         let mut tmp = temp_dir();

--- a/src/repo/fs/pinstore.rs
+++ b/src/repo/fs/pinstore.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
 use tokio::sync::Semaphore;
-use tokio_stream::{empty, StreamExt};
+use tokio_stream::{empty, wrappers::ReadDirStream, StreamExt};
 use tokio_util::either::Either;
 use tracing_futures::Instrument;
 
@@ -444,8 +444,6 @@ impl FsDataStore {
     async fn list_pinfiles(
         &self,
     ) -> impl futures::stream::Stream<Item = Result<(Cid, PinMode), Error>> + 'static {
-        use tokio_stream::wrappers::ReadDirStream;
-
         let stream = match tokio::fs::read_dir(self.path.clone()).await {
             Ok(st) => Either::Left(ReadDirStream::new(st)),
             // make this into a stream which will only yield the initial error

--- a/src/repo/fs/pinstore.rs
+++ b/src/repo/fs/pinstore.rs
@@ -5,13 +5,14 @@ use crate::repo::{PinKind, PinMode, PinModeRequirement, PinStore, References};
 use async_trait::async_trait;
 use cid::Cid;
 use core::convert::TryFrom;
-use futures::future::Either;
-use futures::stream::{empty, StreamExt, TryStreamExt};
+use futures::stream::TryStreamExt;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
 use tokio::sync::Semaphore;
+use tokio_stream::{empty, StreamExt};
+use tokio_util::either::Either;
 use tracing_futures::Instrument;
 
 // PinStore is a trait from ipfs::repo implemented on FsDataStore defined at ipfs::repo::fs or
@@ -36,7 +37,7 @@ impl PinStore for FsDataStore {
 
         futures::pin_mut!(st);
 
-        while let Some(recursive) = st.try_next().await? {
+        while let Some(recursive) = StreamExt::try_next(&mut st).await? {
             // TODO: it might be much better to just deserialize the vec one by one and comparing while
             // going
             let (_, references) = read_recursively_pinned(self.path.clone(), recursive).await?;
@@ -264,7 +265,7 @@ impl PinStore for FsDataStore {
 
             futures::pin_mut!(cids);
 
-            while let Some((cid, mode)) = cids.try_next().await? {
+            while let Some((cid, mode)) = StreamExt::try_next(&mut cids).await? {
 
                 let matches = requirement.matches(&mode);
 
@@ -306,7 +307,7 @@ impl PinStore for FsDataStore {
                 .map_ok(move |cid| read_recursively_pinned(path.clone(), cid))
                 .try_buffer_unordered(4);
 
-            while let Some((_, next_batch)) = recursive.try_next().await? {
+            while let Some((_, next_batch)) = StreamExt::try_next(&mut recursive).await? {
                 for indirect in next_batch {
                     if returned.insert(indirect.clone()) {
                         yield (indirect, PinMode::Indirect);
@@ -317,7 +318,7 @@ impl PinStore for FsDataStore {
             }
         };
 
-        st.in_current_span().boxed()
+        Box::pin(st.in_current_span())
     }
 
     async fn query(
@@ -412,7 +413,9 @@ impl PinStore for FsDataStore {
 
             futures::pin_mut!(recursives);
 
-            'out: while let Some((referring, references)) = recursives.try_next().await? {
+            'out: while let Some((referring, references)) =
+                StreamExt::try_next(&mut recursives).await?
+            {
                 // FIXME: maybe binary search?
                 for cid in references {
                     if let Some(index) = remaining.remove(&cid) {
@@ -441,8 +444,10 @@ impl FsDataStore {
     async fn list_pinfiles(
         &self,
     ) -> impl futures::stream::Stream<Item = Result<(Cid, PinMode), Error>> + 'static {
+        use tokio_stream::wrappers::ReadDirStream;
+
         let stream = match tokio::fs::read_dir(self.path.clone()).await {
-            Ok(st) => Either::Left(st),
+            Ok(st) => Either::Left(ReadDirStream::new(st)),
             // make this into a stream which will only yield the initial error
             Err(e) => Either::Right(futures::stream::once(futures::future::ready(Err(e)))),
         };
@@ -451,7 +456,7 @@ impl FsDataStore {
             .and_then(|d| async move {
                 // map over the shard directories
                 Ok(if d.file_type().await?.is_dir() {
-                    Either::Left(fs::read_dir(d.path()).await?)
+                    Either::Left(ReadDirStream::new(fs::read_dir(d.path()).await?))
                 } else {
                     Either::Right(empty())
                 })

--- a/src/repo/kv.rs
+++ b/src/repo/kv.rs
@@ -291,6 +291,8 @@ impl PinStore for KvDataStore {
         &self,
         requirement: Option<PinMode>,
     ) -> futures::stream::BoxStream<'static, Result<(Cid, PinMode), Error>> {
+        use tokio_stream::wrappers::UnboundedReceiverStream;
+
         let db = self.get_db().to_owned();
 
         // if the pins are always updated in transaction, we might get away with just tree reads.
@@ -375,7 +377,7 @@ impl PinStore for KvDataStore {
         //
         // it would be nice to make sure that the stream doesn't end before task has ended, but
         // perhaps the unboundedness of the channel takes care of that.
-        rx.boxed()
+        UnboundedReceiverStream::new(rx).boxed()
     }
 
     async fn query(

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -685,7 +685,7 @@ mod tests {
     use multihash::Sha2_256;
     use std::env::temp_dir;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_mem_blockstore() {
         let tmp = temp_dir();
         let store = MemBlockStore::new(tmp);
@@ -718,7 +718,7 @@ mod tests {
         assert_eq!(get.await.unwrap(), None);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_mem_blockstore_list() {
         let tmp = temp_dir();
         let mem_store = MemBlockStore::new(tmp);
@@ -741,7 +741,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn test_mem_datastore() {
         let tmp = temp_dir();
         let store = MemDataStore::new(tmp);

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -685,7 +685,7 @@ mod tests {
     use multihash::Sha2_256;
     use std::env::temp_dir;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_mem_blockstore() {
         let tmp = temp_dir();
         let store = MemBlockStore::new(tmp);
@@ -718,7 +718,7 @@ mod tests {
         assert_eq!(get.await.unwrap(), None);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_mem_blockstore_list() {
         let tmp = temp_dir();
         let mem_store = MemBlockStore::new(tmp);
@@ -741,7 +741,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn test_mem_datastore() {
         let tmp = temp_dir();
         let store = MemDataStore::new(tmp);

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -518,7 +518,8 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
 
         let data_store = &self.data_store;
         let key = ipns.to_owned();
-        let bytes = data_store.get(Column::Ipns, key.as_bytes()).await?;
+        // FIXME: needless vec<u8> creation
+        let bytes = data_store.get(Column::Ipns, &key.to_bytes()[..]).await?;
         match bytes {
             Some(ref bytes) => {
                 let string = String::from_utf8_lossy(bytes);
@@ -533,14 +534,19 @@ impl<TRepoTypes: RepoTypes> Repo<TRepoTypes> {
     pub async fn put_ipns(&self, ipns: &PeerId, path: &IpfsPath) -> Result<(), Error> {
         let string = path.to_string();
         let value = string.as_bytes();
+        // FIXME: needless vec<u8> creation
         self.data_store
-            .put(Column::Ipns, ipns.as_bytes(), value)
+            .put(Column::Ipns, &ipns.to_bytes()[..], value)
             .await
     }
 
     /// Remove an ipld path from the datastore.
     pub async fn remove_ipns(&self, ipns: &PeerId) -> Result<(), Error> {
-        self.data_store.remove(Column::Ipns, ipns.as_bytes()).await
+        // FIXME: us needing to clone the peerid is wasteful to pass it as a reference only to be
+        // cloned again
+        self.data_store
+            .remove(Column::Ipns, &ipns.to_bytes()[..])
+            .await
     }
 
     /// Inserts a direct pin for a `Cid`.

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -429,7 +429,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn subscription_basics() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -441,7 +441,7 @@ mod tests {
         assert_eq!(s3.await.unwrap(), 10);
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn subscription_cancelled_on_dropping_registry() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -449,7 +449,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn subscription_cancelled_on_shutdown() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -457,7 +457,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn new_subscriptions_cancelled_after_shutdown() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         registry.shutdown();
@@ -465,7 +465,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn dropping_subscription_future_after_registering() {
         use std::time::Duration;
         use tokio::time::timeout;
@@ -488,12 +488,12 @@ mod tests {
 
     // this test is designed to verify that the subscription registry is working properly
     // and doesn't break even under extreme conditions
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     #[ignore]
     async fn subscription_stress_test() {
         use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
         use std::time::Duration;
-        use tokio::{task, time::delay_for};
+        use tokio::{task, time::sleep};
 
         // optional
         tracing_subscriber::fmt::init();
@@ -527,7 +527,7 @@ mod tests {
             let (mut kind, mut count);
 
             loop {
-                delay_for(Duration::from_millis(CREATE_WAIT_TIME)).await;
+                sleep(Duration::from_millis(CREATE_WAIT_TIME)).await;
 
                 // the id of the object that will gain subscriptions
                 kind = rng_clone.gen_range(0, KIND_COUNT);
@@ -553,7 +553,7 @@ mod tests {
             let (mut kinds, mut count);
 
             loop {
-                delay_for(Duration::from_millis(FINISH_WAIT_TIME)).await;
+                sleep(Duration::from_millis(FINISH_WAIT_TIME)).await;
 
                 kinds = reg_clone
                     .subscriptions
@@ -576,7 +576,7 @@ mod tests {
             let (mut count, mut idx);
 
             loop {
-                delay_for(Duration::from_millis(CANCEL_WAIT_TIME)).await;
+                sleep(Duration::from_millis(CANCEL_WAIT_TIME)).await;
 
                 let subs_unlocked = &mut *subs.lock().unwrap();
                 count = rng.gen_range(0, subs_unlocked.len());

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -429,7 +429,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn subscription_basics() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -441,7 +441,7 @@ mod tests {
         assert_eq!(s3.await.unwrap(), 10);
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn subscription_cancelled_on_dropping_registry() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -449,7 +449,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn subscription_cancelled_on_shutdown() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         let s1 = registry.create_subscription(0.into(), None);
@@ -457,7 +457,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn new_subscriptions_cancelled_after_shutdown() {
         let registry = SubscriptionRegistry::<u32, ()>::default();
         registry.shutdown();
@@ -465,7 +465,7 @@ mod tests {
         assert_eq!(s1.await, Err(SubscriptionErr::Cancelled));
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn dropping_subscription_future_after_registering() {
         use std::time::Duration;
         use tokio::time::timeout;
@@ -488,7 +488,7 @@ mod tests {
 
     // this test is designed to verify that the subscription registry is working properly
     // and doesn't break even under extreme conditions
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     #[ignore]
     async fn subscription_stress_test() {
         use rand::{seq::SliceRandom, Rng};

--- a/tests/bitswap.rs
+++ b/tests/bitswap.rs
@@ -8,7 +8,7 @@ mod common;
 use common::{spawn_nodes, Topology};
 
 // Ensure that the Bitswap object doesn't leak.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn check_bitswap_cleanups() {
     // create a few nodes and connect the first one to others
     let mut nodes = spawn_nodes(3, Topology::Star).await;
@@ -41,7 +41,7 @@ async fn check_bitswap_cleanups() {
 // testing the bitswap protocol (though it would be advised to uncomment
 // the tracing_subscriber for stress-testing purposes)
 #[ignore]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn bitswap_stress_test() {
     fn filter(i: usize) -> bool {
         i % 2 == 0

--- a/tests/bitswap.rs
+++ b/tests/bitswap.rs
@@ -8,7 +8,7 @@ mod common;
 use common::{spawn_nodes, Topology};
 
 // Ensure that the Bitswap object doesn't leak.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn check_bitswap_cleanups() {
     // create a few nodes and connect the first one to others
     let mut nodes = spawn_nodes(3, Topology::Star).await;
@@ -19,7 +19,7 @@ async fn check_bitswap_cleanups() {
     // last node says goodbye; check the number of bitswap peers
     if let Some(node) = nodes.pop() {
         node.shutdown().await;
-        time::delay_for(Duration::from_millis(200)).await;
+        time::sleep(Duration::from_millis(200)).await;
     }
 
     let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
@@ -28,7 +28,7 @@ async fn check_bitswap_cleanups() {
     // another node says goodbye; check the number of bitswap peers
     if let Some(node) = nodes.pop() {
         node.shutdown().await;
-        time::delay_for(Duration::from_millis(200)).await;
+        time::sleep(Duration::from_millis(200)).await;
     }
 
     let bitswap_peers = nodes[0].get_bitswap_peers().await.unwrap();
@@ -41,7 +41,7 @@ async fn check_bitswap_cleanups() {
 // testing the bitswap protocol (though it would be advised to uncomment
 // the tracing_subscriber for stress-testing purposes)
 #[ignore]
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn bitswap_stress_test() {
     fn filter(i: usize) -> bool {
         i % 2 == 0

--- a/tests/block_exchange.rs
+++ b/tests/block_exchange.rs
@@ -15,7 +15,7 @@ fn create_block() -> Block {
 }
 
 // verify that a put block can be received via get_block and the data matches
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn two_node_put_get() {
     let nodes = spawn_nodes(2, Topology::Line).await;
     let block = create_block();
@@ -30,7 +30,7 @@ async fn two_node_put_get() {
 }
 
 // check that a long line of nodes still works with get_block
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 #[ignore]
 async fn long_get_block() {
     // this number could be higher, but it starts hanging above ~24

--- a/tests/block_exchange.rs
+++ b/tests/block_exchange.rs
@@ -31,6 +31,7 @@ async fn two_node_put_get() {
 
 // check that a long line of nodes still works with get_block
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[ignore]
 async fn long_get_block() {
     // this number could be higher, but it starts hanging above ~24
     const N: usize = 10;

--- a/tests/block_exchange.rs
+++ b/tests/block_exchange.rs
@@ -15,7 +15,7 @@ fn create_block() -> Block {
 }
 
 // verify that a put block can be received via get_block and the data matches
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn two_node_put_get() {
     let nodes = spawn_nodes(2, Topology::Line).await;
     let block = create_block();
@@ -30,7 +30,7 @@ async fn two_node_put_get() {
 }
 
 // check that a long line of nodes still works with get_block
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn long_get_block() {
     // this number could be higher, but it starts hanging above ~24
     const N: usize = 10;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -68,7 +68,7 @@ mod tests {
 
     const N: usize = 5;
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn check_topology_line() {
         let nodes = spawn_nodes(N, Topology::Line).await;
 
@@ -81,7 +81,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn check_topology_ring() {
         let nodes = spawn_nodes(N, Topology::Ring).await;
 
@@ -90,7 +90,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn check_topology_mesh() {
         let nodes = spawn_nodes(N, Topology::Mesh).await;
 
@@ -99,7 +99,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+    #[tokio::test]
     async fn check_topology_star() {
         let nodes = spawn_nodes(N, Topology::Star).await;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -68,7 +68,7 @@ mod tests {
 
     const N: usize = 5;
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_topology_line() {
         let nodes = spawn_nodes(N, Topology::Line).await;
 
@@ -81,7 +81,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_topology_ring() {
         let nodes = spawn_nodes(N, Topology::Ring).await;
 
@@ -90,7 +90,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_topology_mesh() {
         let nodes = spawn_nodes(N, Topology::Mesh).await;
 
@@ -99,7 +99,7 @@ mod tests {
         }
     }
 
-    #[tokio::test(max_threads = 1)]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn check_topology_star() {
         let nodes = spawn_nodes(N, Topology::Star).await;
 

--- a/tests/connectivity.rs
+++ b/tests/connectivity.rs
@@ -11,7 +11,7 @@ use common::interop::ForeignNode;
 const TIMEOUT: Duration = Duration::from_secs(5);
 
 // Make sure two instances of ipfs can be connected by `Multiaddr`.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_two_nodes_by_addr() {
     let node_a = Node::new("a").await;
 
@@ -27,7 +27,7 @@ async fn connect_two_nodes_by_addr() {
 }
 
 // Make sure only a `Multiaddr` with `/p2p/` can be used to connect.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: MissingProtocolP2p")]
 async fn dont_connect_without_p2p() {
     let node_a = Node::new("a").await;
@@ -45,7 +45,7 @@ async fn dont_connect_without_p2p() {
 
 // Make sure two instances of ipfs can be connected by `PeerId`.
 #[ignore = "connecting just by PeerId is not currently supported"]
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_two_nodes_by_peer_id() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;
@@ -63,7 +63,7 @@ async fn connect_two_nodes_by_peer_id() {
 }
 
 // Ensure that duplicate connection attempts don't cause hangs.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_duplicate_multiaddr() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;
@@ -79,7 +79,7 @@ async fn connect_duplicate_multiaddr() {
 
 // More complicated one to the above; first node will have two listening addresses and the second
 // one should dial both of the addresses, resulting in two connections.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_two_nodes_with_two_connections_doesnt_panic() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;

--- a/tests/connectivity.rs
+++ b/tests/connectivity.rs
@@ -11,7 +11,7 @@ use common::interop::ForeignNode;
 const TIMEOUT: Duration = Duration::from_secs(5);
 
 // Make sure two instances of ipfs can be connected by `Multiaddr`.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn connect_two_nodes_by_addr() {
     let node_a = Node::new("a").await;
 
@@ -27,7 +27,7 @@ async fn connect_two_nodes_by_addr() {
 }
 
 // Make sure only a `Multiaddr` with `/p2p/` can be used to connect.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 #[should_panic(expected = "called `Result::unwrap()` on an `Err` value: MissingProtocolP2p")]
 async fn dont_connect_without_p2p() {
     let node_a = Node::new("a").await;
@@ -45,7 +45,7 @@ async fn dont_connect_without_p2p() {
 
 // Make sure two instances of ipfs can be connected by `PeerId`.
 #[ignore = "connecting just by PeerId is not currently supported"]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn connect_two_nodes_by_peer_id() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;
@@ -63,7 +63,7 @@ async fn connect_two_nodes_by_peer_id() {
 }
 
 // Ensure that duplicate connection attempts don't cause hangs.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn connect_duplicate_multiaddr() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;
@@ -79,7 +79,7 @@ async fn connect_duplicate_multiaddr() {
 
 // More complicated one to the above; first node will have two listening addresses and the second
 // one should dial both of the addresses, resulting in two connections.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn connect_two_nodes_with_two_connections_doesnt_panic() {
     let node_a = Node::new("a").await;
     let node_b = Node::new("b").await;

--- a/tests/connectivity.rs
+++ b/tests/connectivity.rs
@@ -51,7 +51,7 @@ async fn connect_two_nodes_by_peer_id() {
     let node_b = Node::new("b").await;
 
     node_a
-        .add_peer(node_b.id.clone(), node_b.addrs[0].clone())
+        .add_peer(node_b.id, node_b.addrs[0].clone())
         .await
         .unwrap();
     let b_id_multiaddr: Multiaddr = format!("/p2p/{}", &node_b.id).parse().unwrap();
@@ -93,7 +93,7 @@ async fn connect_two_nodes_with_two_connections_doesnt_panic() {
     assert_eq!(addresses.len(), 2);
 
     for mut addr in addresses.into_iter() {
-        addr.push(Protocol::P2p(node_a.id.clone().into()));
+        addr.push(Protocol::P2p(node_a.id.into()));
 
         timeout(TIMEOUT, node_b.connect(addr))
             .await

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -22,10 +22,10 @@ async fn find_peer_local() {
 
     // while nodes[0] is connected to nodes[1], they know each
     // other's addresses and can find them without using the DHT
-    let mut found_addrs = nodes[0].find_peer(nodes[1].id.clone()).await.unwrap();
+    let mut found_addrs = nodes[0].find_peer(nodes[1].id).await.unwrap();
 
     for addr in &mut found_addrs {
-        addr.push(Protocol::P2p(nodes[1].id.clone().into()));
+        addr.push(Protocol::P2p(nodes[1].id.into()));
         assert!(nodes[1].addrs.contains(addr));
     }
 }
@@ -42,12 +42,12 @@ async fn spawn_bootstrapped_nodes(n: usize) -> (Vec<Node>, Option<ForeignNode>) 
     // they don't have a chance to form the full picture in the DHT
     for i in 0..n {
         let (next_id, next_addr) = if i < n - 1 {
-            (nodes[i + 1].id.clone(), nodes[i + 1].addrs[0].clone())
+            (nodes[i + 1].id, nodes[i + 1].addrs[0].clone())
         } else {
             // the last node in the chain also needs to know some address
             // in order to bootstrap, so give it its neighbour's information
             // and then bootstrap it as well
-            (nodes[n - 2].id.clone(), nodes[n - 2].addrs[0].clone())
+            (nodes[n - 2].id, nodes[n - 2].addrs[0].clone())
         };
 
         nodes[i].add_peer(next_id, next_addr).await.unwrap();
@@ -80,13 +80,13 @@ async fn spawn_bootstrapped_nodes(n: usize) -> (Vec<Node>, Option<ForeignNode>) 
     for i in 0..(n - 1) {
         let (next_id, next_addr) = if i == n / 2 - 1 || i == n / 2 {
             println!("telling rust node {} about the foreign node", i);
-            (foreign_node.id.clone(), foreign_node.addrs[0].clone())
+            (foreign_node.id, foreign_node.addrs[0].clone())
         } else if i < n / 2 {
             println!("telling rust node {} about rust node {}", i, i + 1);
-            (nodes[i + 1].id.clone(), nodes[i + 1].addrs[0].clone())
+            (nodes[i + 1].id, nodes[i + 1].addrs[0].clone())
         } else {
             println!("telling rust node {} about rust node {}", i, i - 1);
-            (nodes[i - 1].id.clone(), nodes[i - 1].addrs[0].clone())
+            (nodes[i - 1].id, nodes[i - 1].addrs[0].clone())
         };
 
         nodes[i].add_peer(next_id, next_addr).await.unwrap();
@@ -112,10 +112,7 @@ async fn dht_find_peer() {
     // node 0 now tries to find the address of the very last node in the
     // chain; the chain should be long enough for it not to automatically
     // be connected to it after the bootstrap
-    let found_addrs = nodes[0]
-        .find_peer(nodes[last_index].id.clone())
-        .await
-        .unwrap();
+    let found_addrs = nodes[0].find_peer(nodes[last_index].id).await.unwrap();
 
     let to_be_found = strip_peer_id(nodes[last_index].addrs[0].clone());
     assert_eq!(found_addrs, vec![to_be_found]);
@@ -127,11 +124,7 @@ async fn dht_get_closest_peers() {
     let (nodes, _foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;
 
     assert_eq!(
-        nodes[0]
-            .get_closest_peers(nodes[0].id.clone())
-            .await
-            .unwrap()
-            .len(),
+        nodes[0].get_closest_peers(nodes[0].id).await.unwrap().len(),
         CHAIN_LEN - 1
     );
 }
@@ -179,7 +172,7 @@ async fn dht_providing() {
         .get_providers(cid)
         .await
         .unwrap()
-        .contains(&nodes[last_index].id.clone()));
+        .contains(&nodes[last_index].id));
 }
 
 /// Check if Ipfs::{get, put} does its job.

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -15,7 +15,7 @@ fn strip_peer_id(addr: Multiaddr) -> Multiaddr {
 }
 
 /// Check if `Ipfs::find_peer` works without DHT involvement.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn find_peer_local() {
     let nodes = spawn_nodes(2, Topology::None).await;
     nodes[0].connect(nodes[1].addrs[0].clone()).await.unwrap();
@@ -101,7 +101,7 @@ async fn spawn_bootstrapped_nodes(n: usize) -> (Vec<Node>, Option<ForeignNode>) 
 }
 
 /// Check if `Ipfs::find_peer` works using DHT.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn dht_find_peer() {
     // works for numbers >=2, though 2 would essentially just
     // be the same as find_peer_local, so it should be higher
@@ -118,7 +118,7 @@ async fn dht_find_peer() {
     assert_eq!(found_addrs, vec![to_be_found]);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn dht_get_closest_peers() {
     const CHAIN_LEN: usize = 10;
     let (nodes, _foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;
@@ -130,7 +130,7 @@ async fn dht_get_closest_peers() {
 }
 
 #[ignore = "targets an actual bootstrapper, so random failures can happen"]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn dht_popular_content_discovery() {
     let peer = Node::new("a").await;
 
@@ -147,7 +147,7 @@ async fn dht_popular_content_discovery() {
 }
 
 /// Check if Ipfs::{get_providers, provide} does its job.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn dht_providing() {
     const CHAIN_LEN: usize = 10;
     let (nodes, foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;
@@ -176,7 +176,7 @@ async fn dht_providing() {
 }
 
 /// Check if Ipfs::{get, put} does its job.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn dht_get_put() {
     const CHAIN_LEN: usize = 10;
     let (nodes, foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;

--- a/tests/kademlia.rs
+++ b/tests/kademlia.rs
@@ -15,7 +15,7 @@ fn strip_peer_id(addr: Multiaddr) -> Multiaddr {
 }
 
 /// Check if `Ipfs::find_peer` works without DHT involvement.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn find_peer_local() {
     let nodes = spawn_nodes(2, Topology::None).await;
     nodes[0].connect(nodes[1].addrs[0].clone()).await.unwrap();
@@ -101,7 +101,7 @@ async fn spawn_bootstrapped_nodes(n: usize) -> (Vec<Node>, Option<ForeignNode>) 
 }
 
 /// Check if `Ipfs::find_peer` works using DHT.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_find_peer() {
     // works for numbers >=2, though 2 would essentially just
     // be the same as find_peer_local, so it should be higher
@@ -121,7 +121,7 @@ async fn dht_find_peer() {
     assert_eq!(found_addrs, vec![to_be_found]);
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_get_closest_peers() {
     const CHAIN_LEN: usize = 10;
     let (nodes, _foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;
@@ -137,7 +137,7 @@ async fn dht_get_closest_peers() {
 }
 
 #[ignore = "targets an actual bootstrapper, so random failures can happen"]
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_popular_content_discovery() {
     let peer = Node::new("a").await;
 
@@ -154,7 +154,7 @@ async fn dht_popular_content_discovery() {
 }
 
 /// Check if Ipfs::{get_providers, provide} does its job.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_providing() {
     const CHAIN_LEN: usize = 10;
     let (nodes, foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;
@@ -183,7 +183,7 @@ async fn dht_providing() {
 }
 
 /// Check if Ipfs::{get, put} does its job.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn dht_get_put() {
     const CHAIN_LEN: usize = 10;
     let (nodes, foreign_node) = spawn_bootstrapped_nodes(CHAIN_LEN).await;

--- a/tests/listening_addresses.rs
+++ b/tests/listening_addresses.rs
@@ -1,4 +1,4 @@
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn multiple_consecutive_ephemeral_listening_addresses() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -12,7 +12,7 @@ async fn multiple_consecutive_ephemeral_listening_addresses() {
     assert_ne!(first, second);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -41,7 +41,7 @@ async fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 #[cfg(not(target_os = "macos"))]
 async fn multiple_concurrent_ephemeral_listening_addresses_on_different_ip() {
     let node = ipfs::Node::new("test_node").await;
@@ -59,7 +59,7 @@ async fn multiple_concurrent_ephemeral_listening_addresses_on_different_ip() {
     second.unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn adding_unspecified_addr_resolves_with_first() {
     let node = ipfs::Node::new("test_node").await;
     // there is no test in trying to match this with others as ... that would be quite
@@ -69,7 +69,7 @@ async fn adding_unspecified_addr_resolves_with_first() {
         .unwrap();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn listening_for_multiple_unspecified_addresses() {
     let node = ipfs::Node::new("test_node").await;
     // there is no test in trying to match this with others as ... that would be quite
@@ -93,7 +93,7 @@ async fn listening_for_multiple_unspecified_addresses() {
     );
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn remove_listening_address() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -117,7 +117,7 @@ fn remove_listening_address_before_completing() {
     // "immediatedly".
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn pre_configured_listening_addrs() {
     use ipfs::{IpfsOptions, MultiaddrWithPeerId, MultiaddrWithoutPeerId, Node};
     use libp2p::Multiaddr;

--- a/tests/listening_addresses.rs
+++ b/tests/listening_addresses.rs
@@ -1,4 +1,4 @@
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn multiple_consecutive_ephemeral_listening_addresses() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -12,7 +12,7 @@ async fn multiple_consecutive_ephemeral_listening_addresses() {
     assert_ne!(first, second);
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -41,7 +41,7 @@ async fn multiple_concurrent_ephemeral_listening_addresses_on_same_ip() {
     );
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[cfg(not(target_os = "macos"))]
 async fn multiple_concurrent_ephemeral_listening_addresses_on_different_ip() {
     let node = ipfs::Node::new("test_node").await;
@@ -59,7 +59,7 @@ async fn multiple_concurrent_ephemeral_listening_addresses_on_different_ip() {
     second.unwrap();
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn adding_unspecified_addr_resolves_with_first() {
     let node = ipfs::Node::new("test_node").await;
     // there is no test in trying to match this with others as ... that would be quite
@@ -69,7 +69,7 @@ async fn adding_unspecified_addr_resolves_with_first() {
         .unwrap();
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn listening_for_multiple_unspecified_addresses() {
     let node = ipfs::Node::new("test_node").await;
     // there is no test in trying to match this with others as ... that would be quite
@@ -93,7 +93,7 @@ async fn listening_for_multiple_unspecified_addresses() {
     );
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn remove_listening_address() {
     let node = ipfs::Node::new("test_node").await;
 
@@ -117,7 +117,7 @@ fn remove_listening_address_before_completing() {
     // "immediatedly".
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn pre_configured_listening_addrs() {
     use ipfs::{IpfsOptions, MultiaddrWithPeerId, MultiaddrWithoutPeerId, Node};
     use libp2p::Multiaddr;

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -7,14 +7,14 @@ use tokio::time::timeout;
 mod common;
 use common::{spawn_nodes, Topology};
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn subscribe_only_once() {
     let a = Node::new("test_node").await;
     let _stream = a.pubsub_subscribe("some_topic".into()).await.unwrap();
     a.pubsub_subscribe("some_topic".into()).await.unwrap_err();
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn resubscribe_after_unsubscribe() {
     let a = Node::new("test_node").await;
 
@@ -26,7 +26,7 @@ async fn resubscribe_after_unsubscribe() {
     drop(a.pubsub_subscribe("topic".into()).await.unwrap());
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn unsubscribe_via_drop() {
     let a = Node::new("test_node").await;
 
@@ -39,7 +39,7 @@ async fn unsubscribe_via_drop() {
     assert_eq!(a.pubsub_subscribed().await.unwrap(), empty);
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn can_publish_without_subscribing() {
     let a = Node::new("test_node").await;
     a.pubsub_publish("topic".into(), b"foobar".to_vec())
@@ -47,7 +47,7 @@ async fn can_publish_without_subscribing() {
         .unwrap()
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 #[allow(clippy::mutable_key_type)] // clippy doesn't like Vec inside HashSet
 async fn publish_between_two_nodes() {
     use futures::stream::StreamExt;
@@ -140,7 +140,7 @@ async fn publish_between_two_nodes() {
 }
 
 #[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 #[ignore = "doesn't work yet"]
 async fn pubsub_interop() {
     use common::interop::{api_call, ForeignNode};

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -7,14 +7,14 @@ use tokio::time::timeout;
 mod common;
 use common::{spawn_nodes, Topology};
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn subscribe_only_once() {
     let a = Node::new("test_node").await;
     let _stream = a.pubsub_subscribe("some_topic".into()).await.unwrap();
     a.pubsub_subscribe("some_topic".into()).await.unwrap_err();
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn resubscribe_after_unsubscribe() {
     let a = Node::new("test_node").await;
 
@@ -26,7 +26,7 @@ async fn resubscribe_after_unsubscribe() {
     drop(a.pubsub_subscribe("topic".into()).await.unwrap());
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn unsubscribe_via_drop() {
     let a = Node::new("test_node").await;
 
@@ -39,7 +39,7 @@ async fn unsubscribe_via_drop() {
     assert_eq!(a.pubsub_subscribed().await.unwrap(), empty);
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn can_publish_without_subscribing() {
     let a = Node::new("test_node").await;
     a.pubsub_publish("topic".into(), b"foobar".to_vec())
@@ -47,7 +47,7 @@ async fn can_publish_without_subscribing() {
         .unwrap()
 }
 
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[allow(clippy::mutable_key_type)] // clippy doesn't like Vec inside HashSet
 async fn publish_between_two_nodes() {
     use futures::stream::StreamExt;
@@ -140,7 +140,7 @@ async fn publish_between_two_nodes() {
 }
 
 #[cfg(any(feature = "test_go_interop", feature = "test_js_interop"))]
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 #[ignore = "doesn't work yet"]
 async fn pubsub_interop() {
     use common::interop::{api_call, ForeignNode};

--- a/tests/pubsub.rs
+++ b/tests/pubsub.rs
@@ -103,7 +103,7 @@ async fn publish_between_two_nodes() {
     ]
     .iter()
     .cloned()
-    .map(|(topics, id, data)| (topics.to_vec(), id.clone(), data.to_vec()))
+    .map(|(topics, id, data)| (topics.to_vec(), *id, data.to_vec()))
     .collect::<HashSet<_>>();
 
     for st in &mut [b_msgs.by_ref(), a_msgs.by_ref()] {

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -51,7 +51,7 @@ async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) 
 }
 
 /// Check if canceling a Cid affects the wantlist.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test]
 async fn wantlist_cancellation() {
     tracing_subscriber::fmt::init();
 

--- a/tests/wantlist_and_cancellation.rs
+++ b/tests/wantlist_and_cancellation.rs
@@ -4,7 +4,7 @@ use futures::future::{AbortHandle, Abortable};
 use ipfs::Node;
 use tokio::{
     task,
-    time::{delay_for, timeout},
+    time::{sleep, timeout},
 };
 
 use std::{
@@ -33,7 +33,7 @@ where
         if check(future().await) {
             return Ok(());
         }
-        delay_for(Duration::from_millis(100)).await;
+        sleep(Duration::from_millis(100)).await;
         elapsed = started.elapsed();
     }
 }
@@ -51,7 +51,7 @@ async fn check_cid_subscriptions(ipfs: &Node, cid: &Cid, expected_count: usize) 
 }
 
 /// Check if canceling a Cid affects the wantlist.
-#[tokio::test(max_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn wantlist_cancellation() {
     tracing_subscriber::fmt::init();
 


### PR DESCRIPTION
Rebased the #431 work on top of the latest master. This PR will leave:

- mdns commented out
- domain a git dependency pending a release or migration to trust-dns following upcoming changes in libp2p-dns