### PR TITLE
Migrate dnslink to trust-dns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,19 +668,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "domain"
-version = "0.5.3"
-source = "git+https://github.com/NLnetLabs/domain.git#0ddde30e716dc23bc07de53acc7377092e7e1204"
-dependencies = [
- "bytes",
- "futures",
- "libc",
- "rand 0.7.3",
- "smallvec",
- "tokio",
-]
-
-[[package]]
 name = "ed25519"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +695,18 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c5f0096a91d210159eceb2ff5e1c4da18388a170e1e3ce948aac9c8fdbbf595"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "fake-simd"
@@ -1069,6 +1068,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
+dependencies = [
+ "libc",
+ "match_cfg",
+ "winapi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,12 +1231,10 @@ dependencies = [
  "byteorder",
  "bytes",
  "cid",
- "domain",
  "either",
  "fs2",
  "futures",
  "hex-literal",
- "ipconfig",
  "ipfs-bitswap",
  "ipfs-unixfs",
  "libp2p",
@@ -1248,6 +1256,7 @@ dependencies = [
  "tracing",
  "tracing-futures",
  "tracing-subscriber",
+ "trust-dns-resolver",
  "void",
 ]
 
@@ -1642,6 +1651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
+
+[[package]]
 name = "lock_api"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1658,6 +1673,21 @@ checksum = "fcf3805d4480bb5b86070dcfeb9e2cb2ebc148adb753c5cca5f884d1d65a42b2"
 dependencies = [
  "cfg-if 0.1.10",
 ]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "match_cfg"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
 name = "matchers"
@@ -2221,6 +2251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quick-protobuf"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,6 +2427,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
+dependencies = [
+ "hostname",
+ "quick-error",
 ]
 
 [[package]]
@@ -2976,6 +3022,50 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trust-dns-proto"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98a0381b2864c2978db7f8e17c7b23cca5a3a5f99241076e13002261a8ecbabd"
+dependencies = [
+ "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "lazy_static",
+ "log",
+ "rand 0.8.2",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "trust-dns-resolver"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3072d18c10bd621cb00507d59cfab5517862285c353160366e37fbf4c74856e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "futures-util",
+ "ipconfig",
+ "lazy_static",
+ "log",
+ "lru-cache",
+ "parking_lot",
+ "resolv-conf",
+ "smallvec",
+ "thiserror",
+ "tokio",
+ "trust-dns-proto",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ipfs-bitswap = { version = "0.1", path = "bitswap" }
 byteorder = { default-features = false, version = "1.3" }
 bytes = { default-features = false, version = "1" }
 cid = { default-features = false, version = "0.5" }
-domain = { default-features = false, git = "https://github.com/NLnetLabs/domain.git", features = ["resolv", "bytes"] }
+trust-dns-resolver = "0.20"
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
@@ -46,10 +46,6 @@ void = { default-features = false, version = "1.0" }
 fs2 = "0.4.3"
 sled = "0.34"
 once_cell = "1.5.2"
-
-[target.'cfg(windows)'.dependencies]
-# required for DNS resolution
-ipconfig = { default-features = false, version = "0.2" }
 
 [build-dependencies]
 prost-build = { default-features = false, version = "0.7" }

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -74,22 +74,22 @@ pub async fn resolve(domain: &str) -> Result<IpfsPath, Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::resolve;
 
     #[tokio::test]
-    #[ignore]
-    async fn test_resolve1() {
+    async fn resolve_ipfs_io() {
+        tracing_subscriber::fmt::init();
         let res = resolve("ipfs.io").await.unwrap().to_string();
         assert_eq!(res, "/ipns/website.ipfs.io");
     }
 
     #[tokio::test]
-    #[ignore]
-    async fn test_resolve2() {
-        let res = resolve("website.ipfs.io").await.unwrap().to_string();
-        assert_eq!(
-            res,
-            "/ipfs/bafybeiayvrj27f65vbecspbnuavehcb3znvnt2strop2rfbczupudoizya"
+    async fn resolve_website_ipfs_io() {
+        let res = resolve("website.ipfs.io").await.unwrap();
+
+        assert!(
+            matches!(res.root(), crate::path::PathRoot::Ipld(_)),
+            "expected an /ipfs/cid path"
         );
     }
 }

--- a/src/ipns/dnslink.rs
+++ b/src/ipns/dnslink.rs
@@ -1,119 +1,75 @@
 use crate::error::Error;
 use crate::path::IpfsPath;
-use bytes::Bytes;
-use domain::base::iana::Rtype;
-use domain::base::{Dname, Question};
-use domain::rdata::rfc1035::Txt;
-use domain::resolv::{stub::Answer, StubResolver};
-use futures::future::{select_ok, SelectOk};
-use futures::pin_mut;
-use std::future::Future;
-use std::pin::Pin;
 use std::str::FromStr;
-use std::task::{Context, Poll};
-use std::{fmt, io};
-
-#[derive(Debug)]
-pub struct DnsLinkError(String);
-
-impl fmt::Display for DnsLinkError {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(fmt, "DNS error: {}", self.0)
-    }
-}
-
-impl std::error::Error for DnsLinkError {}
-
-type FutureAnswer = Pin<Box<dyn Future<Output = Result<Answer, io::Error>> + Send>>;
-
-pub struct DnsLinkFuture {
-    query: SelectOk<FutureAnswer>,
-}
-
-impl Future for DnsLinkFuture {
-    type Output = Result<IpfsPath, Error>;
-
-    fn poll(self: Pin<&mut Self>, context: &mut Context) -> Poll<Self::Output> {
-        let _self = self.get_mut();
-        loop {
-            let query = &mut _self.query;
-            pin_mut!(query);
-            match query.poll(context) {
-                Poll::Ready(Ok((answer, rest))) => {
-                    for record in answer.answer()?.limit_to::<Txt<_>>() {
-                        let txt = record?;
-                        let bytes: &[u8] = txt.data().as_flat_slice().unwrap_or(b"");
-                        let string = String::from_utf8_lossy(&bytes).to_string();
-                        if let Some(path) = string.strip_prefix("dnslink=") {
-                            let path = IpfsPath::from_str(path)?;
-                            return Poll::Ready(Ok(path));
-                        }
-                    }
-                    if !rest.is_empty() {
-                        _self.query = select_ok(rest);
-                    } else {
-                        return Poll::Ready(Err(
-                            DnsLinkError("no DNS records found".to_owned()).into()
-                        ));
-                    }
-                }
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(Err(e)) => return Poll::Ready(Err(DnsLinkError(e.to_string()).into())),
-            }
-        }
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
-fn create_resolver() -> Result<StubResolver, Error> {
-    Ok(StubResolver::default())
-}
-
-#[cfg(target_os = "windows")]
-fn create_resolver() -> Result<StubResolver, Error> {
-    use domain::resolv::stub::conf::ResolvConf;
-    use std::{collections::HashSet, io::Cursor};
-
-    let mut config = ResolvConf::new();
-    let mut name_servers = String::new();
-
-    let mut dns_servers = HashSet::new();
-    for adapter in ipconfig::get_adapters()? {
-        for dns in adapter.dns_servers() {
-            dns_servers.insert(dns.to_owned());
-        }
-    }
-
-    for dns in &dns_servers {
-        name_servers.push_str(&format!("nameserver {}\n", dns));
-    }
-
-    let mut name_servers = Cursor::new(name_servers.into_bytes());
-    config.parse(&mut name_servers)?;
-    config.finalize();
-
-    Ok(StubResolver::from_conf(config))
-}
+use tracing_futures::Instrument;
 
 pub async fn resolve(domain: &str) -> Result<IpfsPath, Error> {
-    let mut dnslink = "_dnslink.".to_string();
-    dnslink.push_str(domain);
-    let resolver = create_resolver()?;
+    use std::borrow::Cow;
+    use trust_dns_resolver::AsyncResolver;
 
-    let qname = Dname::<Bytes>::from_chars(domain.chars())?;
-    let question = Question::new_in(qname, Rtype::Txt);
-    let resolver1 = resolver.clone();
-    let query1 = Box::pin(async move { resolver1.query(question).await });
+    let span = tracing::trace_span!("dnslink", %domain);
 
-    let qname = Dname::<Bytes>::from_chars(dnslink.chars())?;
-    let question = Question::new_in(qname, Rtype::Txt);
-    let resolver2 = resolver;
-    let query2 = Box::pin(async move { resolver2.query(question).await });
+    async move {
+        // allow using non fqdn names (using the local search path suffices)
+        let searched = Some(Cow::Borrowed(domain));
 
-    Ok(DnsLinkFuture {
-        query: select_ok(vec![query1 as FutureAnswer, query2]),
+        let prefix = "_dnslink.";
+        let prefixed = if !domain.starts_with(prefix) {
+            let mut next = String::with_capacity(domain.len() + prefix.len());
+            next.push_str(prefix);
+            next.push_str(domain);
+            Some(Cow::Owned(next))
+        } else {
+            None
+        };
+
+        let searched = searched.into_iter().chain(prefixed.into_iter());
+
+        // FIXME: this uses caching trust-dns resolver even though it's discarded right away
+        // when trust-dns support lands in future libp2p-dns investigate if we could share one, no need
+        // to have multiple related caches.
+        let resolver = AsyncResolver::tokio_from_system_conf()?;
+
+        // previous implementation searched $domain and _dnslink.$domain concurrently. not sure did
+        // `domain` assume fqdn names or not, but local suffices were not being searched on windows at
+        // least. they are probably waste of time most of the time.
+        for domain in searched.into_iter() {
+            let res = match resolver.txt_lookup(&*domain).await {
+                Ok(res) => res,
+                Err(e) => {
+                    tracing::debug!("resolving dnslink of {:?} failed: {}", domain, e);
+                    continue;
+                }
+            };
+
+            let mut paths = res
+                .iter()
+                .flat_map(|txt| txt.iter())
+                .filter_map(|txt| {
+                    if txt.starts_with(b"dnslink=") {
+                        Some(&txt[b"dnslink=".len()..])
+                    } else {
+                        None
+                    }
+                })
+                .map(|suffix| {
+                    std::str::from_utf8(suffix)
+                        .map_err(Error::from)
+                        .and_then(|s| IpfsPath::from_str(s))
+                });
+
+            if let Some(Ok(x)) = paths.next() {
+                tracing::trace!("dnslink found for {:?}", domain);
+                return Ok(x);
+            }
+
+            tracing::trace!("zero TXT records found for {:?}", domain);
+        }
+
+        Err(anyhow::anyhow!("failed to resolve {:?}", domain))
     }
-    .await?)
+    .instrument(span)
+    .await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Ahead next version of libp2p-dns which will finally use trust-dns. Added FIXMEs and more importantly get rid of the windows specific ipconfig, custom future impl around selectok. This shouldn't really affect anything so I doubt this needs to be mentioned in changelog. The IPNS story is quite weak as it is.