### PR TITLE
Fix multinode test spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * feat(http): create `Profile` abstraction [#421]
 * feat: `sled` pinstore [#439], [#442], [#444]
 * chore: update a lot of dependencies including libp2p, tokio, warp [#446]
+* fix: rename spans (part of [#453])
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
@@ -15,6 +16,7 @@
 [#442]: https://github.com/rs-ipfs/rust-ipfs/pull/442
 [#444]: https://github.com/rs-ipfs/rust-ipfs/pull/444
 [#446]: https://github.com/rs-ipfs/rust-ipfs/pull/446
+[#453]: https://github.com/rs-ipfs/rust-ipfs/pull/453
 
 # 0.2.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -363,14 +363,14 @@ impl<Types: IpfsTypes> UninitializedIpfs<Types> {
         // the "current" span which is not entered but the awaited futures are instrumented with it
         let init_span = tracing::trace_span!(parent: &root_span, "init");
 
-        // stored in the Ipfs, added on every method call
+        // stored in the Ipfs, instrumenting every method call
         let facade_span = tracing::trace_span!("facade");
 
         // stored in the executor given to libp2p, used to spawn at least the connections,
         // instrumenting each of those.
         let exec_span = tracing::trace_span!(parent: &root_span, "exec");
 
-        // stored in the IpfsFuture, the background task.
+        // instruments the IpfsFuture, the background task.
         let swarm_span = tracing::trace_span!(parent: &root_span, "swarm");
 
         repo.init().instrument(init_span.clone()).await?;

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -55,7 +55,7 @@ impl From<&IpfsOptions> for SwarmOptions {
 /// Creates a new IPFS swarm.
 pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     options: SwarmOptions,
-    swarm_span: Span,
+    span: Span,
     repo: Arc<Repo<TIpfsTypes>>,
 ) -> io::Result<TSwarm<TIpfsTypes>> {
     let peer_id = options.peer_id;
@@ -68,7 +68,7 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
 
     // Create a Swarm
     let swarm = libp2p::swarm::SwarmBuilder::new(transport, behaviour, peer_id)
-        .executor(Box::new(SpannedExecutor(swarm_span)))
+        .executor(Box::new(SpannedExecutor(span)))
         .build();
 
     Ok(swarm)

--- a/src/repo/fs/pinstore.rs
+++ b/src/repo/fs/pinstore.rs
@@ -13,7 +13,6 @@ use tokio::fs;
 use tokio::sync::Semaphore;
 use tokio_stream::{empty, wrappers::ReadDirStream, StreamExt};
 use tokio_util::either::Either;
-use tracing_futures::Instrument;
 
 // PinStore is a trait from ipfs::repo implemented on FsDataStore defined at ipfs::repo::fs or
 // parent module.
@@ -318,7 +317,7 @@ impl PinStore for FsDataStore {
             }
         };
 
-        Box::pin(st.in_current_span())
+        Box::pin(st)
     }
 
     async fn query(


### PR DESCRIPTION
This PR changes how the spans are set up from IpfsOptions and in UninitializedIpfs. While debugging the now ignored test (see #450) I found that the spans were configured wrong and thus none of the multiple nodes created by `spawn_nodes` could be differentiated.

This also renames the spans to more logical from the "$root" given at `IpfsOptions::span`:

`Span::current` => `$root:init`
`Span::current` => `$root:init:swarm`
`$root:swarm` => `$root:exec` (literally the executor libp2p spawns futures through)
`$root` => `$root:bg_task` => `$root:swarm` (background task)
`$root` => `$root:facade` (futures created through Ipfs::* methods)

Still very far from perfect, but perhaps a step into better direction.