### PR TITLE
feat(http): add default values for --bits and --profile in ipfs init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * refactor(swarm): swarm cleanup following libp2p upgrade to v0.39.1 [#473]
 * fix: strict ordering for DAG-CBOR-encoded map keys [#493]
 * feat: upgrade libp2p to v0.43.0 [#499]
+* feat(http): default values for --bits and --profile [#502]
 
 [#429]: https://github.com/rs-ipfs/rust-ipfs/pull/429
 [#428]: https://github.com/rs-ipfs/rust-ipfs/pull/428
@@ -31,6 +32,7 @@
 [#473]: https://github.com/rs-ipfs/rust-ipfs/pull/473
 [#493]: https://github.com/rs-ipfs/rust-ipfs/pull/493
 [#499]: https://github.com/rs-ipfs/rust-ipfs/pull/499
+[#502]: https://github.com/rs-ipfs/rust-ipfs/pull/502
 
 # 0.2.1
 

--- a/http/src/config.rs
+++ b/http/src/config.rs
@@ -59,16 +59,18 @@ pub enum InitializationError {
 pub fn init(
     ipfs_path: &Path,
     bits: NonZeroU16,
-    profiles: Vec<Profile>,
+    mut profiles: Vec<Profile>,
 ) -> Result<String, InitializationError> {
     use multibase::Base::Base64Pad;
     use prost::Message;
     use std::fs::OpenOptions;
     use std::io::{BufWriter, Write};
 
-    if profiles.len() != 1 {
-        unimplemented!("Multiple profiles are currently unsupported!")
-    }
+    match profiles.len() {
+        0 => profiles.push(Profile::Default),
+        1 => {}
+        _ => unimplemented!("Multiple profiles are currently unsupported!"),
+    };
 
     let bits = bits.get();
 

--- a/http/src/main.rs
+++ b/http/src/main.rs
@@ -15,13 +15,13 @@ enum Options {
     /// with two arguments by default, `--bits 1024` and `--profile test`.
     Init {
         /// Generated key length
-        #[structopt(long)]
+        #[structopt(long, default_value = "2048")]
         bits: NonZeroU16,
         /// List of configuration profiles to apply. Currently only the `Test` and `Default`
         /// profiles are supported.
         ///
         /// `Test` uses ephemeral ports (necessary for conformance tests), `Default` uses `4004`.
-        #[structopt(long, use_delimiter = true)]
+        #[structopt(long, use_delimiter = true, default_value = "default")]
         profile: Vec<config::Profile>,
     },
     /// Start the IPFS node in the foreground (not detaching from parent process).
@@ -95,7 +95,7 @@ fn main() {
                     std::process::exit(1);
                 }
                 Err(config::InitializationError::InvalidRsaKeyLength(bits)) => {
-                    eprintln!("Error: --bits out of range [1024, 16384]: {}", bits);
+                    eprintln!("Error: --bits out of range [2048, 16384]: {}", bits);
                     eprintln!("This is a fake version of ipfs cli which does not support much");
                     std::process::exit(1);
                 }


### PR DESCRIPTION
This PR adds default values for the `ipfs init` command to be more like the go-ipfs `ipfs init`. `--bits 2048` and `--profile default` are the default flags if they not overridden.

I've also included an profiles length check that is more accurate and injects the default profile if none was provided. Plus a small update to an error print statement because 1024 bits for a RSA key is too low.