### PR TITLE
Swarm cleanup following libp2p upgrade to v0.39.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * fix: compilation error when used as a dependency [#470]
 * perf: use hash_hasher where the key is Cid [#467]
 * chore: upgrade to libp2p 0.39.1, update most of the other deps with the notable exception of cid and multihash [#472]
+* refactor(swarm): swarm cleanup following libp2p upgrade to v0.39.1 [#473]
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
@@ -25,6 +26,7 @@
 [#470]: https://github.com/rs-ipfs/rust-ipfs/pull/470
 [#467]: https://github.com/rs-ipfs/rust-ipfs/pull/467
 [#472]: https://github.com/rs-ipfs/rust-ipfs/pull/472
+[#473]: https://github.com/rs-ipfs/rust-ipfs/pull/473
 
 # 0.2.1
 

--- a/src/p2p/addr.rs
+++ b/src/p2p/addr.rs
@@ -215,14 +215,6 @@ pub(crate) fn could_be_bound_from_ephemeral(
     }
 }
 
-// Checks if two instances of multiaddr are equal comparing as many protocol segments as possible
-pub(crate) fn eq_greedy(addr0: &Multiaddr, addr1: &Multiaddr) -> bool {
-    if addr0.is_empty() != addr1.is_empty() {
-        return false;
-    }
-    addr0.iter().zip(addr1.iter()).all(|(a, b)| a == b)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -307,42 +299,6 @@ mod tests {
             1,
             &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(55555u16)),
             &build_multiaddr!(Ip4([127, 0, 0, 1]), Tcp(44444u16))
-        ));
-    }
-
-    #[test]
-    fn greedy_multiaddr_comparison() {
-        assert!(eq_greedy(&Multiaddr::empty(), &Multiaddr::empty()));
-        assert!(eq_greedy(
-            &build_multiaddr!(Ip4([192, 168, 0, 1])),
-            &build_multiaddr!(Ip4([192, 168, 0, 1]))
-        ));
-        assert!(eq_greedy(
-            &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16)),
-            &build_multiaddr!(Ip4([192, 168, 0, 1]))
-        ));
-        assert!(eq_greedy(
-            &build_multiaddr!(Ip4([192, 168, 0, 1])),
-            &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16))
-        ));
-
-        // At least one protocol segment needs to be there
-        assert!(!eq_greedy(
-            &Multiaddr::empty(),
-            &build_multiaddr!(Ip4([192, 168, 0, 1]))
-        ));
-        assert!(!eq_greedy(
-            &build_multiaddr!(Ip4([192, 168, 0, 1])),
-            &Multiaddr::empty()
-        ));
-
-        assert!(!eq_greedy(
-            &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16)),
-            &build_multiaddr!(Ip4([192, 168, 0, 2]))
-        ));
-        assert!(!eq_greedy(
-            &build_multiaddr!(Ip4([192, 168, 0, 2])),
-            &build_multiaddr!(Ip4([192, 168, 0, 1]), Tcp(44444u16))
         ));
     }
 }

--- a/unixfs/src/dir/builder/iter.rs
+++ b/unixfs/src/dir/builder/iter.rs
@@ -187,7 +187,7 @@ impl PostOrderIterator {
                     };
 
                     self.pending.push(Visited::PostRoot { leaves });
-                    self.pending.extend(children.drain(..));
+                    self.pending.append(children);
                 }
                 Visited::Descent {
                     node,
@@ -215,7 +215,7 @@ impl PostOrderIterator {
                         index,
                     });
 
-                    self.pending.extend(children.drain(..));
+                    self.pending.append(children);
                 }
                 Visited::Post {
                     parent_id,


### PR DESCRIPTION
This is a follow up of https://github.com/rs-ipfs/rust-ipfs/pull/472. There are two changes introduced:
* remove eq_greedy as `Multiaddr` in `SwarmApi::pending_{addresses, connections}` contains p2p, align conversions accordingly (https://github.com/rs-ipfs/rust-ipfs/commit/136496f7de57d72782cf4c06108733321b05e9fc),
* explicitly use `MultiaddrWithPeerId` in `SwarmApi::pending_{addresses, connections}` (https://github.com/rs-ipfs/rust-ipfs/commit/3b6f69530f633a9db4545fffe4b054dc69a760fc).

The former (https://github.com/rs-ipfs/rust-ipfs/commit/136496f7de57d72782cf4c06108733321b05e9fc) works fine without the latter (https://github.com/rs-ipfs/rust-ipfs/commit/3b6f69530f633a9db4545fffe4b054dc69a760fc), however I am leaning more towards keeping both changes. Encoding the information about peer id presence/absence in Multiaddr in _type_ instead of relying on comments and `expect()`s improves readability and _developer experience_.

Please let me know what your thoughts are.