### PR TITLE
fix(release 0.3.0: rewrite FsBlockStore.list; crate compiles as dependency again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * chore: update a lot of dependencies including libp2p, tokio, warp [#446]
 * fix: rename spans (part of [#453])
 * fix: connect using DialPeer instead of DialAddress [#454]
+* fix: crate compiles successfully as a dependency again [#464]
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
@@ -19,6 +20,7 @@
 [#446]: https://github.com/rs-ipfs/rust-ipfs/pull/446
 [#453]: https://github.com/rs-ipfs/rust-ipfs/pull/453
 [#454]: https://github.com/rs-ipfs/rust-ipfs/pull/454
+[#464]: https://github.com/rs-ipfs/rust-ipfs/pull/464
 
 # 0.2.1
 

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -355,43 +355,44 @@ impl BlockStore for FsBlockStore {
     }
 
     async fn list(&self) -> Result<Vec<Cid>, Error> {
-        use futures::future::{ready, Either};
-        use futures::stream::{empty, TryStreamExt};
+        use futures::future::Either;
+        use futures::stream::{empty, StreamExt};
         use tokio_stream::wrappers::ReadDirStream;
 
         let span = tracing::trace_span!("listing blocks");
 
         async move {
-            let stream = ReadDirStream::new(fs::read_dir(self.path.clone()).await?);
+            let mut stream = ReadDirStream::new(fs::read_dir(self.path.clone()).await?);
 
             // FIXME: written as a stream to make the Vec be BoxStream<'static, Cid>
-            let vec = stream
-                .and_then(|d| async move {
-                    // map over the shard directories
-                    Ok(if d.file_type().await?.is_dir() {
-                        Either::Left(ReadDirStream::new(fs::read_dir(d.path()).await?))
-                    } else {
-                        Either::Right(empty())
-                    })
-                })
-                // flatten each
-                .try_flatten()
-                // convert the paths ending in ".data" into cid
-                .try_filter_map(|d| {
+            let mut folders_to_list: Vec<
+                Either<ReadDirStream, futures::stream::Empty<std::io::Result<tokio::fs::DirEntry>>>,
+            > = Vec::new();
+            while let Some(d) = stream.next().await {
+                let d = d?;
+                let either = if d.file_type().await?.is_dir() {
+                    Either::Left(ReadDirStream::new(fs::read_dir(d.path()).await?))
+                } else {
+                    Either::Right(empty())
+                };
+                folders_to_list.push(either);
+            }
+            let mut cids: Vec<Cid> = Vec::new();
+            for mut folder in folders_to_list {
+                while let Some(d) = folder.next().await {
+                    let d = d?;
                     let name = d.file_name();
                     let path: &std::path::Path = name.as_ref();
 
-                    ready(if path.extension() != Some("data".as_ref()) {
-                        Ok(None)
-                    } else {
-                        let maybe_cid = filestem_to_block_cid(path.file_stem());
-                        Ok(maybe_cid)
-                    })
-                })
-                .try_collect::<Vec<_>>()
-                .await?;
+                    if path.extension() == Some("data".as_ref()) {
+                        if let Some(maybe_cid) = filestem_to_block_cid(path.file_stem()) {
+                            cids.push(maybe_cid);
+                        }
+                    }
+                }
+            }
 
-            Ok(vec)
+            Ok(cids)
         }
         .instrument(span)
         .await


### PR DESCRIPTION
This PR rewrites `FsBlockStore.list` using for and while let loops, which removes a compilation error when using the `ipfs` crate as a dependency from another project. See issue #458 for relevant discussion.

### Checklist (can be deleted from PR description once items are checked)

- [x] **New** code is “linted” i.e. code formatting via rustfmt and language idioms via clippy
- [x] There are no extraneous changes like formatting, line reordering, etc. Keep the patch sizes small!
- [ ] There are functional and/or unit tests written, and they are passing
- [x] There is suitable documentation. In our case, this means:
    - [x] Each command has a usage example and API specification
    - [x] Rustdoc tests are passing on all code-level comments
    - [ ] Differences between Rust’s IPFS implementation and the Go or JS implementations are explained - N/A?
- [x] Additions to CHANGELOG.md files
