### PR TITLE
Fix swarmapi tests and add more cases

### DIFF
--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -455,11 +455,8 @@ mod tests {
         Swarm::listen_on(&mut swarm1, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
         loop {
-            match swarm1.next_event().await {
-                SwarmEvent::NewListenAddr(_) => {
-                    break;
-                }
-                _ => {}
+            if let SwarmEvent::NewListenAddr(_) = swarm1.next_event().await {
+                break;
             }
         }
 
@@ -522,13 +519,10 @@ mod tests {
         let address;
 
         loop {
-            match swarm1.next_event().await {
-                SwarmEvent::NewListenAddr(addr) => {
-                    // wonder if there should be a timeout?
-                    address = addr;
-                    break;
-                }
-                _ => {}
+            if let SwarmEvent::NewListenAddr(addr) = swarm1.next_event().await {
+                // wonder if there should be a timeout?
+                address = addr;
+                break;
             }
         }
 
@@ -572,9 +566,8 @@ mod tests {
         let mut addresses = Vec::with_capacity(2);
 
         while addresses.len() < 2 {
-            match swarm1.next_event().await {
-                SwarmEvent::NewListenAddr(addr) => addresses.push(addr),
-                _ => {}
+            if let SwarmEvent::NewListenAddr(addr) = swarm1.next_event().await {
+                addresses.push(addr);
             }
         }
 

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -431,6 +431,10 @@ fn connection_point_addr(cp: &ConnectedPoint) -> &Multiaddr {
 mod tests {
     use super::*;
     use crate::p2p::transport::{build_transport, TTransport};
+    use futures::{
+        stream::{StreamExt, TryStreamExt},
+        TryFutureExt,
+    };
     use libp2p::identity::Keypair;
     use libp2p::swarm::SwarmEvent;
     use libp2p::{multiaddr::Protocol, multihash::Multihash, swarm::Swarm, swarm::SwarmBuilder};
@@ -483,7 +487,6 @@ mod tests {
                         // does it mean to connect to a peer? one way to look at it would be to
                         // make the peer a "pinned peer" or "friend" and to keep the connection
                         // alive at all costs. perhaps that is something for the next round.
-                        //
                         // another aspect would be to fail this future because there was no
                         // `inject_connected`, only `inject_connection_established`. taking that
                         // route would be good; it does however leave the special case of adding
@@ -501,9 +504,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wrong_peer_first_later_good() {
-        use futures::stream::{StreamExt, TryStreamExt};
-
+    async fn wrong_peerid() {
         let (peer1_id, trans) = mk_transport();
         let mut swarm1 = SwarmBuilder::new(trans, SwarmApi::default(), peer1_id)
             .executor(Box::new(ThreadLocalTokio))
@@ -517,28 +518,67 @@ mod tests {
         let peer3_id = Keypair::generate_ed25519().public().into_peer_id();
 
         Swarm::listen_on(&mut swarm1, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
+
+        let address;
+
+        loop {
+            match swarm1.next_event().await {
+                SwarmEvent::NewListenAddr(addr) => {
+                    // wonder if there should be a timeout?
+                    address = addr;
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        let mut fut = swarm2
+            .connect(
+                MultiaddrWithoutPeerId::try_from(address)
+                    .unwrap()
+                    .with(peer3_id),
+            )
+            .unwrap()
+            // remove the private type wrapper
+            .map_err(|e| e.into_inner());
+
+        loop {
+            tokio::select! {
+                _ = swarm1.next_event() => {},
+                _ = swarm2.next_event() => {},
+                res = &mut fut => {
+                    assert_eq!(res.unwrap_err(), Some("Pending connection: Invalid peer ID.".into()));
+                    return;
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn racy_connecting_attempts() {
+        let (peer1_id, trans) = mk_transport();
+        let mut swarm1 = SwarmBuilder::new(trans, SwarmApi::default(), peer1_id)
+            .executor(Box::new(ThreadLocalTokio))
+            .build();
+
+        let (peer2_id, trans) = mk_transport();
+        let mut swarm2 = SwarmBuilder::new(trans, SwarmApi::default(), peer2_id)
+            .executor(Box::new(ThreadLocalTokio))
+            .build();
+
+        Swarm::listen_on(&mut swarm1, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
         Swarm::listen_on(&mut swarm1, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
         let mut addresses = Vec::with_capacity(2);
 
         while addresses.len() < 2 {
-            tokio::select! {
-                evt = swarm1.next_event() => {
-                    match evt {
-                        SwarmEvent::NewListenAddr(addr) => addresses.push(addr),
-                        _ => {}
-                    }
-                }
-            };
+            match swarm1.next_event().await {
+                SwarmEvent::NewListenAddr(addr) => addresses.push(addr),
+                _ => {}
+            }
         }
 
-        println!("got addresses");
-
         let targets = (
-            // first one is with wrong peer_id
-            MultiaddrWithoutPeerId::try_from(addresses[0].clone())
-                .unwrap()
-                .with(peer3_id),
             MultiaddrWithoutPeerId::try_from(addresses[0].clone())
                 .unwrap()
                 .with(peer1_id),
@@ -548,15 +588,11 @@ mod tests {
         );
 
         let mut connections = futures::stream::FuturesOrdered::new();
-        // this should always fail, get to inject_dial_failure finishing the subscription with
-        // error.to_string()
-        connections.push(swarm2.connect(targets.0).unwrap());
-
         // these two should be attempted in parallel. since we know both of them work, and they are
         // given in this order, we know that in libp2p 0.34 only the first should win, however at
         // both should always be finished.
+        connections.push(swarm2.connect(targets.0).unwrap());
         connections.push(swarm2.connect(targets.1).unwrap());
-        connections.push(swarm2.connect(targets.2).unwrap());
         let ready = connections
             // turn the private error type into Option
             .map_err(|e| e.into_inner())
@@ -573,7 +609,6 @@ mod tests {
                     assert_eq!(
                         res,
                         vec![
-                            Err(Some("Pending connection: Invalid peer ID.".into())),
                             Ok(()),
                             Err(Some("finished connecting to another address".into()))
                         ]);
@@ -582,10 +617,6 @@ mod tests {
                 }
             }
         }
-
-        // most of this test case could be done just by exercising the NetworkBehaviour surface of
-        // SwarmApi. however it would also not break if libp2p ever starts to dial in parallel (the
-        // next version possibly).
     }
 
     fn mk_transport() -> (PeerId, TTransport) {

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -561,7 +561,7 @@ mod tests {
 
         let mut connections = futures::stream::FuturesOrdered::new();
         // these two should be attempted in parallel. since we know both of them work, and they are
-        // given in this order, we know that in libp2p 0.34 only the first should win, however at
+        // given in this order, we know that in libp2p 0.34 only the first should win, however
         // both should always be finished.
         connections.push(swarm2.connect(targets.0).unwrap());
         connections.push(swarm2.connect(targets.1).unwrap());

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -476,6 +476,19 @@ mod tests {
                         // this is currently a success even though the connection is never really
                         // established, the DummyProtocolsHandler doesn't do anything nor want the
                         // connection to be kept alive and thats it.
+                        //
+                        // it could be argued that this should be `Err("keepalive disconnected")`
+                        // or something and I'd agree, but I also agree this can be an `Ok(())`;
+                        // it's the sort of difficulty with the cli functionality in general: what
+                        // does it mean to connect to a peer? one way to look at it would be to
+                        // make the peer a "pinned peer" or "friend" and to keep the connection
+                        // alive at all costs. perhaps that is something for the next round.
+                        //
+                        // another aspect would be to fail this future because there was no
+                        // `inject_connected`, only `inject_connection_established`. taking that
+                        // route would be good; it does however leave the special case of adding
+                        // another connection, which does add even more complexity than it exists
+                        // at the present.
                         res.unwrap();
 
                         // just to confirm that there are no connections.
@@ -497,7 +510,8 @@ mod tests {
     use std::future::Future;
     use std::pin::Pin;
 
-    // can only be used from within tokio context.
+    // can only be used from within tokio context. this is required since otherwise libp2p-tcp will
+    // use tokio, but from a futures-executor threadpool, which is outside of tokio context.
     struct ThreadLocalTokio;
 
     impl libp2p::core::Executor for ThreadLocalTokio {

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -144,6 +144,9 @@ impl<T: Debug + Clone + PartialEq, E: Debug + Clone> SubscriptionRegistry<T, E> 
 
             #[cfg(debug_assertions)]
             if awoken == 0 {
+                // this assertion was originally added because we had quite a lot of trouble with
+                // the subscriptions and it still isn't perfect. if you hit these assertion please
+                // do report a bug.
                 let msg = format!(
                     "no subscriptions to be awoken! subs: {:?}; req_kind: {:?}",
                     related_subs, req_kind

--- a/src/subscription.rs
+++ b/src/subscription.rs
@@ -219,6 +219,16 @@ impl<E: Debug + PartialEq> fmt::Display for SubscriptionErr<E> {
 
 impl<E: Debug + PartialEq> std::error::Error for SubscriptionErr<E> {}
 
+impl<E: Debug + PartialEq> SubscriptionErr<E> {
+    pub fn into_inner(self) -> Option<E> {
+        use SubscriptionErr::*;
+        match self {
+            Cancelled => None,
+            Failed(e) => Some(e),
+        }
+    }
+}
+
 /// Represents a request for a resource at different stages of its lifetime.
 pub enum Subscription<T, E> {
     /// A finished `Subscription` containing the desired `TRes` value.


### PR DESCRIPTION
This PR fixes the swarm tests and yet another swarmapi related panic reachable through only the swarmapi "unit tests". It also adds a two new cases which would had been quite ugly add to under `tests/`. 

First of all, the test had been broken long time ago in a rust-libp2p update when the listening address adding became asynchronous.

The additional panic exposed by now working test case comes from the `inject_connected` never arriving when only using SwarmApi as the only behaviour. It uses the DummyProtocolHandler which opens no streams and demands keepalive, the connection is immediatedly closed.

The additional test cases cover connecting to wrong peerid, and dialing multiple addresses when only first one succeeds, the second errors.