### PR TITLE
refactor: Replace floodsub with gossipsub

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ either = { default-features = false, version = "1.5" }
 futures = { default-features = false, version = "0.3.9", features = ["alloc", "std"] }
 hash_hasher = "2.0.3"
 ipfs-unixfs = { version = "0.2", path = "unixfs" }
-libp2p = { default-features = false, features = ["floodsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.43.0" }
+libp2p = { default-features = false, features = ["gossipsub", "identify", "kad", "tcp-tokio", "mplex", "noise", "ping", "yamux", "dns-tokio"], version = "0.43.0" }
 multibase = { default-features = false, version = "0.9" }
 multihash = { default-features = false, version = "0.11" }
 prost = { default-features = false, version = "0.9" }

--- a/src/p2p/mod.rs
+++ b/src/p2p/mod.rs
@@ -1,10 +1,11 @@
 //! P2P handling for IPFS nodes.
+use crate::error::Error;
 use crate::repo::Repo;
 use crate::{IpfsOptions, IpfsTypes};
+
 use libp2p::identity::Keypair;
 use libp2p::Swarm;
 use libp2p::{Multiaddr, PeerId};
-use std::io;
 use std::sync::Arc;
 use tracing::Span;
 
@@ -57,14 +58,14 @@ pub async fn create_swarm<TIpfsTypes: IpfsTypes>(
     options: SwarmOptions,
     span: Span,
     repo: Arc<Repo<TIpfsTypes>>,
-) -> io::Result<TSwarm<TIpfsTypes>> {
+) -> Result<TSwarm<TIpfsTypes>, Error> {
     let peer_id = options.peer_id;
 
     // Set up an encrypted TCP transport over the Mplex protocol.
     let transport = transport::build_transport(options.keypair.clone())?;
 
     // Create a Kademlia behaviour
-    let behaviour = behaviour::build_behaviour(options, repo).await;
+    let behaviour = behaviour::build_behaviour(options, repo).await?;
 
     // Create a Swarm
     let swarm = libp2p::swarm::SwarmBuilder::new(transport, behaviour, peer_id)


### PR DESCRIPTION
This PR replaces floodsub with gossipsub. Left it as a draft as a starting point to get a bit more insight as to if this is the right starting point to proceed from there. Will be going back after to comment on everything as well that needs commenting or if comments needs adjustments to reflect changes.

~The only issue right now, which I may just be looking over (due to my lack of time in debugging it) is that while I am able to subscribe to the topic, no messages are being published to it nor is the stream receiving anything in the topic.~

EDIT: When the peers are connected (either directly or is discovered via mdns) they are able to see each other.

This [Draft] PR supersede #489

### Checklist (can be deleted from PR description once items are checked)

- [x] **New** code is “linted” i.e. code formatting via rustfmt and language idioms via clippy
- [x] There are no extraneous changes like formatting, line reordering, etc. Keep the patch sizes small!
- [ ] There are functional and/or unit tests written, and they are passing
- [ ] There is suitable documentation. In our case, this means:
    - [ ] Each command has a usage example and API specification
    - [ ] Rustdoc tests are passing on all code-level comments
    - [ ] Differences between Rust’s IPFS implementation and the Go or JS implementations are explained
- [ ] Additions to CHANGELOG.md files
