### PR TITLE
chore: upgrade to libp2p 0.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * fix: connect using DialPeer instead of DialAddress [#454]
 * fix: compilation error when used as a dependency [#470]
 * perf: use hash_hasher where the key is Cid [#467]
+* chore: upgrade to libp2p 0.39.1, update most of the other deps with the notable exception of cid and multihash [#472]
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
@@ -23,6 +24,7 @@
 [#454]: https://github.com/rs-ipfs/rust-ipfs/pull/454
 [#470]: https://github.com/rs-ipfs/rust-ipfs/pull/470
 [#467]: https://github.com/rs-ipfs/rust-ipfs/pull/467
+[#472]: https://github.com/rs-ipfs/rust-ipfs/pull/472
 
 # 0.2.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,10 @@ either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.38" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.39" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
-prost = { default-features = false, version = "0.7" }
+prost = { default-features = false, version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, features = ["std"], version = "1.0" }
 thiserror = { default-features = false, version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns"], version = "0.34" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.38" }
 multibase = { default-features = false, version = "0.8" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ test_js_interop = []
 anyhow = "1.0"
 async-stream = { default-features = false, version = "0.3" }
 async-trait = { default-features = false, version = "0.1" }
-base64 = { default-features = false, features = ["alloc"], version = "0.12" }
+base64 = { default-features = false, features = ["alloc"], version = "0.13" }
 ipfs-bitswap = { version = "0.1", path = "bitswap" }
 byteorder = { default-features = false, version = "1.3" }
 bytes = { default-features = false, version = "1" }
@@ -32,7 +32,7 @@ futures = { default-features = false, version = "0.3.9", features = ["alloc", "s
 hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
 libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.39" }
-multibase = { default-features = false, version = "0.8" }
+multibase = { default-features = false, version = "0.9" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
@@ -49,7 +49,7 @@ sled = "0.34"
 once_cell = "1.5.2"
 
 [build-dependencies]
-prost-build = { default-features = false, version = "0.7" }
+prost-build = { default-features = false, version = "0.8" }
 
 [dev-dependencies]
 criterion = { default-features = false, version = "0.3" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -15,8 +15,8 @@ cid = { default-features = false, version = "0.5" }
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
 hash_hasher = "2.0.3"
-libp2p-core = { default-features = false, version = "0.27" }
-libp2p-swarm = { default-features = false, version = "0.27" }
+libp2p-core = { default-features = false, version = "0.28" }
+libp2p-swarm = { default-features = false, version = "0.29" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.7" }
 thiserror = { default-features = false, version = "1.0" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -15,10 +15,10 @@ cid = { default-features = false, version = "0.5" }
 fnv = { default-features = false, version = "1.0" }
 futures = { default-features = false, version = "0.3" }
 hash_hasher = "2.0.3"
-libp2p-core = { default-features = false, version = "0.28" }
-libp2p-swarm = { default-features = false, version = "0.29" }
+libp2p-core = { default-features = false, version = "0.29" }
+libp2p-swarm = { default-features = false, version = "0.30" }
 multihash = { default-features = false, version = "0.11" }
-prost = { default-features = false, version = "0.7" }
+prost = { default-features = false, version = "0.8" }
 thiserror = { default-features = false, version = "1.0" }
 tokio = { default-features = false, version = "1", features = ["rt"] }
 tracing = { default-features = false, version = "0.1" }

--- a/bitswap/Cargo.toml
+++ b/bitswap/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rs-ipfs/rust-ipfs"
 
 [build-dependencies]
-prost-build = { default-features = false, version = "0.7" }
+prost-build = { default-features = false, version = "0.8" }
 
 [dependencies]
 cid = { default-features = false, version = "0.5" }

--- a/bitswap/src/error.rs
+++ b/bitswap/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum BitswapError {
     #[error("Error while reading from socket: {0}")]
-    ReadError(#[from] libp2p_core::upgrade::ReadOneError),
+    ReadError(#[from] std::io::Error),
     #[error("Error while decoding bitswap message: {0}")]
     ProtobufError(#[from] prost::DecodeError),
     #[error("Error while parsing cid: {0}")]

--- a/bitswap/src/protocol.rs
+++ b/bitswap/src/protocol.rs
@@ -42,7 +42,7 @@ where
     #[inline]
     fn upgrade_inbound(self, mut socket: TSocket, _info: Self::Info) -> Self::Future {
         Box::pin(async move {
-            let packet = upgrade::read_one(&mut socket, MAX_BUF_SIZE).await?;
+            let packet = upgrade::read_length_prefixed(&mut socket, MAX_BUF_SIZE).await?;
             let message = Message::from_bytes(&packet)?;
             Ok(message)
         })
@@ -71,7 +71,7 @@ where
     fn upgrade_outbound(self, mut socket: TSocket, _info: Self::Info) -> Self::Future {
         Box::pin(async move {
             let bytes = self.to_bytes();
-            upgrade::write_one(&mut socket, bytes).await
+            upgrade::write_length_prefixed(&mut socket, bytes).await
         })
     }
 }

--- a/bitswap/src/protocol.rs
+++ b/bitswap/src/protocol.rs
@@ -8,7 +8,10 @@ use crate::ledger::Message;
 use core::future::Future;
 use core::iter;
 use core::pin::Pin;
-use futures::io::{AsyncRead, AsyncWrite};
+use futures::{
+    io::{AsyncRead, AsyncWrite},
+    AsyncWriteExt,
+};
 use libp2p_core::{upgrade, InboundUpgrade, OutboundUpgrade, UpgradeInfo};
 use std::io;
 
@@ -71,7 +74,8 @@ where
     fn upgrade_outbound(self, mut socket: TSocket, _info: Self::Info) -> Self::Future {
         Box::pin(async move {
             let bytes = self.to_bytes();
-            upgrade::write_length_prefixed(&mut socket, bytes).await
+            upgrade::write_length_prefixed(&mut socket, bytes).await?;
+            socket.close().await
         })
     }
 }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -6,7 +6,7 @@ name = "ipfs-http"
 version = "0.1.0"
 
 [build-dependencies]
-prost-build = { default-features = false, version = "0.7" }
+prost-build = { default-features = false, version = "0.8" }
 vergen = { default-features = false, version = "3.1" }
 
 [dependencies]
@@ -19,7 +19,7 @@ humantime = { default-features = false, version = "2.0" }
 ipfs = { path = "../" }
 mime = { default-features = false, version = "0.3" }
 mpart-async = { default-features = false, version = "0.5" }
-multibase = { default-features = false, version = "0.8" }
+multibase = { default-features = false, features = ["std"], version = "0.9" }
 multihash = { default-features = false, version = "0.11" }
 # openssl is required for rsa keygen but not used by the rust-ipfs or its dependencies
 openssl = { default-features = false, version = "0.10" }

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -24,7 +24,7 @@ multihash = { default-features = false, version = "0.11" }
 # openssl is required for rsa keygen but not used by the rust-ipfs or its dependencies
 openssl = { default-features = false, version = "0.10" }
 percent-encoding = { default-features = false, version = "2.1" }
-prost = { default-features = false, version = "0.7" }
+prost = { default-features = false, version = "0.8" }
 serde = { default-features = false, features = ["derive"], version = "1.0" }
 serde_json = { default-features = false, version = "1.0" }
 structopt = { default-features = false, version = "0.3" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1382,7 +1382,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                 // off the events from Ipfs and ... this looping goes on for a while.
                 done = false;
                 match inner {
-                    Some(SwarmEvent::NewListenAddr{address, ..}) => {
+                    Some(SwarmEvent::NewListenAddr { address, .. }) => {
                         self.complete_listening_address_adding(address);
                     }
                     _ => trace!("{:?}", inner),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1372,7 +1372,6 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                     let next = self.swarm.next();
                     futures::pin_mut!(next);
                     match next.poll(ctx) {
-                        // klis:TODO handle None here?
                         Poll::Ready(inner) => inner,
                         Poll::Pending if done => return Poll::Pending,
                         Poll::Pending => break,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1369,7 +1369,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
             loop {
                 let inner = {
                     use futures::StreamExt;
-                    let next = self.swarm.next();
+                    let next = self.swarm.select_next_some();
                     futures::pin_mut!(next);
                     match next.poll(ctx) {
                         Poll::Ready(inner) => inner,
@@ -1382,7 +1382,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                 // off the events from Ipfs and ... this looping goes on for a while.
                 done = false;
                 match inner {
-                    Some(SwarmEvent::NewListenAddr { address, .. }) => {
+                    SwarmEvent::NewListenAddr { address, .. } => {
                         self.complete_listening_address_adding(address);
                     }
                     _ => trace!("{:?}", inner),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1358,7 +1358,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context) -> Poll<Self::Output> {
-        use libp2p::{swarm::SwarmEvent, Swarm};
+        use libp2p::swarm::SwarmEvent;
 
         // begin by polling the swarm so that initially it'll first have chance to bind listeners
         // and such.
@@ -1401,24 +1401,22 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
 
                 match inner {
                     IpfsEvent::Connect(target, ret) => {
-                        ret.send(self.swarm.connect(target)).ok();
+                        ret.send(self.swarm.behaviour_mut().connect(target)).ok();
                     }
                     IpfsEvent::Addresses(ret) => {
-                        let addrs = self.swarm.addrs();
+                        let addrs = self.swarm.behaviour_mut().addrs();
                         ret.send(Ok(addrs)).ok();
                     }
                     IpfsEvent::Listeners(ret) => {
-                        let listeners = Swarm::listeners(&self.swarm)
-                            .cloned()
-                            .collect::<Vec<Multiaddr>>();
+                        let listeners = self.swarm.listeners().cloned().collect::<Vec<Multiaddr>>();
                         ret.send(Ok(listeners)).ok();
                     }
                     IpfsEvent::Connections(ret) => {
-                        let connections = self.swarm.connections();
+                        let connections = self.swarm.behaviour_mut().connections();
                         ret.send(Ok(connections.collect())).ok();
                     }
                     IpfsEvent::Disconnect(addr, ret) => {
-                        if let Some(disconnector) = self.swarm.disconnect(addr) {
+                        if let Some(disconnector) = self.swarm.behaviour_mut().disconnect(addr) {
                             disconnector.disconnect(&mut self.swarm);
                         }
                         ret.send(Ok(())).ok();
@@ -1426,48 +1424,49 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                     IpfsEvent::GetAddresses(ret) => {
                         // perhaps this could be moved under `IpfsEvent` or free functions?
                         let mut addresses = Vec::new();
-                        addresses.extend(Swarm::listeners(&self.swarm).cloned());
-                        addresses.extend(
-                            Swarm::external_addresses(&self.swarm).map(|ar| ar.addr.clone()),
-                        );
+                        addresses.extend(self.swarm.listeners().map(|a| a.to_owned()));
+                        addresses
+                            .extend(self.swarm.external_addresses().map(|ar| ar.addr.to_owned()));
                         // ignore error, perhaps caller went away already
                         let _ = ret.send(addresses);
                     }
                     IpfsEvent::PubsubSubscribe(topic, ret) => {
-                        let _ = ret.send(self.swarm.pubsub().subscribe(topic));
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().subscribe(topic));
                     }
                     IpfsEvent::PubsubUnsubscribe(topic, ret) => {
-                        let _ = ret.send(self.swarm.pubsub().unsubscribe(topic));
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().unsubscribe(topic));
                     }
                     IpfsEvent::PubsubPublish(topic, data, ret) => {
-                        self.swarm.pubsub().publish(topic, data);
+                        self.swarm.behaviour_mut().pubsub().publish(topic, data);
                         let _ = ret.send(());
                     }
                     IpfsEvent::PubsubPeers(Some(topic), ret) => {
                         let topic = libp2p::floodsub::Topic::new(topic);
-                        let _ = ret.send(self.swarm.pubsub().subscribed_peers(&topic));
+                        let _ =
+                            ret.send(self.swarm.behaviour_mut().pubsub().subscribed_peers(&topic));
                     }
                     IpfsEvent::PubsubPeers(None, ret) => {
-                        let _ = ret.send(self.swarm.pubsub().known_peers());
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().known_peers());
                     }
                     IpfsEvent::PubsubSubscribed(ret) => {
-                        let _ = ret.send(self.swarm.pubsub().subscribed_topics());
+                        let _ = ret.send(self.swarm.behaviour_mut().pubsub().subscribed_topics());
                     }
                     IpfsEvent::WantList(peer, ret) => {
                         let list = if let Some(peer) = peer {
                             self.swarm
+                                .behaviour_mut()
                                 .bitswap()
                                 .peer_wantlist(&peer)
                                 .unwrap_or_default()
                         } else {
-                            self.swarm.bitswap().local_wantlist()
+                            self.swarm.behaviour_mut().bitswap().local_wantlist()
                         };
                         let _ = ret.send(list);
                     }
                     IpfsEvent::BitswapStats(ret) => {
-                        let stats = self.swarm.bitswap().stats();
-                        let peers = self.swarm.bitswap().peers();
-                        let wantlist = self.swarm.bitswap().local_wantlist();
+                        let stats = self.swarm.behaviour_mut().bitswap().stats();
+                        let peers = self.swarm.behaviour_mut().bitswap().peers();
+                        let wantlist = self.swarm.behaviour_mut().bitswap().local_wantlist();
                         let _ = ret.send((stats, peers, wantlist).into());
                     }
                     IpfsEvent::AddListeningAddress(addr, ret) => {
@@ -1476,7 +1475,7 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                     IpfsEvent::RemoveListeningAddress(addr, ret) => {
                         let removed = if let Some((id, _)) = self.listening_addresses.remove(&addr)
                         {
-                            Swarm::remove_listener(&mut self.swarm, id).map_err(|_: ()| {
+                            self.swarm.remove_listener(id).map_err(|_: ()| {
                                 format_err!(
                                     "Failed to remove previously added listening address: {}",
                                     addr
@@ -1489,19 +1488,20 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                         let _ = ret.send(removed);
                     }
                     IpfsEvent::Bootstrap(ret) => {
-                        let future = self.swarm.bootstrap();
+                        let future = self.swarm.behaviour_mut().bootstrap();
                         let _ = ret.send(future);
                     }
                     IpfsEvent::AddPeer(peer_id, addr) => {
-                        self.swarm.add_peer(peer_id, addr);
+                        self.swarm.behaviour_mut().add_peer(peer_id, addr);
                     }
                     IpfsEvent::GetClosestPeers(peer_id, ret) => {
-                        let future = self.swarm.get_closest_peers(peer_id);
+                        let future = self.swarm.behaviour_mut().get_closest_peers(peer_id);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::GetBitswapPeers(ret) => {
                         let peers = self
                             .swarm
+                            .behaviour_mut()
                             .bitswap()
                             .connected_peers
                             .keys()
@@ -1510,52 +1510,55 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
                         let _ = ret.send(peers);
                     }
                     IpfsEvent::FindPeer(peer_id, local_only, ret) => {
-                        let swarm_addrs = self.swarm.swarm.connections_to(&peer_id);
+                        let swarm_addrs = self.swarm.behaviour_mut().swarm.connections_to(&peer_id);
                         let locally_known_addrs = if !swarm_addrs.is_empty() {
                             swarm_addrs
                         } else {
-                            self.swarm.kademlia().addresses_of_peer(&peer_id)
+                            self.swarm
+                                .behaviour_mut()
+                                .kademlia()
+                                .addresses_of_peer(&peer_id)
                         };
                         let addrs = if !locally_known_addrs.is_empty() || local_only {
                             Either::Left(locally_known_addrs)
                         } else {
-                            Either::Right(self.swarm.get_closest_peers(peer_id))
+                            Either::Right(self.swarm.behaviour_mut().get_closest_peers(peer_id))
                         };
                         let _ = ret.send(addrs);
                     }
                     IpfsEvent::GetProviders(cid, ret) => {
-                        let future = self.swarm.get_providers(cid);
+                        let future = self.swarm.behaviour_mut().get_providers(cid);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::Provide(cid, ret) => {
-                        let _ = ret.send(self.swarm.start_providing(cid));
+                        let _ = ret.send(self.swarm.behaviour_mut().start_providing(cid));
                     }
                     IpfsEvent::DhtGet(key, quorum, ret) => {
-                        let future = self.swarm.dht_get(key, quorum);
+                        let future = self.swarm.behaviour_mut().dht_get(key, quorum);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::DhtPut(key, value, quorum, ret) => {
-                        let future = self.swarm.dht_put(key, value, quorum);
+                        let future = self.swarm.behaviour_mut().dht_put(key, value, quorum);
                         let _ = ret.send(future);
                     }
                     IpfsEvent::GetBootstrappers(ret) => {
-                        let list = self.swarm.get_bootstrappers();
+                        let list = self.swarm.behaviour_mut().get_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::AddBootstrapper(addr, ret) => {
-                        let result = self.swarm.add_bootstrapper(addr);
+                        let result = self.swarm.behaviour_mut().add_bootstrapper(addr);
                         let _ = ret.send(result);
                     }
                     IpfsEvent::RemoveBootstrapper(addr, ret) => {
-                        let result = self.swarm.remove_bootstrapper(addr);
+                        let result = self.swarm.behaviour_mut().remove_bootstrapper(addr);
                         let _ = ret.send(result);
                     }
                     IpfsEvent::ClearBootstrappers(ret) => {
-                        let list = self.swarm.clear_bootstrappers();
+                        let list = self.swarm.behaviour_mut().clear_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::RestoreBootstrappers(ret) => {
-                        let list = self.swarm.restore_bootstrappers();
+                        let list = self.swarm.behaviour_mut().restore_bootstrappers();
                         let _ = ret.send(list);
                     }
                     IpfsEvent::Exit => {
@@ -1569,21 +1572,25 @@ impl<TRepoTypes: RepoTypes> Future for IpfsFuture<TRepoTypes> {
             // wants this to be written with a `while let`.
             while let Poll::Ready(Some(evt)) = Pin::new(&mut self.repo_events).poll_next(ctx) {
                 match evt {
-                    RepoEvent::WantBlock(cid) => self.swarm.want_block(cid),
-                    RepoEvent::UnwantBlock(cid) => self.swarm.bitswap().cancel_block(&cid),
+                    RepoEvent::WantBlock(cid) => self.swarm.behaviour_mut().want_block(cid),
+                    RepoEvent::UnwantBlock(cid) => {
+                        self.swarm.behaviour_mut().bitswap().cancel_block(&cid)
+                    }
                     RepoEvent::NewBlock(cid, ret) => {
                         // TODO: consider if cancel is applicable in cases where we provide the
                         // associated Block ourselves
-                        self.swarm.bitswap().cancel_block(&cid);
+                        self.swarm.behaviour_mut().bitswap().cancel_block(&cid);
                         // currently disabled; see https://github.com/rs-ipfs/rust-ipfs/pull/281#discussion_r465583345
                         // for details regarding the concerns about enabling this functionality as-is
                         if false {
-                            let _ = ret.send(self.swarm.start_providing(cid));
+                            let _ = ret.send(self.swarm.behaviour_mut().start_providing(cid));
                         } else {
                             let _ = ret.send(Err(anyhow!("not actively providing blocks yet")));
                         }
                     }
-                    RepoEvent::RemovedBlock(cid) => self.swarm.stop_providing_block(&cid),
+                    RepoEvent::RemovedBlock(cid) => {
+                        self.swarm.behaviour_mut().stop_providing_block(&cid)
+                    }
                 }
             }
 

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -215,6 +215,30 @@ pub(crate) fn could_be_bound_from_ephemeral(
     }
 }
 
+// Checks if two instances of multiaddr are equal comparing as many protocol segments as possible
+pub(crate) fn eq_greedy(addr0: &Multiaddr, addr1: &Multiaddr) -> bool {
+    match (addr0.is_empty(), addr1.is_empty()) {
+        (true, true) => true,
+        (false, false) => {
+            let mut it1 = addr1.iter();
+
+            for i0 in addr0.iter() {
+                if let Some(i1) = it1.next() {
+                    if i0 != i1 {
+                        return false;
+                    }
+                } else {
+                    // All previous segments were equal
+                    return true;
+                }
+            }
+        
+            true
+        },
+        _ => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -300,5 +324,20 @@ mod tests {
             &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(55555u16)),
             &build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(44444u16))
         ));
+    }
+
+    #[test]
+    fn greedy_multiaddr_comparison() {
+        assert!(eq_greedy(&Multiaddr::empty(), &Multiaddr::empty()));
+        assert!(eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1])), &build_multiaddr!(Ip4([192, 168, 0, 1]))));
+        assert!(eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16)), &build_multiaddr!(Ip4([192, 168, 0, 1]))));
+        assert!(eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1])), &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16))));
+
+        // At least one protocol segment needs to be there
+        assert!(!eq_greedy(&Multiaddr::empty(), &build_multiaddr!(Ip4([192, 168, 0, 1]))));
+        assert!(!eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1])), &Multiaddr::empty()));
+        
+        assert!(!eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16)), &build_multiaddr!(Ip4([192, 168, 0, 2]))));
+        assert!(!eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 2])), &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16))));
     }
 }

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -217,26 +217,10 @@ pub(crate) fn could_be_bound_from_ephemeral(
 
 // Checks if two instances of multiaddr are equal comparing as many protocol segments as possible
 pub(crate) fn eq_greedy(addr0: &Multiaddr, addr1: &Multiaddr) -> bool {
-    match (addr0.is_empty(), addr1.is_empty()) {
-        (true, true) => true,
-        (false, false) => {
-            let mut it1 = addr1.iter();
-
-            for i0 in addr0.iter() {
-                if let Some(i1) = it1.next() {
-                    if i0 != i1 {
-                        return false;
-                    }
-                } else {
-                    // All previous segments were equal
-                    return true;
-                }
-            }
-
-            true
-        }
-        _ => false,
+    if addr0.is_empty() != addr1.is_empty() {
+        return false;
     }
+    addr0.iter().zip(addr1.iter()).all(|(a, b)| a == b)
 }
 
 #[cfg(test)]

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -232,9 +232,9 @@ pub(crate) fn eq_greedy(addr0: &Multiaddr, addr1: &Multiaddr) -> bool {
                     return true;
                 }
             }
-        
+
             true
-        },
+        }
         _ => false,
     }
 }
@@ -329,15 +329,36 @@ mod tests {
     #[test]
     fn greedy_multiaddr_comparison() {
         assert!(eq_greedy(&Multiaddr::empty(), &Multiaddr::empty()));
-        assert!(eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1])), &build_multiaddr!(Ip4([192, 168, 0, 1]))));
-        assert!(eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16)), &build_multiaddr!(Ip4([192, 168, 0, 1]))));
-        assert!(eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1])), &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16))));
+        assert!(eq_greedy(
+            &build_multiaddr!(Ip4([192, 168, 0, 1])),
+            &build_multiaddr!(Ip4([192, 168, 0, 1]))
+        ));
+        assert!(eq_greedy(
+            &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16)),
+            &build_multiaddr!(Ip4([192, 168, 0, 1]))
+        ));
+        assert!(eq_greedy(
+            &build_multiaddr!(Ip4([192, 168, 0, 1])),
+            &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16))
+        ));
 
         // At least one protocol segment needs to be there
-        assert!(!eq_greedy(&Multiaddr::empty(), &build_multiaddr!(Ip4([192, 168, 0, 1]))));
-        assert!(!eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1])), &Multiaddr::empty()));
-        
-        assert!(!eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16)), &build_multiaddr!(Ip4([192, 168, 0, 2]))));
-        assert!(!eq_greedy(&build_multiaddr!(Ip4([192, 168, 0, 2])), &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16))));
+        assert!(!eq_greedy(
+            &Multiaddr::empty(),
+            &build_multiaddr!(Ip4([192, 168, 0, 1]))
+        ));
+        assert!(!eq_greedy(
+            &build_multiaddr!(Ip4([192, 168, 0, 1])),
+            &Multiaddr::empty()
+        ));
+
+        assert!(!eq_greedy(
+            &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16)),
+            &build_multiaddr!(Ip4([192, 168, 0, 2]))
+        ));
+        assert!(!eq_greedy(
+            &build_multiaddr!(Ip4([192, 168, 0, 2])),
+            &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16))
+        ));
     }
 }

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -84,7 +84,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
         };
 
         match event {
-            InboundRequestServed { request, } => {
+            InboundRequestServed { request } => {
                 trace!("kad: inbound {:?} request handled", request);
             }
             OutboundQueryCompleted { result, id, .. } => {

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -84,7 +84,10 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
         };
 
         match event {
-            QueryResult { result, id, .. } => {
+            InboundRequestServed { request, } => {
+                trace!("kad: inbound {:?} request handled", request);
+            }
+            OutboundQueryCompleted { result, id, .. } => {
                 // make sure the query is exhausted
                 if self.kademlia.query(&id).is_none() {
                     match result {
@@ -296,7 +299,9 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
             }
             RoutingUpdated {
                 peer,
+                is_new_peer: _,
                 addresses,
+                bucket_range: _,
                 old_peer: _,
             } => {
                 trace!("kad: routing updated; {}: {:?}", peer, addresses);

--- a/src/p2p/behaviour.rs
+++ b/src/p2p/behaviour.rs
@@ -9,7 +9,7 @@ use anyhow::anyhow;
 use cid::Cid;
 use ipfs_bitswap::{Bitswap, BitswapEvent};
 use libp2p::core::{Multiaddr, PeerId};
-use libp2p::identify::{Identify, IdentifyEvent};
+use libp2p::identify::{Identify, IdentifyConfig, IdentifyEvent};
 use libp2p::kad::record::{store::MemoryStore, Key, Record};
 use libp2p::kad::{Kademlia, KademliaConfig, KademliaEvent, Quorum};
 // use libp2p::mdns::{MdnsEvent, TokioMdns};
@@ -185,7 +185,7 @@ impl<Types: IpfsTypes> NetworkBehaviourEventProcess<KademliaEvent> for Behaviour
                         let key = multibase::encode(Base::Base32Lower, key);
                         warn!("kad: timed out while trying to republish provider {}", key);
                     }
-                    GetRecord(Ok(GetRecordOk { records })) => {
+                    GetRecord(Ok(GetRecordOk { records, .. })) => {
                         if self.kademlia.query(&id).is_none() {
                             let records = records.into_iter().map(|rec| rec.record).collect();
                             self.kad_subscriptions
@@ -445,9 +445,8 @@ impl<Types: IpfsTypes> Behaviour<Types> {
         let bitswap = Bitswap::default();
         let ping = Ping::default();
         let identify = Identify::new(
-            "/ipfs/0.1.0".into(),
-            "rust-ipfs".into(),
-            options.keypair.public(),
+            IdentifyConfig::new("/ipfs/0.1.0".into(), options.keypair.public())
+                .with_agent_version("rust-ipfs".into()),
         );
         let pubsub = Pubsub::new(options.peer_id);
         let mut swarm = SwarmApi::default();

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -431,7 +431,10 @@ impl NetworkBehaviour for Pubsub {
                         score,
                     });
                 }
-                NetworkBehaviourAction::CloseConnection { peer_id, connection } => {
+                NetworkBehaviourAction::CloseConnection {
+                    peer_id,
+                    connection,
+                } => {
                     return Poll::Ready(NetworkBehaviourAction::CloseConnection {
                         peer_id,
                         connection,

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -300,12 +300,12 @@ impl NetworkBehaviour for Pubsub {
         self.floodsub.inject_dial_failure(peer_id)
     }
 
-    fn inject_new_listen_addr(&mut self, addr: &Multiaddr) {
-        self.floodsub.inject_new_listen_addr(addr)
+    fn inject_new_listen_addr(&mut self, id: ListenerId, addr: &Multiaddr) {
+        self.floodsub.inject_new_listen_addr(id, addr)
     }
 
-    fn inject_expired_listen_addr(&mut self, addr: &Multiaddr) {
-        self.floodsub.inject_expired_listen_addr(addr)
+    fn inject_expired_listen_addr(&mut self, id: ListenerId, addr: &Multiaddr) {
+        self.floodsub.inject_expired_listen_addr(id, addr)
     }
 
     fn inject_new_external_addr(&mut self, addr: &Multiaddr) {

--- a/src/p2p/pubsub.rs
+++ b/src/p2p/pubsub.rs
@@ -431,6 +431,12 @@ impl NetworkBehaviour for Pubsub {
                         score,
                     });
                 }
+                NetworkBehaviourAction::CloseConnection { peer_id, connection } => {
+                    return Poll::Ready(NetworkBehaviourAction::CloseConnection {
+                        peer_id,
+                        connection,
+                    });
+                }
             }
         }
     }

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -416,8 +416,13 @@ impl NetworkBehaviour for SwarmApi {
 
 fn connection_point_addr(cp: &ConnectedPoint) -> MultiaddrWithoutPeerId {
     match cp {
-        ConnectedPoint::Dialer { address } => MultiaddrWithPeerId::try_from(address.to_owned()).expect("dialed address contains peerid in libp2p 0.38").into(),
-        ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr.to_owned().try_into().expect("send back address does not contain peerid in libp2p 0.38"),
+        ConnectedPoint::Dialer { address } => MultiaddrWithPeerId::try_from(address.to_owned())
+            .expect("dialed address contains peerid in libp2p 0.38")
+            .into(),
+        ConnectedPoint::Listener { send_back_addr, .. } => send_back_addr
+            .to_owned()
+            .try_into()
+            .expect("send back address does not contain peerid in libp2p 0.38"),
     }
 }
 
@@ -442,7 +447,7 @@ mod tests {
         Swarm::listen_on(&mut swarm1, "/ip4/127.0.0.1/tcp/0".parse().unwrap()).unwrap();
 
         loop {
-            if let Some(SwarmEvent::NewListenAddr{..}) = swarm1.next().await {
+            if let Some(SwarmEvent::NewListenAddr { .. }) = swarm1.next().await {
                 break;
             }
         }
@@ -502,7 +507,7 @@ mod tests {
         let addr;
 
         loop {
-            if let Some(SwarmEvent::NewListenAddr {address, ..}) = swarm1.next().await {
+            if let Some(SwarmEvent::NewListenAddr { address, .. }) = swarm1.next().await {
                 // wonder if there should be a timeout?
                 addr = address;
                 break;
@@ -543,7 +548,7 @@ mod tests {
         let mut addr = Vec::with_capacity(2);
 
         while addr.len() < 2 {
-            if let Some(SwarmEvent::NewListenAddr {address, ..}) = swarm1.next().await {
+            if let Some(SwarmEvent::NewListenAddr { address, .. }) = swarm1.next().await {
                 addr.push(address);
             }
         }

--- a/src/p2p/swarm.rs
+++ b/src/p2p/swarm.rs
@@ -456,7 +456,10 @@ mod tests {
                 Multihash::from_bytes(&peer1_id.to_bytes()).unwrap(),
             ));
 
-            let mut sub = swarm2.connect(addr.try_into().unwrap()).unwrap();
+            let mut sub = swarm2
+                .behaviour_mut()
+                .connect(addr.try_into().unwrap())
+                .unwrap();
 
             loop {
                 tokio::select! {
@@ -481,7 +484,7 @@ mod tests {
                         res.unwrap();
 
                         // just to confirm that there are no connections.
-                        assert_eq!(Vec::<Multiaddr>::new(), swarm1.connections_to(&peer2_id));
+                        assert_eq!(Vec::<Multiaddr>::new(), swarm1.behaviour().connections_to(&peer2_id));
                         break;
                     }
                 }
@@ -509,6 +512,7 @@ mod tests {
         }
 
         let mut fut = swarm2
+            .behaviour_mut()
             .connect(
                 MultiaddrWithoutPeerId::try_from(address)
                     .unwrap()
@@ -559,8 +563,8 @@ mod tests {
         // these two should be attempted in parallel. since we know both of them work, and they are
         // given in this order, we know that in libp2p 0.34 only the first should win, however
         // both should always be finished.
-        connections.push(swarm2.connect(targets.0).unwrap());
-        connections.push(swarm2.connect(targets.1).unwrap());
+        connections.push(swarm2.behaviour_mut().connect(targets.0).unwrap());
+        connections.push(swarm2.behaviour_mut().connect(targets.1).unwrap());
         let ready = connections
             // turn the private error type into Option
             .map_err(|e| e.into_inner())

--- a/src/p2p/transport.rs
+++ b/src/p2p/transport.rs
@@ -2,7 +2,7 @@ use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::upgrade::Version;
 use libp2p::core::transport::Boxed;
 use libp2p::core::upgrade::SelectUpgrade;
-use libp2p::dns::DnsConfig;
+use libp2p::dns::TokioDnsConfig;
 use libp2p::identity;
 use libp2p::mplex::MplexConfig;
 use libp2p::noise::{self, NoiseConfig};
@@ -24,7 +24,7 @@ pub fn build_transport(keypair: identity::Keypair) -> io::Result<TTransport> {
         .unwrap();
     let noise_config = NoiseConfig::xx(xx_keypair).into_authenticated();
 
-    Ok(DnsConfig::new(TokioTcpConfig::new().nodelay(true))?
+    Ok(TokioDnsConfig::system(TokioTcpConfig::new())?
         .upgrade(Version::V1)
         .authenticate(noise_config)
         .multiplex(SelectUpgrade::new(

--- a/unixfs/Cargo.toml
+++ b/unixfs/Cargo.toml
@@ -16,14 +16,14 @@ cid = { default-features = false, version = "0.5" }
 either = { default-features = false, version = "1.5" }
 filetime = { optional = true, version = "0.2.12" }
 multihash = { default-features = false, version = "0.11" }
-quick-protobuf = { default-features = false, features = ["std"], version = "0.7" }
+quick-protobuf = { default-features = false, features = ["std"], version = "0.8" }
 sha2 = { default-features = false, version = "0.9" }
 
 [dev-dependencies]
 hash_hasher = "2.0.3"
 hex-literal = { default-features = false, version = "0.3" }
 libc = { default-features = false, version = "0.2.71" }
-multibase = { default-features = false, version = "0.8.0" }
+multibase = { default-features = false, version = "0.9" }
 tar = { default-features = false, version = "0.4" }
 criterion = { default-features = false, version = "0.3" }
 


### PR DESCRIPTION
This PR is a follow up of #463.

It includes the following:
- upgrading libp2p to [v.0.39.1](https://github.com/libp2p/rust-libp2p/releases/tag/v0.39.1)
- upgrading some other deps (e.g.: prost, prost-base, quick-protobuf, base64), **excluding cid and multihash**
- fixes to tests that started failing following upgrade to libp2p v.0.38 in #463

Incoming shortly:
- [x] respective changelog update
- [x] ~~I haven't run the changes against current workflow, so some additional fixes could be necessary;~~ edit: though I did check against all tests locally numerous times during dev, albeit only in a linux/x64 environment; btw looks like the workflows are fine with the changes
