### PR TITLE
Fixing build issue described in: https://github.com/libp2p/rust-libp2p/issues/2231

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.39" }
+libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.39.1" }
 multibase = { default-features = false, version = "0.9" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.8" }


### PR DESCRIPTION
When including rust-ipfs as a dependency in any crate, it fails with the following error:

```
error: failed to select a version for the requirement `aesni = "^0.7"`
candidate versions found which didn't match: 0.99.99, 0.10.0, 0.9.0, ...
location searched: crates.io index
required by package `aes v0.4.0`
    ... which is depended on by `aes-gcm v0.6.0`
    ... which is depended on by `snow v0.7.1`
    ... which is depended on by `libp2p-noise v0.30.0 (/home/alexander/dev/misc/rust-libp2p/transports/noise)`
    ... which is depended on by `libp2p v0.37.1 (/home/alexander/dev/misc/rust-libp2p)`
    ... which is depended on by `libp2p-relay v0.2.0 (/home/alexander/dev/misc/rust-libp2p/protocols/relay)`
```

This fix updates the libp2p version into one that has a fix for this dependency and now it compiles fine
