### PR TITLE
Use hash_hasher in hashmaps/sets where the key is a Cid/Multihash #258

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * fix: rename spans (part of [#453])
 * fix: connect using DialPeer instead of DialAddress [#454]
 * fix: compilation error when used as a dependency [#470]
+* perf: use hash_hasher where the key is Cid [#467]
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
@@ -21,6 +22,7 @@
 [#453]: https://github.com/rs-ipfs/rust-ipfs/pull/453
 [#454]: https://github.com/rs-ipfs/rust-ipfs/pull/454
 [#470]: https://github.com/rs-ipfs/rust-ipfs/pull/470
+[#467]: https://github.com/rs-ipfs/rust-ipfs/pull/467
 
 # 0.2.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ cid = { default-features = false, version = "0.5" }
 trust-dns-resolver = "0.20"
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
-hash_hasher = { default-features = false, version = "2.0.3" } 
+hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.34" }
 multibase = { default-features = false, version = "0.8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ cid = { default-features = false, version = "0.5" }
 trust-dns-resolver = "0.20"
 either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
+hash_hasher = { default-features = false, version = "2.0.3" } 
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.34" }
 multibase = { default-features = false, version = "0.8" }
@@ -51,12 +52,17 @@ once_cell = "1.5.2"
 prost-build = { default-features = false, version = "0.7" }
 
 [dev-dependencies]
+criterion = { default-features = false, version = "0.3" }
 hex-literal = { default-features = false, version = "0.3" }
 sha2 = { default-features = false, version = "0.9" }
 tokio = { default-features = false, features = ["io-std", "io-util", "time"], version = "1" }
 tracing-subscriber = { default-features = false, features = ["fmt", "tracing-log", "ansi", "env-filter"], version = "0.2" }
 rand = { default-features = false, version = "0.8", features = ["std", "std_rng"] }
 tempfile = "3.1.0"
+
+[[bench]]
+name = "hashed-map-cid"
+harness = false
 
 [workspace]
 members = [ "bitswap", "http", "unixfs" ]

--- a/benches/hashed-map-cid.rs
+++ b/benches/hashed-map-cid.rs
@@ -22,7 +22,7 @@ fn insert_get<H: BuildHasher + Default>(cids: &Cids) {
 
     cids.0.iter().enumerate().for_each(|(_, c)| {
         for _ in 0..GETS_PER_INSERT {
-            h.get(&c).unwrap();
+            h.get(c).unwrap();
         }
     });
 }
@@ -51,11 +51,11 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     for c in cids {
         group.bench_with_input(BenchmarkId::new("HashMap", c.clone()), &c, |b, c| {
-            b.iter(|| insert_get::<RandomState>(&c));
+            b.iter(|| insert_get::<RandomState>(c));
         });
 
         group.bench_with_input(BenchmarkId::new("HashedMap", c.clone()), &c, |b, c| {
-            b.iter(|| insert_get::<HashBuildHasher>(&c));
+            b.iter(|| insert_get::<HashBuildHasher>(c));
         });
     }
 

--- a/benches/hashed-map-cid.rs
+++ b/benches/hashed-map-cid.rs
@@ -1,0 +1,66 @@
+use cid::Cid;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use hash_hasher::HashBuildHasher;
+use multihash::Sha2_256;
+use std::{
+    collections::{hash_map::RandomState, HashMap},
+    fmt::Formatter,
+    hash::BuildHasher,
+    vec::Vec,
+};
+
+#[derive(Debug, Clone)]
+struct Cids(Vec<Cid>);
+
+const GETS_PER_INSERT: usize = 10;
+
+fn insert_get<H: BuildHasher + Default>(cids: &Cids) {
+    let mut h = HashMap::<Cid, usize, H>::default();
+    cids.0.iter().enumerate().for_each(|(i, c)| {
+        h.insert(c.clone(), i);
+    });
+
+    cids.0.iter().enumerate().for_each(|(_, c)| {
+        for _ in 0..GETS_PER_INSERT {
+            h.get(&c).unwrap();
+        }
+    });
+}
+
+impl std::fmt::Display for Cids {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "[{} elems]", self.0.len())
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let sizes: Vec<usize> = vec![10000];
+    let cids: Vec<Cids> = sizes
+        .iter()
+        .map(|size| {
+            Cids(
+                (0..*size)
+                    .into_iter()
+                    .map(|i| Cid::new_v0(Sha2_256::digest(&i.to_be_bytes())).unwrap())
+                    .collect(),
+            )
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("hashed-map-cid");
+
+    for c in cids {
+        group.bench_with_input(BenchmarkId::new("HashMap", c.clone()), &c, |b, c| {
+            b.iter(|| insert_get::<RandomState>(&c));
+        });
+
+        group.bench_with_input(BenchmarkId::new("HashedMap", c.clone()), &c, |b, c| {
+            b.iter(|| insert_get::<HashBuildHasher>(&c));
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -14,7 +14,7 @@ prost-build = { default-features = false, version = "0.7" }
 cid = { default-features = false, version = "0.5" }
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
-hash_hasher = { default-features = false, version = "2.0.3" }
+hash_hasher = "2.0.3"
 libp2p-core = { default-features = false, version = "0.27" }
 libp2p-swarm = { default-features = false, version = "0.27" }
 multihash = { default-features = false, version = "0.11" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -14,6 +14,7 @@ prost-build = { default-features = false, version = "0.7" }
 cid = { default-features = false, version = "0.5" }
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
+hash_hasher = { default-features = false, version = "2.0.3" }
 libp2p-core = { default-features = false, version = "0.27" }
 libp2p-swarm = { default-features = false, version = "0.27" }
 multihash = { default-features = false, version = "0.11" }

--- a/bitswap/src/behaviour.rs
+++ b/bitswap/src/behaviour.rs
@@ -11,6 +11,7 @@ use crate::protocol::{BitswapConfig, MessageWrapper};
 use cid::Cid;
 use fnv::FnvHashSet;
 use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+use hash_hasher::HashedMap;
 use libp2p_core::{connection::ConnectionId, Multiaddr, PeerId};
 use libp2p_swarm::protocols_handler::{IntoProtocolsHandler, OneShotHandler, ProtocolsHandler};
 use libp2p_swarm::{
@@ -93,7 +94,7 @@ pub struct Bitswap {
     /// Ledger
     pub connected_peers: HashMap<PeerId, Ledger>,
     /// Wanted blocks
-    wanted_blocks: HashMap<Cid, Priority>,
+    wanted_blocks: HashedMap<Cid, Priority>,
     /// Blocks queued to be sent
     pub queued_blocks: UnboundedSender<(PeerId, Block)>,
     ready_blocks: UnboundedReceiver<(PeerId, Block)>,

--- a/bitswap/src/ledger.rs
+++ b/bitswap/src/ledger.rs
@@ -4,11 +4,9 @@ use crate::error::BitswapError;
 use crate::prefix::Prefix;
 use cid::Cid;
 use core::convert::TryFrom;
+use hash_hasher::{HashedMap, HashedSet};
 use prost::Message as ProstMessage;
-use std::{
-    collections::{HashMap, HashSet},
-    mem,
-};
+use std::mem;
 
 pub type Priority = i32;
 
@@ -16,9 +14,9 @@ pub type Priority = i32;
 #[derive(Debug, Default)]
 pub struct Ledger {
     /// The list of wanted blocks sent to the peer.
-    sent_want_list: HashMap<Cid, Priority>,
+    sent_want_list: HashedMap<Cid, Priority>,
     /// The list of wanted blocks received from the peer.
-    pub(crate) received_want_list: HashMap<Cid, Priority>,
+    pub(crate) received_want_list: HashedMap<Cid, Priority>,
     /// Queued message.
     message: Message,
 }
@@ -69,9 +67,9 @@ impl Ledger {
 #[derive(Clone, PartialEq, Default)]
 pub struct Message {
     /// List of wanted blocks.
-    want: HashMap<Cid, Priority>,
+    want: HashedMap<Cid, Priority>,
     /// List of blocks to cancel.
-    cancel: HashSet<Cid>,
+    cancel: HashedSet<Cid>,
     /// Wheather it is the full list of wanted blocks.
     full: bool,
     /// List of blocks to send.
@@ -90,12 +88,12 @@ impl Message {
     }
 
     /// Returns the list of wanted blocks.
-    pub fn want(&self) -> &HashMap<Cid, Priority> {
+    pub fn want(&self) -> &HashedMap<Cid, Priority> {
         &self.want
     }
 
     /// Returns the list of cancelled blocks.
-    pub fn cancel(&self) -> &HashSet<Cid> {
+    pub fn cancel(&self) -> &HashedSet<Cid> {
         &self.cancel
     }
 

--- a/src/repo/common_tests.rs
+++ b/src/repo/common_tests.rs
@@ -53,7 +53,7 @@ macro_rules! pinstore_interface_tests {
             use crate::repo::{DataStore, PinKind, PinMode, PinStore};
             use cid::Cid;
             use futures::{StreamExt, TryStreamExt};
-            use std::collections::HashMap;
+            use hash_hasher::HashedMap;
             use std::convert::TryFrom;
 
             #[tokio::test]
@@ -178,7 +178,7 @@ macro_rules! pinstore_interface_tests {
                 let mut both = repo
                     .list(None)
                     .await
-                    .try_collect::<HashMap<Cid, PinMode>>()
+                    .try_collect::<HashedMap<Cid, PinMode>>()
                     .await
                     .unwrap();
 
@@ -211,7 +211,7 @@ macro_rules! pinstore_interface_tests {
                 let mut both = repo
                     .list(None)
                     .await
-                    .try_collect::<HashMap<Cid, PinMode>>()
+                    .try_collect::<HashedMap<Cid, PinMode>>()
                     .await
                     .unwrap();
 
@@ -242,7 +242,7 @@ macro_rules! pinstore_interface_tests {
                 let mut both = repo
                     .list(None)
                     .await
-                    .try_collect::<HashMap<Cid, PinMode>>()
+                    .try_collect::<HashedMap<Cid, PinMode>>()
                     .await
                     .unwrap();
 
@@ -302,7 +302,7 @@ macro_rules! pinstore_interface_tests {
                 let mut one = repo
                     .list(None)
                     .await
-                    .try_collect::<HashMap<Cid, PinMode>>()
+                    .try_collect::<HashedMap<Cid, PinMode>>()
                     .await
                     .unwrap();
 

--- a/src/repo/fs/blocks.rs
+++ b/src/repo/fs/blocks.rs
@@ -107,7 +107,10 @@ impl BlockStore for FsBlockStore {
     fn new(path: PathBuf) -> Self {
         FsBlockStore {
             path,
-            writes: Arc::new(Mutex::new(HashedMap::with_capacity_and_hasher(8, HashBuildHasher::default()))),
+            writes: Arc::new(Mutex::new(HashedMap::with_capacity_and_hasher(
+                8,
+                HashBuildHasher::default(),
+            ))),
             written_bytes: Default::default(),
         }
     }

--- a/src/repo/fs/pinstore.rs
+++ b/src/repo/fs/pinstore.rs
@@ -6,7 +6,8 @@ use async_trait::async_trait;
 use cid::Cid;
 use core::convert::TryFrom;
 use futures::stream::TryStreamExt;
-use std::collections::{HashMap, HashSet};
+use hash_hasher::HashedSet;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::fs;
@@ -254,11 +255,11 @@ impl PinStore for FsDataStore {
         let st = async_stream::try_stream! {
 
             // keep track of all returned not to give out duplicate cids
-            let mut returned: HashSet<Cid> = HashSet::new();
+            let mut returned: HashedSet<Cid> = HashedSet::default();
 
             // the set of recursive will be interesting after all others
-            let mut recursive: HashSet<Cid> = HashSet::new();
-            let mut direct: HashSet<Cid> = HashSet::new();
+            let mut recursive: HashedSet<Cid> = HashedSet::default();
+            let mut direct: HashedSet<Cid> = HashedSet::default();
 
             let collect_recursive_for_indirect = requirement.is_indirect_or_any();
 

--- a/src/repo/mem.rs
+++ b/src/repo/mem.rs
@@ -7,6 +7,7 @@ use crate::repo::{
 use crate::Block;
 use async_trait::async_trait;
 use cid::Cid;
+use hash_hasher::HashedMap;
 use std::convert::TryFrom;
 use std::path::PathBuf;
 use tokio::sync::{Mutex, OwnedMutexGuard};
@@ -24,7 +25,7 @@ use std::sync::Arc;
 /// Blocks are stored as a `HashMap` of the `Cid` and `Block`.
 #[derive(Debug, Default)]
 pub struct MemBlockStore {
-    blocks: Mutex<HashMap<RepoCid, Block>>,
+    blocks: Mutex<HashedMap<RepoCid, Block>>,
 }
 
 #[async_trait]

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -20,7 +20,7 @@ quick-protobuf = { default-features = false, features = ["std"], version = "0.7"
 sha2 = { default-features = false, version = "0.9" }
 
 [dev-dependencies]
-hash_hasher = { default-features = false, version = "2.0.3" }
+hash_hasher = "2.0.3"
 hex-literal = { default-features = false, version = "0.3" }
 libc = { default-features = false, version = "0.2.71" }
 multibase = { default-features = false, version = "0.8.0" }

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -20,6 +20,7 @@ quick-protobuf = { default-features = false, features = ["std"], version = "0.7"
 sha2 = { default-features = false, version = "0.9" }
 
 [dev-dependencies]
+hash_hasher = { default-features = false, version = "2.0.3" }
 hex-literal = { default-features = false, version = "0.3" }
 libc = { default-features = false, version = "0.2.71" }
 multibase = { default-features = false, version = "0.8.0" }

--- a/unixfs/src/test_support.rs
+++ b/unixfs/src/test_support.rs
@@ -1,11 +1,11 @@
 use cid::Cid;
 use core::convert::TryFrom;
+use hash_hasher::HashedMap;
 use hex_literal::hex;
-use std::collections::HashMap;
 
 #[derive(Default)]
 pub struct FakeBlockstore {
-    blocks: HashMap<Cid, Vec<u8>>,
+    blocks: HashedMap<Cid, Vec<u8>>,
 }
 
 impl FakeBlockstore {


### PR DESCRIPTION
This PR implements a fix for #258, ie. using hash_hasher to improve performance in HashMaps/Sets what utilize Cid as key. hash_hasher provides approx. 40% increase in performance in this case.

There are two things that still need to be done:
- code is **not linted** yet, since this will be done in a separate PR by Mirko,
- a simple benchmark is included for the sake of comparing HashedMap<Cid,> vs HashMap<Cid,>; Imho this bench should not be merged.
