### PR TITLE
In-memory reading from tar archives instead of extract to temp folder

### DIFF
--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -257,8 +257,8 @@ mod tests {
     use ipfs::{Block, Ipfs, IpfsTypes, Node};
     use multihash::Sha2_256;
     use std::convert::TryFrom;
-    use std::path::PathBuf;
     use std::io::Read;
+    use std::path::PathBuf;
 
     // Entry we'll use in expectations
     #[derive(Debug, PartialEq, Eq)]

--- a/http/src/v0/root_files.rs
+++ b/http/src/v0/root_files.rs
@@ -258,6 +258,7 @@ mod tests {
     use multihash::Sha2_256;
     use std::convert::TryFrom;
     use std::path::PathBuf;
+    use std::io::Read;
 
     // Entry we'll use in expectations
     #[derive(Debug, PartialEq, Eq)]
@@ -279,15 +280,11 @@ mod tests {
                     let path = entry.path()?.into();
                     let size = header.size()?;
 
-                    // writing to file is the only supported way to get the contents
-                    let tempdir = tempfile::tempdir()?;
-                    let temp_file = tempdir.path().join("temporary_file_for_testing.txt");
-                    entry.unpack(&temp_file)?;
-
-                    let bytes = std::fs::read(&temp_file);
-
-                    // regardless of read success let's prefer deleting the file
-                    std::fs::remove_file(&temp_file)?;
+                    // From https://github.com/alexcrichton/tar-rs/blob/0.4.35/src/entry.rs#L281
+                    // Preallocate some data but don't let ourselves get too crazy now.
+                    let cap = std::cmp::min(entry.size(), 128 * 1024);
+                    let mut v = Vec::with_capacity(cap as usize);
+                    let bytes = entry.read_to_end(&mut v).map(|_| v);
 
                     // and only later check if the read succeeded
                     Entry::File(path, size, bytes?)


### PR DESCRIPTION
Get rid of work with filesystem in fs-unrelated tests.

No more problems like https://github.com/rs-ipfs/rust-ipfs/issues/465 lead to tests failure.